### PR TITLE
Tests/pkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ todo.txt
 logs/logfile
 
 notes/
+
+# Go test coverage viewer
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,9 @@ clean:
 
 gitpush: 
 	git add . && git commit -m "${COMMIT_MESSAGE}" && git push origin ${BRANCH_NAME}
+
+test:
+	go test ./... -v
+
+testrpc:
+	go test ./pkg/rpc -v

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,9 @@ test:
 
 testrpc:
 	go test ./pkg/rpc -v
+
+coverage:
+	go test -coverprofile=coverage.out ./... || true
+	go tool cover -html=coverage.out -o coverage.html
+	open coverage.html
+	rm coverage.out

--- a/pkg/defra/block_handler.go
+++ b/pkg/defra/block_handler.go
@@ -31,14 +31,26 @@ func NewBlockHandler(host string, port int) *BlockHandler {
 }
 
 func (h *BlockHandler) ConvertHexToInt(s string, sugar *zap.SugaredLogger) int64 {
-	block16 := s[2:]
-	blockInt, err := strconv.ParseInt(block16, 16, 64)
-	if blockInt != 0 {
-		return blockInt
+	// Handle empty string
+	if s == "" {
+		sugar.Error("Empty hex string provided")
+		return 0
 	}
-	sugar.Fatalf("Failed to ParseInt(", err, ")")
-	return 0
-
+	
+	// Remove "0x" prefix if present
+	hexStr := s
+	if strings.HasPrefix(s, "0x") {
+		hexStr = s[2:]
+	}
+	
+	// Parse the hex string
+	blockInt, err := strconv.ParseInt(hexStr, 16, 64)
+	if err != nil {
+		sugar.Errorf("Failed to parse hex string '%s': %v", s, err)
+		return 0
+	}
+	
+	return blockInt
 }
 
 func (h *BlockHandler) CreateBlock(ctx context.Context, block *types.Block, sugar *zap.SugaredLogger) string {

--- a/pkg/defra/block_handler.go
+++ b/pkg/defra/block_handler.go
@@ -260,12 +260,12 @@ func (h *BlockHandler) PostToCollection(ctx context.Context, collection string, 
 	createField := fmt.Sprintf("create_%s", collection)
 	items, ok := response.Data[createField]
 	if !ok {
-		sugar.Errorf("create_", collection, " field not found in response")
+		sugar.Errorf("create_%s field not found in response", collection)
 		sugar.Debug("Response data: ", response.Data)
 		return ""
 	}
 	if len(items) == 0 {
-		sugar.Warnf("no document ID returned for create_", collection)
+		sugar.Warnf("no document ID returned for create_%s", collection)
 		return ""
 	}
 	return items[0].DocID

--- a/pkg/defra/block_handler_test.go
+++ b/pkg/defra/block_handler_test.go
@@ -66,9 +66,11 @@ func TestCreateBlock_MockServer(t *testing.T) {
 		// Mock successful block creation response
 		response := `{
 			"data": {
-				"create_Block": {
-					"_docID": "test-block-doc-id"
-				}
+				"create_Block": [
+					{
+						"_docID": "test-block-doc-id"
+					}
+				]
 			}
 		}`
 		w.Header().Set("Content-Type", "application/json")
@@ -113,9 +115,11 @@ func TestCreateTransaction_MockServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := `{
 			"data": {
-				"create_Transaction": {
-					"_docID": "test-tx-doc-id"
-				}
+				"create_Transaction": [
+					{
+						"_docID": "test-tx-doc-id"
+					}
+				]
 			}
 		}`
 		w.Header().Set("Content-Type", "application/json")
@@ -358,9 +362,11 @@ func TestCreateLog_MockServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := `{
 			"data": {
-				"create_Log": {
-					"_docID": "test-log-doc-id"
-				}
+				"create_Log": [
+					{
+						"_docID": "test-log-doc-id"
+					}
+				]
 			}
 		}`
 		w.Header().Set("Content-Type", "application/json")
@@ -402,9 +408,11 @@ func TestCreateEvent_MockServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := `{
 			"data": {
-				"create_Event": {
-					"_docID": "test-event-doc-id"
-				}
+				"create_Event": [
+					{
+						"_docID": "test-event-doc-id"
+					}
+				]
 			}
 		}`
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/defra/block_handler_test.go
+++ b/pkg/defra/block_handler_test.go
@@ -162,9 +162,11 @@ func TestUpdateTransactionRelationships_MockServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := `{
 			"data": {
-				"update_Transaction": {
-					"_docID": "updated-tx-doc-id"
-				}
+				"update_Transaction": [
+					{
+						"_docID": "updated-tx-doc-id"
+					}
+				]
 			}
 		}`
 		w.Header().Set("Content-Type", "application/json")
@@ -196,7 +198,7 @@ func TestGetHighestBlockNumber_MockServer(t *testing.T) {
 			"data": {
 				"Block": [
 					{
-						"number": "12345"
+						"number": 12345
 					}
 				]
 			}
@@ -262,9 +264,11 @@ func TestPostToCollection_Success(t *testing.T) {
 
 		response := `{
 			"data": {
-				"create_TestCollection": {
-					"_docID": "test-doc-id"
-				}
+				"create_TestCollection": [
+					{
+						"_docID": "test-doc-id"
+					}
+				]
 			}
 		}`
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/defra/block_handler_test.go
+++ b/pkg/defra/block_handler_test.go
@@ -65,7 +65,7 @@ func TestConvertHexToInt(t *testing.T) {
 func TestCreateBlock_MockServer(t *testing.T) {
 	// Create a mock DefraDB server using the helper
 	response := testutils.CreateGraphQLCreateResponse("Block", "test-block-doc-id")
-	server := testutils.CreateGraphQLMockServer(response)
+	server := testutils.CreateMockServer(testutils.DefaultMockServerConfig(response))
 	defer server.Close()
 
 	// Create handler with test server URL
@@ -102,7 +102,7 @@ func TestCreateBlock_MockServer(t *testing.T) {
 
 func TestCreateTransaction_MockServer(t *testing.T) {
 	response := testutils.CreateGraphQLCreateResponse("Transaction", "test-tx-doc-id")
-	server := testutils.CreateGraphQLMockServer(response)
+	server := testutils.CreateMockServer(testutils.DefaultMockServerConfig(response))
 	defer server.Close()
 
 	handler := &BlockHandler{
@@ -137,7 +137,7 @@ func TestCreateTransaction_MockServer(t *testing.T) {
 
 func TestUpdateTransactionRelationships_MockServer(t *testing.T) {
 	response := testutils.CreateGraphQLUpdateResponse("Transaction", "updated-tx-doc-id")
-	server := testutils.CreateGraphQLMockServer(response)
+	server := testutils.CreateMockServer(testutils.DefaultMockServerConfig(response))
 	defer server.Close()
 
 	handler := &BlockHandler{
@@ -163,7 +163,7 @@ func TestGetHighestBlockNumber_MockServer(t *testing.T) {
 			"number": 12345
 		}
 	]`)
-	server := testutils.CreateGraphQLMockServer(response)
+	server := testutils.CreateMockServer(testutils.DefaultMockServerConfig(response))
 	defer server.Close()
 
 	handler := &BlockHandler{
@@ -182,7 +182,7 @@ func TestGetHighestBlockNumber_MockServer(t *testing.T) {
 
 func TestGetHighestBlockNumber_EmptyResponse(t *testing.T) {
 	response := testutils.CreateGraphQLQueryResponse("Block", "[]")
-	server := testutils.CreateGraphQLMockServer(response)
+	server := testutils.CreateMockServer(testutils.DefaultMockServerConfig(response))
 	defer server.Close()
 
 	handler := &BlockHandler{
@@ -304,20 +304,8 @@ func TestSendToGraphql_Success(t *testing.T) {
 }
 
 func TestCreateLog_MockServer(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := `{
-			"data": {
-				"create_Log": [
-					{
-						"_docID": "test-log-doc-id"
-					}
-				]
-			}
-		}`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(response))
-	}))
+	response := testutils.CreateGraphQLCreateResponse("Log", "test-log-doc-id")
+	server := testutils.CreateMockServer(testutils.DefaultMockServerConfig(response))
 	defer server.Close()
 
 	handler := &BlockHandler{
@@ -350,20 +338,8 @@ func TestCreateLog_MockServer(t *testing.T) {
 }
 
 func TestCreateEvent_MockServer(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := `{
-			"data": {
-				"create_Event": [
-					{
-						"_docID": "test-event-doc-id"
-					}
-				]
-			}
-		}`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(response))
-	}))
+	response := testutils.CreateGraphQLCreateResponse("Event", "test-event-doc-id")
+	server := testutils.CreateMockServer(testutils.DefaultMockServerConfig(response))
 	defer server.Close()
 
 	handler := &BlockHandler{

--- a/pkg/defra/block_handler_test.go
+++ b/pkg/defra/block_handler_test.go
@@ -46,6 +46,8 @@ func TestConvertHexToInt(t *testing.T) {
 		{"Zero", "0x0", 0},
 		{"Large number", "0x1000", 4096},
 		{"Block number", "0x1234", 4660},
+		{"All characters, lowercase", "0x1234567890abcdef", 1311768467294899695},
+		{"All characters, uppercase", "0x1234567890ABCDEF", 1311768467294899695},
 	}
 
 	for _, tt := range tests {
@@ -84,20 +86,20 @@ func TestCreateBlock_MockServer(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 
 	block := &types.Block{
-		Hash:        "0x1234567890abcdef",
-		Number:      "12345",
-		Timestamp:   "1600000000",
-		ParentHash:  "0xabcdef1234567890",
-		Difficulty:  "1000000",
-		GasUsed:     "4000000",
-		GasLimit:    "8000000",
-		Nonce:       "123456789",
-		Miner:       "0xminer",
-		Size:        "1024",
-		StateRoot:   "0xstateroot",
-		Sha3Uncles:  "0xsha3uncles",
+		Hash:         "0x1234567890abcdef",
+		Number:       "12345",
+		Timestamp:    "1600000000",
+		ParentHash:   "0xabcdef1234567890",
+		Difficulty:   "1000000",
+		GasUsed:      "4000000",
+		GasLimit:     "8000000",
+		Nonce:        "123456789",
+		Miner:        "0xminer",
+		Size:         "1024",
+		StateRoot:    "0xstateroot",
+		Sha3Uncles:   "0xsha3uncles",
 		ReceiptsRoot: "0xreceiptsroot",
-		ExtraData:   "extra",
+		ExtraData:    "extra",
 	}
 
 	docID := handler.CreateBlock(context.Background(), block, logger)

--- a/pkg/defra/block_handler_test.go
+++ b/pkg/defra/block_handler_test.go
@@ -1,0 +1,439 @@
+package defra
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"shinzo/version1/pkg/types"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNewBlockHandler(t *testing.T) {
+	host := "localhost"
+	port := 9181
+
+	handler := NewBlockHandler(host, port)
+
+	if handler == nil {
+		t.Fatal("NewBlockHandler should not return nil")
+	}
+
+	expectedURL := "http://localhost:9181/api/v0/graphql"
+	if handler.defraURL != expectedURL {
+		t.Errorf("Expected defraURL %s, got %s", expectedURL, handler.defraURL)
+	}
+
+	if handler.client == nil {
+		t.Error("HTTP client should not be nil")
+	}
+}
+
+func TestConvertHexToInt(t *testing.T) {
+	// Create a test logger
+	logger := zap.NewNop().Sugar()
+	handler := NewBlockHandler("localhost", 9181)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected int64
+	}{
+		{"Simple hex", "0x1", 1},
+		{"Larger hex", "0xff", 255},
+		{"Zero", "0x0", 0},
+		{"Large number", "0x1000", 4096},
+		{"Block number", "0x1234", 4660},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := handler.ConvertHexToInt(tt.input, logger)
+			if result != tt.expected {
+				t.Errorf("ConvertHexToInt(%s) = %d, want %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCreateBlock_MockServer(t *testing.T) {
+	// Create a mock DefraDB server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mock successful block creation response
+		response := `{
+			"data": {
+				"create_Block": {
+					"_docID": "test-block-doc-id"
+				}
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	// Create handler with test server URL
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	block := &types.Block{
+		Hash:        "0x1234567890abcdef",
+		Number:      "12345",
+		Timestamp:   "1600000000",
+		ParentHash:  "0xabcdef1234567890",
+		Difficulty:  "1000000",
+		GasUsed:     "4000000",
+		GasLimit:    "8000000",
+		Nonce:       "123456789",
+		Miner:       "0xminer",
+		Size:        "1024",
+		StateRoot:   "0xstateroot",
+		Sha3Uncles:  "0xsha3uncles",
+		ReceiptsRoot: "0xreceiptsroot",
+		ExtraData:   "extra",
+	}
+
+	docID := handler.CreateBlock(context.Background(), block, logger)
+
+	if docID != "test-block-doc-id" {
+		t.Errorf("Expected docID 'test-block-doc-id', got '%s'", docID)
+	}
+}
+
+func TestCreateTransaction_MockServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"data": {
+				"create_Transaction": {
+					"_docID": "test-tx-doc-id"
+				}
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	tx := &types.Transaction{
+		Hash:             "0xtxhash",
+		BlockHash:        "0xblockhash",
+		BlockNumber:      "12345",
+		From:             "0xfrom",
+		To:               "0xto",
+		Value:            "1000",
+		Gas:              "21000",
+		GasPrice:         "20000000000",
+		Input:            "0xinput",
+		Nonce:            "1",
+		TransactionIndex: "0",
+		Status:           true,
+	}
+
+	blockID := "test-block-id"
+	docID := handler.CreateTransaction(context.Background(), tx, blockID, logger)
+
+	if docID != "test-tx-doc-id" {
+		t.Errorf("Expected docID 'test-tx-doc-id', got '%s'", docID)
+	}
+}
+
+func TestUpdateTransactionRelationships_MockServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"data": {
+				"update_Transaction": {
+					"_docID": "updated-tx-doc-id"
+				}
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	blockID := "test-block-id"
+	txHash := "0xtxhash"
+
+	docID := handler.UpdateTransactionRelationships(context.Background(), blockID, txHash, logger)
+
+	if docID != "updated-tx-doc-id" {
+		t.Errorf("Expected docID 'updated-tx-doc-id', got '%s'", docID)
+	}
+}
+
+func TestGetHighestBlockNumber_MockServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"data": {
+				"Block": [
+					{
+						"number": "12345"
+					}
+				]
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	blockNumber := handler.GetHighestBlockNumber(context.Background(), logger)
+
+	if blockNumber != 12345 {
+		t.Errorf("Expected block number 12345, got %d", blockNumber)
+	}
+}
+
+func TestGetHighestBlockNumber_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"data": {
+				"Block": []
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	blockNumber := handler.GetHighestBlockNumber(context.Background(), logger)
+
+	if blockNumber != 0 {
+		t.Errorf("Expected block number 0 for empty response, got %d", blockNumber)
+	}
+}
+
+func TestPostToCollection_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and content type
+		if r.Method != "POST" {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+
+		contentType := r.Header.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("Expected Content-Type application/json, got %s", contentType)
+		}
+
+		response := `{
+			"data": {
+				"create_TestCollection": {
+					"_docID": "test-doc-id"
+				}
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	data := map[string]interface{}{
+		"field1": "value1",
+		"field2": 123,
+	}
+
+	docID := handler.PostToCollection(context.Background(), "TestCollection", data, logger)
+
+	if docID != "test-doc-id" {
+		t.Errorf("Expected docID 'test-doc-id', got '%s'", docID)
+	}
+}
+
+func TestPostToCollection_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Internal Server Error"))
+	}))
+	defer server.Close()
+
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	data := map[string]interface{}{
+		"field1": "value1",
+	}
+
+	docID := handler.PostToCollection(context.Background(), "TestCollection", data, logger)
+
+	// Should return empty string on error
+	if docID != "" {
+		t.Errorf("Expected empty docID on error, got '%s'", docID)
+	}
+}
+
+func TestSendToGraphql_Success(t *testing.T) {
+	expectedQuery := "query { test }"
+	var receivedQuery string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture the request body to verify the query
+		body := make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		receivedQuery = string(body)
+
+		response := `{"data": {"test": "result"}}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	request := types.Request{
+		Query: expectedQuery,
+	}
+
+	result := handler.SendToGraphql(context.Background(), request, logger)
+
+	if result == nil {
+		t.Fatal("Result should not be nil")
+	}
+
+	// Verify the query was sent correctly
+	if !strings.Contains(receivedQuery, expectedQuery) {
+		t.Errorf("Request body should contain query '%s', got '%s'", expectedQuery, receivedQuery)
+	}
+}
+
+func TestCreateLog_MockServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"data": {
+				"create_Log": {
+					"_docID": "test-log-doc-id"
+				}
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	log := &types.Log{
+		Address:          "0xcontract",
+		Topics:           []string{"0xtopic1", "0xtopic2"},
+		Data:             "0xlogdata",
+		BlockNumber:      "12345",
+		TransactionHash:  "0xtxhash",
+		TransactionIndex: "0",
+		BlockHash:        "0xblockhash",
+		LogIndex:         "0",
+		Removed:          false,
+	}
+
+	blockID := "test-block-id"
+	txID := "test-tx-id"
+
+	docID := handler.CreateLog(context.Background(), log, blockID, txID, logger)
+
+	if docID != "test-log-doc-id" {
+		t.Errorf("Expected docID 'test-log-doc-id', got '%s'", docID)
+	}
+}
+
+func TestCreateEvent_MockServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"data": {
+				"create_Event": {
+					"_docID": "test-event-doc-id"
+				}
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	handler := &BlockHandler{
+		defraURL: server.URL,
+		client:   &http.Client{},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	event := &types.Event{
+		ContractAddress:  "0xcontract",
+		EventName:        "Transfer",
+		Parameters:       "0xeventdata",
+		TransactionHash:  "0xtxhash",
+		BlockHash:        "0xblockhash",
+		BlockNumber:      "12345",
+		TransactionIndex: "0",
+		LogIndex:         "0",
+	}
+
+	logID := "test-log-id"
+
+	docID := handler.CreateEvent(context.Background(), event, logID, logger)
+
+	if docID != "test-event-doc-id" {
+		t.Errorf("Expected docID 'test-event-doc-id', got '%s'", docID)
+	}
+}

--- a/pkg/logger/zap_test.go
+++ b/pkg/logger/zap_test.go
@@ -1,0 +1,189 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestInit_Development(t *testing.T) {
+	// Create a temporary logs directory for testing
+	tempDir := t.TempDir()
+	logsDir := filepath.Join(tempDir, "logs")
+	err := os.MkdirAll(logsDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create logs directory: %v", err)
+	}
+
+	// Change working directory temporarily
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	os.Chdir(tempDir)
+
+	// Test development mode
+	Init(true)
+
+	if Sugar == nil {
+		t.Fatal("Sugar logger should not be nil after Init")
+	}
+
+	// Test that we can log without panicking
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Logging should not panic: %v", r)
+		}
+	}()
+
+	Sugar.Debug("Test debug message")
+	Sugar.Info("Test info message")
+	Sugar.Warn("Test warn message")
+	Sugar.Error("Test error message")
+}
+
+func TestInit_Production(t *testing.T) {
+	// Create a temporary logs directory for testing
+	tempDir := t.TempDir()
+	logsDir := filepath.Join(tempDir, "logs")
+	err := os.MkdirAll(logsDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create logs directory: %v", err)
+	}
+
+	// Change working directory temporarily
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	os.Chdir(tempDir)
+
+	// Test production mode
+	Init(false)
+
+	if Sugar == nil {
+		t.Fatal("Sugar logger should not be nil after Init")
+	}
+
+	// Test that we can log without panicking
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Logging should not panic: %v", r)
+		}
+	}()
+
+	Sugar.Info("Test info message")
+	Sugar.Warn("Test warn message")
+	Sugar.Error("Test error message")
+}
+
+func TestInit_LogLevels(t *testing.T) {
+	// Create a temporary logs directory for testing
+	tempDir := t.TempDir()
+	logsDir := filepath.Join(tempDir, "logs")
+	err := os.MkdirAll(logsDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create logs directory: %v", err)
+	}
+
+	// Change working directory temporarily
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	os.Chdir(tempDir)
+
+	// Test development mode (should have debug level)
+	Init(true)
+	if Sugar == nil {
+		t.Fatal("Sugar logger should not be nil after Init")
+	}
+
+	// Test production mode (should have info level)
+	Init(false)
+	if Sugar == nil {
+		t.Fatal("Sugar logger should not be nil after Init")
+	}
+}
+
+func TestInit_GlobalSugarVariable(t *testing.T) {
+	// Create a temporary logs directory for testing
+	tempDir := t.TempDir()
+	logsDir := filepath.Join(tempDir, "logs")
+	err := os.MkdirAll(logsDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create logs directory: %v", err)
+	}
+
+	// Change working directory temporarily
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	os.Chdir(tempDir)
+
+	// Ensure Sugar is initially nil or set it to nil
+	Sugar = nil
+
+	Init(true)
+
+	// Verify the global Sugar variable is set
+	if Sugar == nil {
+		t.Error("Global Sugar variable should be set after Init")
+	}
+
+	// Verify it's actually a SugaredLogger
+	if _, ok := interface{}(Sugar).(*zap.SugaredLogger); !ok {
+		t.Error("Sugar should be a *zap.SugaredLogger")
+	}
+}
+
+func TestInit_LogFileCreation(t *testing.T) {
+	// Create a temporary logs directory for testing
+	tempDir := t.TempDir()
+	logsDir := filepath.Join(tempDir, "logs")
+	err := os.MkdirAll(logsDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create logs directory: %v", err)
+	}
+
+	// Change working directory temporarily
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	os.Chdir(tempDir)
+
+	Init(true)
+
+	// Log some messages to ensure file is created
+	Sugar.Info("Test message for file creation")
+	Sugar.Sync() // Ensure messages are flushed
+
+	// Check if log file was created
+	logFile := filepath.Join(logsDir, "logfile")
+	if _, err := os.Stat(logFile); os.IsNotExist(err) {
+		// This test might fail in some environments, so we'll make it a warning
+		t.Logf("Warning: Log file was not created at %s", logFile)
+	}
+}
+
+func TestEncoderConfig(t *testing.T) {
+	// Test that the encoder config is set up correctly by initializing and checking for panics
+	tempDir := t.TempDir()
+	logsDir := filepath.Join(tempDir, "logs")
+	err := os.MkdirAll(logsDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create logs directory: %v", err)
+	}
+
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	os.Chdir(tempDir)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Init should not panic with encoder config: %v", r)
+		}
+	}()
+
+	Init(true)
+
+	// Test different log levels to ensure encoder works
+	Sugar.Debug("Debug level test")
+	Sugar.Info("Info level test")
+	Sugar.Warn("Warn level test")
+	Sugar.Error("Error level test")
+}

--- a/pkg/rpc/alchemy_test.go
+++ b/pkg/rpc/alchemy_test.go
@@ -1,0 +1,236 @@
+package rpc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewAlchemyClient(t *testing.T) {
+	apiKey := "test-api-key"
+	client := NewAlchemyClient(apiKey)
+
+	if client == nil {
+		t.Fatal("NewAlchemyClient should not return nil")
+	}
+
+	if client.apiKey != apiKey {
+		t.Errorf("Expected apiKey %s, got %s", apiKey, client.apiKey)
+	}
+
+	if client.baseURL != "https://eth-mainnet.alchemyapi.io/v2" {
+		t.Errorf("Expected baseURL to be https://eth-mainnet.alchemyapi.io/v2, got %s", client.baseURL)
+	}
+
+	if client.client == nil {
+		t.Error("HTTP client should not be nil")
+	}
+}
+
+func TestAlchemyClient_GetBlock_Success(t *testing.T) {
+	// Create a test server that returns a mock block response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"jsonrpc": "2.0",
+			"id": 1,
+			"result": {
+				"hash": "0x1234567890abcdef",
+				"number": "0x1",
+				"timestamp": "0x5f5e100",
+				"parentHash": "0xabcdef1234567890",
+				"transactions": []
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	client := NewAlchemyClient("test-key")
+	client.baseURL = server.URL // Override baseURL to use test server
+
+	ctx := context.Background()
+	block, err := client.GetBlock(ctx, "0x1")
+
+	if err != nil {
+		t.Fatalf("GetBlock failed: %v", err)
+	}
+
+	if block == nil {
+		t.Fatal("Block should not be nil")
+	}
+
+	if block.Hash != "0x1234567890abcdef" {
+		t.Errorf("Expected hash 0x1234567890abcdef, got %s", block.Hash)
+	}
+
+	if block.Number != "0x1" {
+		t.Errorf("Expected number 0x1, got %s", block.Number)
+	}
+}
+
+func TestAlchemyClient_GetBlock_ServerError(t *testing.T) {
+	// Create a test server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Internal Server Error"))
+	}))
+	defer server.Close()
+
+	client := NewAlchemyClient("test-key")
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	_, err := client.GetBlock(ctx, "0x1")
+
+	if err == nil {
+		t.Error("Expected error for server error, got nil")
+	}
+}
+
+func TestAlchemyClient_GetTransactionReceipt_Success(t *testing.T) {
+	// Create a test server that returns a mock receipt response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"jsonrpc": "2.0",
+			"id": 1,
+			"result": {
+				"transactionHash": "0xabcdef1234567890",
+				"blockHash": "0x1234567890abcdef",
+				"blockNumber": "0x1",
+				"transactionIndex": "0x0",
+				"status": "0x1",
+				"gasUsed": "0x5208",
+				"logs": []
+			}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	client := NewAlchemyClient("test-key")
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	receipt, err := client.GetTransactionReceipt(ctx, "0xabcdef1234567890")
+
+	if err != nil {
+		t.Fatalf("GetTransactionReceipt failed: %v", err)
+	}
+
+	if receipt == nil {
+		t.Fatal("Receipt should not be nil")
+	}
+
+	if receipt.TransactionHash != "0xabcdef1234567890" {
+		t.Errorf("Expected txHash 0xabcdef1234567890, got %s", receipt.TransactionHash)
+	}
+
+	if receipt.Status != "0x1" {
+		t.Errorf("Expected status 0x1, got %s", receipt.Status)
+	}
+}
+
+func TestAlchemyClient_GetTransactionReceipt_NotFound(t *testing.T) {
+	// Create a test server that returns null result (transaction not found)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"jsonrpc": "2.0",
+			"id": 1,
+			"result": null
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	client := NewAlchemyClient("test-key")
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	receipt, err := client.GetTransactionReceipt(ctx, "0xnonexistent")
+
+	if err != nil {
+		t.Fatalf("GetTransactionReceipt failed: %v", err)
+	}
+
+	if receipt != nil {
+		t.Error("Receipt should be nil for non-existent transaction")
+	}
+}
+
+func TestAlchemyClient_Post_RequestFormat(t *testing.T) {
+	// Create a test server that captures the request
+	var capturedBody string
+	var capturedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header
+		body := make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		capturedBody = string(body)
+
+		// Return a minimal valid response
+		response := `{"jsonrpc": "2.0", "id": 1, "result": null}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	client := NewAlchemyClient("test-key")
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	payload := `{"jsonrpc": "2.0", "method": "test", "id": 1}`
+
+	resp, err := client.post(ctx, payload)
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Verify request format
+	if capturedHeaders.Get("Content-Type") != "application/json" {
+		t.Errorf("Expected Content-Type application/json, got %s", capturedHeaders.Get("Content-Type"))
+	}
+
+	if !strings.Contains(capturedBody, payload) {
+		t.Errorf("Request body should contain payload, got: %s", capturedBody)
+	}
+}
+
+func TestAlchemyClient_Context_Cancellation(t *testing.T) {
+	// Create a test server that delays response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(time.Second) // Delay to allow context cancellation
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"result": null}`))
+	}))
+	defer server.Close()
+
+	client := NewAlchemyClient("test-key")
+	client.baseURL = server.URL
+
+	// Create a context that will be cancelled quickly
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := client.GetBlock(ctx, "0x1")
+
+	if err == nil {
+		t.Error("Expected error due to context cancellation, got nil")
+	}
+
+	// Check that it's a context error
+	if ctx.Err() == nil {
+		t.Error("Context should have been cancelled")
+	}
+}

--- a/pkg/testutils/mock_server.go
+++ b/pkg/testutils/mock_server.go
@@ -1,0 +1,94 @@
+package testutils
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+// MockServerConfig holds configuration for creating mock servers
+type MockServerConfig struct {
+	ResponseBody    string
+	StatusCode      int
+	Headers         map[string]string
+	ValidateRequest func(r *http.Request) error
+}
+
+// DefaultMockServerConfig returns a default configuration
+func DefaultMockServerConfig(responseBody string) MockServerConfig {
+	return MockServerConfig{
+		ResponseBody: responseBody,
+		StatusCode:   http.StatusOK,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+}
+
+// CreateMockServer creates a mock HTTP server with the given configuration
+func CreateMockServer(config MockServerConfig) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if config.ValidateRequest != nil {
+			if err := config.ValidateRequest(r); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
+		for key, value := range config.Headers {
+			w.Header().Set(key, value)
+		}
+
+		w.WriteHeader(config.StatusCode)
+
+		w.Write([]byte(config.ResponseBody))
+	}))
+}
+
+// CreateGraphQLMockServer creates a mock server that returns a GraphQL response
+func CreateGraphQLMockServer(responseBody string) *httptest.Server {
+	return CreateMockServer(DefaultMockServerConfig(responseBody))
+}
+
+// CreateGraphQLCreateResponse creates a standard GraphQL create response
+func CreateGraphQLCreateResponse(collectionName, docID string) string {
+	return `{
+		"data": {
+			"create_` + collectionName + `": [
+				{
+					"_docID": "` + docID + `"
+				}
+			]
+		}
+	}`
+}
+
+// CreateGraphQLUpdateResponse creates a standard GraphQL update response
+func CreateGraphQLUpdateResponse(collectionName, docID string) string {
+	return `{
+		"data": {
+			"update_` + collectionName + `": [
+				{
+					"_docID": "` + docID + `"
+				}
+			]
+		}
+	}`
+}
+
+// CreateGraphQLQueryResponse creates a standard GraphQL query response
+func CreateGraphQLQueryResponse(collectionName, responseData string) string {
+	return `{
+		"data": {
+			"` + collectionName + `": ` + responseData + `
+		}
+	}`
+}
+
+// CreateErrorServer creates a mock server that returns an error
+func CreateErrorServer(statusCode int, errorMessage string) *httptest.Server {
+	return CreateMockServer(MockServerConfig{
+		ResponseBody: errorMessage,
+		StatusCode:   statusCode,
+		Headers:      map[string]string{},
+	})
+}

