### PR TITLE
Block queries integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,6 @@ bin/*
 
 todo.txt
 
-logs/logfile
-
 notes/
 
 # Go test coverage viewer
@@ -47,5 +45,4 @@ coverage.html
 .history/
 
 # Logs
-blockposter_logs.txt
-defradb_logs.txt
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ coverage.html
 
 # VSCode
 .history/
+
+# Logs
+blockposter_logs.txt
+defradb_logs.txt

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@
 
 DEFRA_PATH ?=
 
-DEFRA_ROOT := $(abspath $(DEFRA_PATH))
-ROOTDIR := $(abspath .defra)
-
 deps:
 	go mod download
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps env build start clean defradb gitpush test testrpc coverage bootstrap playground stop
+.PHONY: deps env build start clean defradb gitpush test testrpc coverage bootstrap playground stop integration-test
 
 DEFRA_PATH ?=
 
@@ -25,6 +25,14 @@ gitpush:
 
 test:
 	go test ./... -v
+
+integration-test:
+	@if [ -z "$(DEFRA_PATH)" ]; then \
+		echo "ERROR: You must pass DEFRA_PATH. Usage:"; \
+		echo "  make integration-test DEFRA_PATH=../path/to/defradb"; \
+		exit 1; \
+	fi
+	@scripts/test_integration.sh "$(DEFRA_PATH)"
 
 testrpc:
 	go test ./pkg/rpc -v

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: deps env build start clean defradb
+.PHONY: deps env build start clean defradb gitpush test testrpc coverage bootstrap playground stop
+
+DEFRA_PATH ?=
+
+DEFRA_ROOT := $(abspath $(DEFRA_PATH))
+ROOTDIR := $(abspath .defra)
 
 deps:
 	go mod download
@@ -32,3 +37,23 @@ coverage:
 	go tool cover -html=coverage.out -o coverage.html
 	open coverage.html
 	rm coverage.out
+
+bootstrap:
+	@if [ -z "$(DEFRA_PATH)" ]; then \
+		echo "ERROR: You must pass DEFRA_PATH. Usage:"; \
+		echo "  make bootstrap DEFRA_PATH=../path/to/defradb"; \
+		exit 1; \
+	fi
+	@scripts/bootstrap.sh "$(DEFRA_PATH)" "$(PLAYGROUND)"
+
+playground:
+	@if [ -z "$(DEFRA_PATH)" ]; then \
+		echo "ERROR: You must pass DEFRA_PATH. Usage:"; \
+		echo "  make playground DEFRA_PATH=../path/to/defradb"; \
+		exit 1; \
+	fi
+	@$(MAKE) bootstrap PLAYGROUND=1 DEFRA_PATH="$(DEFRA_PATH)"
+
+stop:
+	@echo "===> Stopping defradb if running..."
+	@pkill -f "defradb start" || echo "defradb not running"

--- a/README.md
+++ b/README.md
@@ -31,26 +31,6 @@ A high-performance blockchain indexing solution built with Source Network, Defra
 - Navigate to defradb
 - Add a .nvmrc file with the node `v23.10.0`
 
-### Defra Start
-*To start DefraDB in the correct location please include the flag `--root-dir` with the path to the .defra directory*
-
-*Example*
-- Run Commands [each as a separate command]
-```bash
-  make build
-  ./defradb start --root-dir /path/to/version1/.defra/
-```
-
-*The playground includes an interface to query DefraDB Data*
-### Playground Setup 
-
-- Run Commands [each as a separate command]
-```bash
-  make deps:playground
-  GOFLAGS="-tags=playground" make build
-  ./defradb start --root-dir /path/to/version1/.defra/
-```
-
 ## Installation
 
 1. Clone the repository:
@@ -77,11 +57,6 @@ A high-performance blockchain indexing solution built with Source Network, Defra
     DEFRADB_URL=<DEFRADB_URL> # DefraDB HTTP URL
    ```
 
-4. Apply Schema
-```bash
-  ./scripts/apply_schema.sh
-```
-
 ## Configuration
 
 1. Configure DefraDB schema:
@@ -97,18 +72,13 @@ A high-performance blockchain indexing solution built with Source Network, Defra
      url: ${DEFRA_URL}
    ```
 
-## Running the Indexer
+## How to Run
 
-1. Start DefraDB:
-   ```bash
-   export $(cat .env) && ~/go/bin/defradb start --root-dir /path/to/version1/.defra/
-   ```
+`make bootstrap DEFRA_PATH=/path/to/defradb`
+or, to open the playground as well, use
+`make playground DEFRA_PATH=/path/to/defradb`
 
-2. Build and run the indexer:
-   ```bash
-   go build -o bin/block_poster cmd/block_poster/main.go
-   ./bin/block_poster > logs/log.txt 1>&2   
-   ```
+To avoid passing the `DEFRA_PATH=/path/to/defradb` portion of the command, set `DEFRA_PATH` as an environment variable.
 
 ## Data Model
 

--- a/integration/block_query_test.go
+++ b/integration/block_query_test.go
@@ -1,0 +1,67 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+)
+
+func getLatestBlockNumber(t *testing.T) int {
+	query := `query { Block(order: {number: DESC}, limit: 1) { number } }`
+	result := postGraphQLQuery(t, query, nil)
+	blockList, ok := result["data"].(map[string]interface{})["Block"].([]interface{})
+	if !ok || len(blockList) == 0 {
+		t.Fatalf("No blocks returned: %v", result)
+	}
+	num, ok := blockList[0].(map[string]interface{})["number"]
+	if !ok {
+		t.Fatalf("Block missing number field: %v", blockList[0])
+	}
+	n, ok := num.(float64)
+	if !ok {
+		t.Fatalf("Block number is not a number: %v", num)
+	}
+	return int(n)
+}
+
+func TestGetHighestBlockNumber(t *testing.T) {
+	_ = getLatestBlockNumber(t) // Just check we can get it
+}
+
+func TestGetLatestBlocks(t *testing.T) {
+	query := `query { Block(order: {number: DESC}, limit: 10) { hash number parentHash difficulty gasUsed gasLimit nonce miner size stateRoot transactionsRoot receiptsRoot extraData } }`
+	result := postGraphQLQuery(t, query, nil)
+	blockList, ok := result["data"].(map[string]interface{})["Block"].([]interface{})
+	if !ok {
+		t.Fatalf("No Block field or wrong type in response: %v", result)
+	}
+	if len(blockList) == 0 {
+		t.Fatalf("No blocks returned")
+	}
+	for _, b := range blockList {
+		block := b.(map[string]interface{})
+		if _, ok := block["hash"]; !ok {
+			t.Errorf("Block missing hash field")
+		}
+		if _, ok := block["number"]; !ok {
+			t.Errorf("Block missing number field")
+		}
+	}
+}
+
+func TestGetBlockWithTransactions(t *testing.T) {
+	blockNumber := getLatestBlockNumber(t)
+
+	query := `query($blockNumber: Int!) { Block(filter: {number: {_eq: $blockNumber}}) { hash number parentHash difficulty gasUsed gasLimit nonce miner size stateRoot transactionsRoot receiptsRoot extraData transactions { hash blockHash blockNumber from to value gasPrice inputData nonce transactionIndex logs { address topics data blockNumber transactionHash transactionIndex blockHash logIndex removed } } } }`
+	variables := map[string]interface{}{ "blockNumber": blockNumber }
+	result := postGraphQLQuery(t, query, variables)
+	blockList, ok := result["data"].(map[string]interface{})["Block"].([]interface{})
+	if !ok || len(blockList) == 0 {
+		t.Fatalf("No block with number %v found; cannot test transactions.", blockNumber)
+	}
+	block := blockList[0].(map[string]interface{})
+	if _, ok := block["transactions"]; !ok {
+		t.Errorf("Block missing transactions field")
+	}
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -13,7 +13,7 @@ import (
 
 const graphqlURL = "http://localhost:9181/api/v0/graphql"
 
-func TestIntegration_Connection(t *testing.T) {
+func TestGraphQLConnection(t *testing.T) {
 	resp, err := http.Post(graphqlURL, "application/json", bytes.NewBuffer([]byte(`{"query":"query { __typename }"}`)))
 	if err != nil {
 		t.Fatalf("Failed to connect to GraphQL endpoint: %v", err)
@@ -53,56 +53,3 @@ func postGraphQLQuery(t *testing.T, query string, variables map[string]interface
 	}
 	return result
 }
-
-func TestIntegration_GetHighestBlockNumber(t *testing.T) {
-	query := `query { Block(order: {number: DESC}, limit: 1) { number } }`
-	result := postGraphQLQuery(t, query, nil)
-	blockList, ok := result["data"].(map[string]interface{})["Block"].([]interface{})
-	if !ok {
-		t.Fatalf("No Block field or wrong type in response: %v", result)
-	}
-	if len(blockList) == 0 {
-		t.Fatalf("No blocks returned")
-	}
-	if _, ok := blockList[0].(map[string]interface{})["number"]; !ok {
-		t.Fatalf("Block missing number field")
-	}
-}
-
-func TestIntegration_GetLatestBlocks(t *testing.T) {
-	query := `query { Block(order: {number: DESC}, limit: 10) { hash number parentHash difficulty gasUsed gasLimit nonce miner size stateRoot transactionsRoot receiptsRoot extraData } }`
-	result := postGraphQLQuery(t, query, nil)
-	blockList, ok := result["data"].(map[string]interface{})["Block"].([]interface{})
-	if !ok {
-		t.Fatalf("No Block field or wrong type in response: %v", result)
-	}
-	if len(blockList) == 0 {
-		t.Fatalf("No blocks returned")
-	}
-	for _, b := range blockList {
-		block := b.(map[string]interface{})
-		if _, ok := block["hash"]; !ok {
-			t.Errorf("Block missing hash field")
-		}
-		if _, ok := block["number"]; !ok {
-			t.Errorf("Block missing number field")
-		}
-	}
-}
-
-func TestIntegration_GetBlockWithTransactions(t *testing.T) {
-	query := `query($blockNumber: Int!) { Block(filter: {number: {_eq: $blockNumber}}) { hash number parentHash difficulty gasUsed gasLimit nonce miner size stateRoot transactionsRoot receiptsRoot extraData transactions { hash blockHash blockNumber from to value gasPrice inputData nonce transactionIndex logs { address topics data blockNumber transactionHash transactionIndex blockHash logIndex removed } } } }`
-	variables := map[string]interface{}{ "blockNumber": 1 }
-	result := postGraphQLQuery(t, query, variables)
-	blockList, ok := result["data"].(map[string]interface{})["Block"].([]interface{})
-	if !ok {
-		t.Fatalf("No Block field or wrong type in response: %v", result)
-	}
-	if len(blockList) == 0 {
-		t.Skip("No block with number 1 found; skipping test.")
-	}
-	block := blockList[0].(map[string]interface{})
-	if _, ok := block["transactions"]; !ok {
-		t.Errorf("Block missing transactions field")
-	}
-} 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+const graphqlURL = "http://localhost:9181/api/v0/graphql"
+
+func TestIntegration_Connection(t *testing.T) {
+	resp, err := http.Post(graphqlURL, "application/json", bytes.NewBuffer([]byte(`{"query":"query { __typename }"}`)))
+	if err != nil {
+		t.Fatalf("Failed to connect to GraphQL endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("Unexpected status code: %d", resp.StatusCode)
+	}
+	body, _ := ioutil.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if _, ok := result["data"]; !ok {
+		t.Fatalf("No data field in response: %s", string(body))
+	}
+}
+
+func postGraphQLQuery(t *testing.T, query string, variables map[string]interface{}) map[string]interface{} {
+	payload := map[string]interface{}{"query": query}
+	if variables != nil {
+		payload["variables"] = variables
+	}
+	b, _ := json.Marshal(payload)
+	resp, err := http.Post(graphqlURL, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		t.Fatalf("Failed to POST query: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("Unexpected status code: %d", resp.StatusCode)
+	}
+	body, _ := ioutil.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	return result
+}
+
+func TestIntegration_GetHighestBlockNumber(t *testing.T) {
+	query := `query { Block(order: {number: DESC}, limit: 1) { number } }`
+	result := postGraphQLQuery(t, query, nil)
+	blockList, ok := result["data"].(map[string]interface{})["Block"].([]interface{})
+	if !ok {
+		t.Fatalf("No Block field or wrong type in response: %v", result)
+	}
+	if len(blockList) == 0 {
+		t.Fatalf("No blocks returned")
+	}
+	if _, ok := blockList[0].(map[string]interface{})["number"]; !ok {
+		t.Fatalf("Block missing number field")
+	}
+}
+
+func TestIntegration_GetLatestBlocks(t *testing.T) {
+	query := `query { Block(order: {number: DESC}, limit: 10) { hash number parentHash difficulty gasUsed gasLimit nonce miner size stateRoot transactionsRoot receiptsRoot extraData } }`
+	result := postGraphQLQuery(t, query, nil)
+	blockList, ok := result["data"].(map[string]interface{})["Block"].([]interface{})
+	if !ok {
+		t.Fatalf("No Block field or wrong type in response: %v", result)
+	}
+	if len(blockList) == 0 {
+		t.Fatalf("No blocks returned")
+	}
+	for _, b := range blockList {
+		block := b.(map[string]interface{})
+		if _, ok := block["hash"]; !ok {
+			t.Errorf("Block missing hash field")
+		}
+		if _, ok := block["number"]; !ok {
+			t.Errorf("Block missing number field")
+		}
+	}
+}
+
+func TestIntegration_GetBlockWithTransactions(t *testing.T) {
+	query := `query($blockNumber: Int!) { Block(filter: {number: {_eq: $blockNumber}}) { hash number parentHash difficulty gasUsed gasLimit nonce miner size stateRoot transactionsRoot receiptsRoot extraData transactions { hash blockHash blockNumber from to value gasPrice inputData nonce transactionIndex logs { address topics data blockNumber transactionHash transactionIndex blockHash logIndex removed } } } }`
+	variables := map[string]interface{}{ "blockNumber": 1 }
+	result := postGraphQLQuery(t, query, variables)
+	blockList, ok := result["data"].(map[string]interface{})["Block"].([]interface{})
+	if !ok {
+		t.Fatalf("No Block field or wrong type in response: %v", result)
+	}
+	if len(blockList) == 0 {
+		t.Skip("No block with number 1 found; skipping test.")
+	}
+	block := blockList[0].(map[string]interface{})
+	if _, ok := block["transactions"]; !ok {
+		t.Errorf("Block missing transactions field")
+	}
+}
+
+func TestIntegration_GetCounts(t *testing.T) {
+	query := `query { Block { _count } Transaction { _count } Log { _count } }`
+	result := postGraphQLQuery(t, query, nil)
+	data := result["data"].(map[string]interface{})
+	for _, entity := range []string{"Block", "Transaction", "Log"} {
+		if _, ok := data[entity]; !ok {
+			t.Errorf("Missing %s field in response", entity)
+		}
+		if arr, ok := data[entity].([]interface{}); ok && len(arr) > 0 {
+			if _, ok := arr[0].(map[string]interface{})["_count"]; !ok {
+				t.Errorf("%s missing _count field", entity)
+			}
+		}
+	}
+} 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -105,20 +105,4 @@ func TestIntegration_GetBlockWithTransactions(t *testing.T) {
 	if _, ok := block["transactions"]; !ok {
 		t.Errorf("Block missing transactions field")
 	}
-}
-
-func TestIntegration_GetCounts(t *testing.T) {
-	query := `query { Block { _count } Transaction { _count } Log { _count } }`
-	result := postGraphQLQuery(t, query, nil)
-	data := result["data"].(map[string]interface{})
-	for _, entity := range []string{"Block", "Transaction", "Log"} {
-		if _, ok := data[entity]; !ok {
-			t.Errorf("Missing %s field in response", entity)
-		}
-		if arr, ok := data[entity].([]interface{}); ok && len(arr) > 0 {
-			if _, ok := arr[0].(map[string]interface{})["_count"]; !ok {
-				t.Errorf("%s missing _count field", entity)
-			}
-		}
-	}
 } 

--- a/queries/blocks.graphql
+++ b/queries/blocks.graphql
@@ -62,15 +62,3 @@ query GetBlockWithTransactions($blockNumber: Int!) {
     }
   }
 }
-
-query GetCounts {
-  Block {
-    _count
-  }
-  Transaction {
-    _count
-  }
-  Log {
-    _count
-  }
-}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -55,9 +55,13 @@ if [[ "$PLAYGROUND" == "1" ]]; then
   fi
 fi
 
-# When the process is killed (via Control + C or other means), this trap statement will execute, shutting down the DefraDB and block_poster instances
+# Create an empty file to indicate that services are ready - this is used to signal to other scripts that rely on the services that they are ready
+echo "===> Ready"
+touch "$ROOTDIR/ready"
+
+# When the process is killed (via Control + C or other means), this trap statement will execute, shutting down the DefraDB and block_poster instances and deleting the ready file
 trap 'echo "Stopping defradb (PID $DEFRA_PID)..."; kill $DEFRA_PID 2>/dev/null || true; rm -f "$ROOTDIR/defradb.pid"; \
-      echo "Stopping block_poster (PID $POSTER_PID)..."; kill $POSTER_PID 2>/dev/null || true; rm -f "$ROOTDIR/block_poster.pid"; exit 0;' INT TERM
+      echo "Stopping block_poster (PID $POSTER_PID)..."; kill $POSTER_PID 2>/dev/null || true; rm -f "$ROOTDIR/block_poster.pid"; rm -f "$ROOTDIR/ready"; exit 0;' INT TERM
 
 wait $DEFRA_PID $POSTER_PID
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+DEFRA_PATH="$1"
+ROOTDIR="$(pwd)/.defra"
+PLAYGROUND="$2"
+
+if [[ -z "$DEFRA_PATH" ]]; then
+  echo "ERROR: You must pass DEFRA_PATH. Usage:"
+  echo "  ./scripts/bootstrap.sh /path/to/defradb [PLAYGROUND]"
+  exit 1
+fi
+
+DEFRA_ROOT="$(cd "$DEFRA_PATH" && pwd)"
+DEFRA_LOG_PATH="defradb_logs.txt"
+BLOCK_POSTER_LOG_PATH="blockposter_logs.txt"
+
+# Build and run DefraDB
+echo "===> Building DefraDB from $DEFRA_ROOT"
+cd "$DEFRA_ROOT"
+make deps:playground
+GOFLAGS="-tags=playground" make build
+./build/defradb start --rootdir "$ROOTDIR" > "$OLDPWD/$DEFRA_LOG_PATH" 2>&1 &
+DEFRA_PID=$!
+echo "$DEFRA_PID" > "$ROOTDIR/defradb.pid"
+echo "Started defradb (PID $DEFRA_PID). Logs at $DEFRA_LOG_PATH"
+cd "$OLDPWD"
+sleep 3
+
+# Apply schema
+echo "===> Applying schema"
+./scripts/apply_schema.sh || echo "⚠️  Warning: Schema application failed (likely already applied). Proceeding..."
+
+# Build and run block_poster
+echo "===> Building block_poster"
+go build -o bin/block_poster cmd/block_poster/main.go
+echo "===> Running block_poster"
+./bin/block_poster > "$BLOCK_POSTER_LOG_PATH" 2>&1 &
+POSTER_PID=$!
+echo "$POSTER_PID" > "$ROOTDIR/block_poster.pid"
+echo "Started block_poster (PID $POSTER_PID). Logs at $BLOCK_POSTER_LOG_PATH"
+
+# If playground flag provided, open up the playground in browser
+if [[ "$PLAYGROUND" == "1" ]]; then
+  echo "===> Opening DefraDB Playground at http://localhost:9181"
+  if command -v open >/dev/null 2>&1; then
+    open http://localhost:9181
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open http://localhost:9181
+  else
+    echo "⚠️ Could not auto-open browser. Please open http://localhost:9181 manually."
+  fi
+fi
+
+# When the process is killed (via Control + C or other means), this trap statement will execute, shutting down the DefraDB and block_poster instances
+trap 'echo "Stopping defradb (PID $DEFRA_PID)..."; kill $DEFRA_PID 2>/dev/null || true; rm -f "$ROOTDIR/defradb.pid"; \
+      echo "Stopping block_poster (PID $POSTER_PID)..."; kill $POSTER_PID 2>/dev/null || true; rm -f "$ROOTDIR/block_poster.pid"; exit 0;' INT TERM
+
+wait $DEFRA_PID $POSTER_PID
+

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -13,8 +13,10 @@ if [[ -z "$DEFRA_PATH" ]]; then
 fi
 
 DEFRA_ROOT="$(cd "$DEFRA_PATH" && pwd)"
-DEFRA_LOG_PATH="defradb_logs.txt"
-BLOCK_POSTER_LOG_PATH="blockposter_logs.txt"
+DEFRA_LOG_PATH="logs/defradb_logs.txt"
+BLOCK_POSTER_LOG_PATH="logs/blockposter_logs.txt"
+
+mkdir -p logs
 
 # Build and run DefraDB
 echo "===> Building DefraDB from $DEFRA_ROOT"

--- a/scripts/test_integration.sh
+++ b/scripts/test_integration.sh
@@ -52,7 +52,7 @@ for i in {1..30}; do
 done
 
 # Run integration tests
-GO111MODULE=on go test -v -tags=integration ./integration/... > integration_test_output.txt 2>&1
+GO111MODULE=on go test -v -tags=integration ./integration/... > integration_test_output.txt 2>&1 || true
 echo -e "\n\n===> Integration test output:"
 cat integration_test_output.txt
 rm integration_test_output.txt

--- a/scripts/test_integration.sh
+++ b/scripts/test_integration.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+# Usage: ./scripts/test_integration.sh /path/to/defradb [PLAYGROUND]
+# Or:   DEFRA_PATH=/path/to/defradb ./scripts/test_integration.sh [PLAYGROUND]
+
+if [[ -z "$DEFRA_PATH" && -z "$1" ]]; then
+  echo "ERROR: You must provide DEFRA_PATH as an env variable or first argument."
+  echo "Usage: ./scripts/test_integration.sh /path/to/defradb [PLAYGROUND]"
+  exit 1
+fi
+
+DEFRA_PATH_ARG="$DEFRA_PATH"
+if [[ -z "$DEFRA_PATH_ARG" ]]; then
+  DEFRA_PATH_ARG="$1"
+  shift
+fi
+
+# Start services in the background
+./scripts/bootstrap.sh "$DEFRA_PATH_ARG" "$@" &
+BOOTSTRAP_PID=$!
+
+# Ensure cleanup on exit or interruption
+cleanup() {
+  echo "===> Cleaning up bootstrap.sh (PID $BOOTSTRAP_PID) and child services..."
+  kill $BOOTSTRAP_PID 2>/dev/null || true
+  wait $BOOTSTRAP_PID 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Wait for ready file from bootstrap.sh
+READY_FILE=".defra/ready"
+echo "===> Waiting for $READY_FILE to be created by bootstrap.sh..."
+for i in {1..30}; do
+  if [ -f "$READY_FILE" ]; then
+    echo "===> $READY_FILE found."
+    break
+  fi
+  sleep 1
+done
+
+# Wait for GraphQL endpoint to be ready
+GRAPHQL_URL="http://localhost:9181/api/v0/graphql"
+echo "===> Waiting for GraphQL endpoint at $GRAPHQL_URL to be ready (schema applied)..."
+for i in {1..30}; do
+  RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" --data '{"query":"{ Block { __typename } }"}' "$GRAPHQL_URL")
+  if echo "$RESPONSE" | grep -q '"Block"'; then
+    echo "===> GraphQL endpoint is up and schema is applied."
+    break
+  fi
+  sleep 1
+done
+
+# Run integration tests
+GO111MODULE=on go test -tags=integration ./integration/... 

--- a/scripts/test_integration.sh
+++ b/scripts/test_integration.sh
@@ -52,4 +52,8 @@ for i in {1..30}; do
 done
 
 # Run integration tests
-GO111MODULE=on go test -tags=integration ./integration/... 
+GO111MODULE=on go test -tags=integration ./integration/... > integration_test_output.txt 2>&1
+echo -e "\n\n===> Integration test output:"
+cat integration_test_output.txt
+rm integration_test_output.txt
+echo -e "\n\n===> Starting cleanup..."

--- a/scripts/test_integration.sh
+++ b/scripts/test_integration.sh
@@ -52,7 +52,7 @@ for i in {1..30}; do
 done
 
 # Run integration tests
-GO111MODULE=on go test -tags=integration ./integration/... > integration_test_output.txt 2>&1
+GO111MODULE=on go test -v -tags=integration ./integration/... > integration_test_output.txt 2>&1
 echo -e "\n\n===> Integration test output:"
 cat integration_test_output.txt
 rm integration_test_output.txt


### PR DESCRIPTION
Contains #23  as a pre-requisite

With this PR, we introduce an integration testing setup. How it works:

1. We introduce an integration tests directory. Scripts in here should be conditionally compiled when `-tags=integration` is included - this separates our unit tests from our integration tests so that they can be run separately (useful due to differences in runtime)
2. We introduce a shell script `scripts/test_integration.sh` that will setup our test environment (`make bootstrap`), run the tests, then teardown our test environment when it exits
3. We introduce some integration tests for each query in `blocks.graphql` (I've removed the broken one). These queries are dynamically read from their source file `blocks.graphql` and are used to query our indexer infra (running locally due to `make bootstrap`). We also introduce some basic connectivity tests to help with debugging should our tests start to fail (allowing you to verify that you can actually connect to the db)