### PR TITLE
feat: add transaction event and log queries to sub directory

### DIFF
--- a/queries/blocks.graphql
+++ b/queries/blocks.graphql
@@ -1,3 +1,9 @@
+query GetHighestBlockNumber {
+  Block(order: {number: DESC}, limit: 1) {
+    number
+  }
+}
+
 query GetLatestBlocks {
   Block(orderBy: {number: DESC}, limit: 10) {
     hash

--- a/queries/events.graphql
+++ b/queries/events.graphql
@@ -1,0 +1,15 @@
+query GetEventsForBlock($blockHash: String!) {
+    Event (filter: { blockHash: { _eq: $blockHash }}){
+		contractAddress
+    	eventName
+    	parameters
+    }
+}
+
+query GetEventsByEventName($name: String!) {
+    Event (filter: { eventName: { _eq: $name }}){
+		contractAddress
+    	eventName
+    	parameters
+    }
+}

--- a/queries/logs.graphql
+++ b/queries/logs.graphql
@@ -1,0 +1,32 @@
+query GetAllTransactionLogs($txHash: String!) {
+  Log(filter: { transactionHash: { _eq: $txHash } }) {
+    address
+    topics
+    data
+    blockHash
+    logIndex
+    removed
+  }
+}
+
+query GetAllBlockLogs($blockHash: String!) {
+  Log(filter: { blockHash: { _eq: $blockHash } }) {
+    address
+    topics
+    data
+    logIndex
+    removed
+  }
+}
+
+query GetAllLogsByTopic($topic: String!) {
+  Log(filter: { topics: { _any: { _eq: $topic } } }) {
+    address
+    topics
+    data
+    blockHash
+    transactionHash
+    logIndex
+    removed
+  }
+}

--- a/queries/transaction.graphql
+++ b/queries/transaction.graphql
@@ -1,0 +1,69 @@
+query GetTransactionByHash($txHash: String!) {
+  Transaction(filter: {hash: {_eq: $txHash}}) {
+    hash
+    blockHash
+    blockNumber
+    from
+    to
+    value
+    gasPrice
+    nonce
+    transactionIndex
+    logs {
+      address
+      topics
+      data
+      blockNumber
+      transactionHash
+      transactionIndex
+      blockHash
+      logIndex
+      removed
+    }
+  }
+}
+
+query GetTransactionsInvolvingAddress($address: String!) {
+    Transaction(filter: { _or: [
+        {from: { _eq: $address }}
+        {to: { _eq: $address }}
+    ]}) {
+        hash
+        blockHash
+        blockNumber
+        from
+        to
+        value
+        gasPrice
+        nonce
+        transactionIndex
+        logs {
+            address
+            topics
+            data
+            blockNumber
+            transactionHash
+            transactionIndex
+            blockHash
+            logIndex
+            removed
+        }
+    }
+}
+
+query GetAllTransactionWithTopic($topic: String!) {
+  Log(filter: { topics: { _any: { _eq: $topic } } }) {
+    address
+    topics
+    data
+    blockHash
+    logIndex
+    removed
+    transaction {
+      hash
+      from
+      to
+      value
+    }
+  }
+}


### PR DESCRIPTION
## ✨ What’s New

This MR introduces a set of **GraphQL queries** grouped into relevant subcategories within the `queries` subdirectory.

### Transaction Queries
- `GetTransactionByHash` – Fetches a transaction using its hash.
- `GetTransactionsInvolvingAddress` – Retrieves all transactions involving a specified address.
- `GetAllTransactionWithTopic` – Returns transactions filtered by a specific topic.

### Logs Queries
- `GetAllTransactionLogs` – Retrieves all logs associated with transactions.
- `GetAllBlockLogs` – Fetches logs for each block.
- `GetAllLogsByTopic` – Filters logs based on a specific topic.

###  Event Queries
- `GetEventsForBlock` – Retrieves events that occurred within a specific block.
- `GetEventsByEventName` – Filters events by event name.

## ✅ Checklist
- [x] Queries tested