--- a/pkg/testutils/mock_server.go
+++ b/pkg/testutils/mock_server.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 )
@@ -42,11 +43,6 @@ func CreateMockServer(config MockServerConfig) *httptest.Server {
 
 		w.Write([]byte(config.ResponseBody))
 	}))
-}
-
-// CreateGraphQLMockServer creates a mock server that returns a GraphQL response
-func CreateGraphQLMockServer(responseBody string) *httptest.Server {
-	return CreateMockServer(DefaultMockServerConfig(responseBody))
 }
 
 // CreateGraphQLCreateResponse creates a standard GraphQL create response
@@ -91,4 +87,20 @@ func CreateErrorServer(statusCode int, errorMessage string) *httptest.Server {
 		StatusCode:   statusCode,
 		Headers:      map[string]string{},
 	})
+}
+
+// CreateRPCNodeResponse creates a standard JSON-RPC response
+// result: the result data (can be nil for null responses)
+func CreateRPCNodeResponse(result interface{}) string {
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		// Fallback to "null" if marshaling fails
+		resultJSON = []byte("null")
+	}
+	
+	return `{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"result": ` + string(resultJSON) + `
+	}`
 }

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,327 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTransactionReceiptJSONMarshaling(t *testing.T) {
+	receipt := TransactionReceipt{
+		TransactionHash:   "0x1234567890abcdef",
+		TransactionIndex:  "0",
+		BlockHash:         "0xabcdef1234567890",
+		BlockNumber:       "12345",
+		From:              "0xfrom",
+		To:                "0xto",
+		CumulativeGasUsed: "100000",
+		GasUsed:           "21000",
+		ContractAddress:   "0xcontract",
+		Status:            "0x1",
+		Logs:              []Log{},
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatalf("Failed to marshal TransactionReceipt: %v", err)
+	}
+
+	// Test unmarshaling
+	var unmarshaled TransactionReceipt
+	err = json.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal TransactionReceipt: %v", err)
+	}
+
+	// Verify data integrity
+	if unmarshaled.TransactionHash != receipt.TransactionHash {
+		t.Errorf("TransactionHash mismatch: got %s, want %s", unmarshaled.TransactionHash, receipt.TransactionHash)
+	}
+	if unmarshaled.BlockNumber != receipt.BlockNumber {
+		t.Errorf("BlockNumber mismatch: got %s, want %s", unmarshaled.BlockNumber, receipt.BlockNumber)
+	}
+}
+
+func TestBlockJSONMarshaling(t *testing.T) {
+	block := Block{
+		Hash:             "0x1234567890abcdef",
+		Number:           "12345",
+		Timestamp:        "1600000000",
+		ParentHash:       "0xparent",
+		Difficulty:       "1000000",
+		GasUsed:          "4000000",
+		GasLimit:         "8000000",
+		Nonce:            "123456789",
+		Miner:            "0xminer",
+		Size:             "1024",
+		StateRoot:        "0xstateroot",
+		Sha3Uncles:       "0xsha3uncles",
+		TransactionsRoot: "0xtxroot",
+		ReceiptsRoot:     "0xreceiptsroot",
+		ExtraData:        "extra",
+		Transactions:     []Transaction{},
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("Failed to marshal Block: %v", err)
+	}
+
+	// Test unmarshaling
+	var unmarshaled Block
+	err = json.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal Block: %v", err)
+	}
+
+	// Verify data integrity
+	if unmarshaled.Hash != block.Hash {
+		t.Errorf("Hash mismatch: got %s, want %s", unmarshaled.Hash, block.Hash)
+	}
+	if unmarshaled.Number != block.Number {
+		t.Errorf("Number mismatch: got %s, want %s", unmarshaled.Number, block.Number)
+	}
+}
+
+func TestTransactionJSONMarshaling(t *testing.T) {
+	tx := Transaction{
+		Hash:             "0xtxhash",
+		BlockHash:        "0xblockhash",
+		BlockNumber:      "12345",
+		From:             "0xfrom",
+		To:               "0xto",
+		Value:            "1000",
+		Gas:              "21000",
+		GasPrice:         "20000000000",
+		Input:            "0xinput",
+		Nonce:            "1",
+		TransactionIndex: "0",
+		Status:           true,
+		Logs:             []Log{},
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(tx)
+	if err != nil {
+		t.Fatalf("Failed to marshal Transaction: %v", err)
+	}
+
+	// Test unmarshaling
+	var unmarshaled Transaction
+	err = json.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal Transaction: %v", err)
+	}
+
+	// Verify data integrity
+	if unmarshaled.Hash != tx.Hash {
+		t.Errorf("Hash mismatch: got %s, want %s", unmarshaled.Hash, tx.Hash)
+	}
+	if unmarshaled.Status != tx.Status {
+		t.Errorf("Status mismatch: got %t, want %t", unmarshaled.Status, tx.Status)
+	}
+}
+
+func TestLogJSONMarshaling(t *testing.T) {
+	log := Log{
+		Address:          "0xcontract",
+		Topics:           []string{"0xtopic1", "0xtopic2"},
+		Data:             "0xlogdata",
+		BlockNumber:      "12345",
+		TransactionHash:  "0xtxhash",
+		TransactionIndex: "0",
+		BlockHash:        "0xblockhash",
+		LogIndex:         "0",
+		Removed:          false,
+		Events:           []Event{},
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(log)
+	if err != nil {
+		t.Fatalf("Failed to marshal Log: %v", err)
+	}
+
+	// Test unmarshaling
+	var unmarshaled Log
+	err = json.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal Log: %v", err)
+	}
+
+	// Verify data integrity
+	if unmarshaled.Address != log.Address {
+		t.Errorf("Address mismatch: got %s, want %s", unmarshaled.Address, log.Address)
+	}
+	if len(unmarshaled.Topics) != len(log.Topics) {
+		t.Errorf("Topics length mismatch: got %d, want %d", len(unmarshaled.Topics), len(log.Topics))
+	}
+	if unmarshaled.Removed != log.Removed {
+		t.Errorf("Removed mismatch: got %t, want %t", unmarshaled.Removed, log.Removed)
+	}
+}
+
+func TestEventJSONMarshaling(t *testing.T) {
+	event := Event{
+		ContractAddress:  "0xcontract",
+		EventName:        "Transfer",
+		Parameters:       "0xeventdata",
+		TransactionHash:  "0xtxhash",
+		BlockHash:        "0xblockhash",
+		BlockNumber:      "12345",
+		TransactionIndex: "0",
+		LogIndex:         "0",
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Failed to marshal Event: %v", err)
+	}
+
+	// Test unmarshaling
+	var unmarshaled Event
+	err = json.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal Event: %v", err)
+	}
+
+	// Verify data integrity
+	if unmarshaled.EventName != event.EventName {
+		t.Errorf("EventName mismatch: got %s, want %s", unmarshaled.EventName, event.EventName)
+	}
+	if unmarshaled.ContractAddress != event.ContractAddress {
+		t.Errorf("ContractAddress mismatch: got %s, want %s", unmarshaled.ContractAddress, event.ContractAddress)
+	}
+}
+
+func TestRequestJSONMarshaling(t *testing.T) {
+	request := Request{
+		Type:  "query",
+		Query: "{ Block { number } }",
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Failed to marshal Request: %v", err)
+	}
+
+	// Test unmarshaling
+	var unmarshaled Request
+	err = json.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal Request: %v", err)
+	}
+
+	// Verify data integrity
+	if unmarshaled.Type != request.Type {
+		t.Errorf("Type mismatch: got %s, want %s", unmarshaled.Type, request.Type)
+	}
+	if unmarshaled.Query != request.Query {
+		t.Errorf("Query mismatch: got %s, want %s", unmarshaled.Query, request.Query)
+	}
+}
+
+func TestResponseJSONMarshaling(t *testing.T) {
+	response := Response{
+		Data: map[string][]struct {
+			DocID string `json:"_docID"`
+		}{
+			"Block": {
+				{DocID: "doc-id-1"},
+				{DocID: "doc-id-2"},
+			},
+		},
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal Response: %v", err)
+	}
+
+	// Test unmarshaling
+	var unmarshaled Response
+	err = json.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal Response: %v", err)
+	}
+
+	// Verify data integrity
+	if len(unmarshaled.Data["Block"]) != 2 {
+		t.Errorf("Expected 2 Block entries, got %d", len(unmarshaled.Data["Block"]))
+	}
+	if unmarshaled.Data["Block"][0].DocID != "doc-id-1" {
+		t.Errorf("DocID mismatch: got %s, want %s", unmarshaled.Data["Block"][0].DocID, "doc-id-1")
+	}
+}
+
+func TestUpdateStructsJSONMarshaling(t *testing.T) {
+	// Test UpdateTransactionStruct
+	updateTx := UpdateTransactionStruct{
+		BlockId: "block-id-123",
+		TxHash:  "0xtxhash123",
+	}
+
+	data, err := json.Marshal(updateTx)
+	if err != nil {
+		t.Fatalf("Failed to marshal UpdateTransactionStruct: %v", err)
+	}
+
+	var unmarshaledTx UpdateTransactionStruct
+	err = json.Unmarshal(data, &unmarshaledTx)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal UpdateTransactionStruct: %v", err)
+	}
+
+	if unmarshaledTx.BlockId != updateTx.BlockId {
+		t.Errorf("BlockId mismatch: got %s, want %s", unmarshaledTx.BlockId, updateTx.BlockId)
+	}
+
+	// Test UpdateLogStruct
+	updateLog := UpdateLogStruct{
+		BlockId:  "block-id-123",
+		TxId:     "tx-id-456",
+		TxHash:   "0xtxhash123",
+		LogIndex: "0",
+	}
+
+	data, err = json.Marshal(updateLog)
+	if err != nil {
+		t.Fatalf("Failed to marshal UpdateLogStruct: %v", err)
+	}
+
+	var unmarshaledLog UpdateLogStruct
+	err = json.Unmarshal(data, &unmarshaledLog)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal UpdateLogStruct: %v", err)
+	}
+
+	if unmarshaledLog.TxId != updateLog.TxId {
+		t.Errorf("TxId mismatch: got %s, want %s", unmarshaledLog.TxId, updateLog.TxId)
+	}
+
+	// Test UpdateEventStruct
+	updateEvent := UpdateEventStruct{
+		LogIndex: "0",
+		TxHash:   "0xtxhash123",
+		LogDocId: "log-doc-id-789",
+	}
+
+	data, err = json.Marshal(updateEvent)
+	if err != nil {
+		t.Fatalf("Failed to marshal UpdateEventStruct: %v", err)
+	}
+
+	var unmarshaledEvent UpdateEventStruct
+	err = json.Unmarshal(data, &unmarshaledEvent)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal UpdateEventStruct: %v", err)
+	}
+
+	if unmarshaledEvent.LogDocId != updateEvent.LogDocId {
+		t.Errorf("LogDocId mismatch: got %s, want %s", unmarshaledEvent.LogDocId, updateEvent.LogDocId)
+	}
+}


### PR DESCRIPTION
Added unit tests covering the majority of the happy paths for the packages.

Added a Makefile command `make coverage` that will run all the unit tests and open a test coverage visualizer in your browser - this is helpful to see, at a glance, if there are portions of your project with little-no testing. For example: in this case, it was useful to notice that the unhappy paths need further testing