### PR TITLE
Add github action that will run the go tests in this repo

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,34 @@
+# This workflow will run 'go test' on the project when creating a PR (or trying to push to) main
+name: Go Test CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23' 
+
+    - name: Cache Go build
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Run tests
+      run: go test ./...


### PR DESCRIPTION
The Github Action will trigger whenever opening a PR targeting `main` or whenever trying to push to `main`

If you want to simulate the Github Action locally, you can install `act` using `brew install act` (install homebrew if you don't already have it https://brew.sh/). Then, `act push`, this will run the action on the current state of your project as if you'd committed and pushed it. See https://github.com/nektos/act