### PR TITLE
Logging update; new logging init function for tests only console

### DIFF
--- a/integration/live/live_integration_test.go
+++ b/integration/live/live_integration_test.go
@@ -33,7 +33,7 @@ var (
 // TestMain sets up and tears down the live integration test environment
 func TestMain(m *testing.M) {
 	// Initialize logger for live integration tests first
-	logger.Init(true)
+	logger.InitConsoleOnly(true)
 	logger.Test("TestMain - Starting live integration tests with real Ethereum data")
 
 	// Check required environment variables

--- a/pkg/defra/block_handler_test.go
+++ b/pkg/defra/block_handler_test.go
@@ -20,7 +20,7 @@ import (
 // TestMain sets up testing environment
 func TestMain(m *testing.M) {
 	// Initialize logger for all tests
-	logger.Init(true)
+	logger.InitConsoleOnly(true)
 
 	// Run tests
 	code := m.Run()

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -119,7 +119,11 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 		cfg = DefaultConfig
 	}
 	cfg.DefraDB.P2P.BootstrapPeers = append(cfg.DefraDB.P2P.BootstrapPeers, requiredPeers...)
-	logger.Init(cfg.Logger.Development)
+	
+	// Only initialize logger if it hasn't been initialized yet (e.g., in tests)
+	if logger.Sugar == nil {
+		logger.Init(cfg.Logger.Development)
+	}
 
 	if !defraStarted {
 		options := []node.Option{

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -24,7 +24,7 @@ func TestIndexing_StartDefraFirst(t *testing.T) {
 		t.Skip("Skipping integration test - SKIP_INTEGRATION_TESTS is set")
 	}
 
-	logger.Init(true)
+	logger.InitConsoleOnly(true)
 
 	defraUrl := "127.0.0.1:0"
 	options := []node.Option{
@@ -134,7 +134,7 @@ func TestIndexing(t *testing.T) {
 		t.Skip("Skipping integration test - SKIP_INTEGRATION_TESTS is set")
 	}
 
-	logger.Init(true)
+	logger.InitConsoleOnly(true)
 
 	// Create embedded DefraDB with dynamic port to avoid conflicts
 	defraUrl := "127.0.0.1:0"

--- a/pkg/logger/zap_test.go
+++ b/pkg/logger/zap_test.go
@@ -20,8 +20,8 @@ func TestInit_Development(t *testing.T) {
 	defer os.Chdir(originalWd)
 	os.Chdir(tempDir)
 
-	// Test development mode
-	Init(true)
+	// Test development mode (console only for tests)
+	InitConsoleOnly(true)
 
 	if Sugar == nil {
 		t.Fatal("Sugar logger should not be nil after Init")
@@ -54,8 +54,8 @@ func TestInit_Production(t *testing.T) {
 	defer os.Chdir(originalWd)
 	os.Chdir(tempDir)
 
-	// Test production mode
-	Init(false)
+	// Test production mode (console only for tests)
+	InitConsoleOnly(false)
 
 	if Sugar == nil {
 		t.Fatal("Sugar logger should not be nil after Init")
@@ -87,14 +87,14 @@ func TestInit_LogLevels(t *testing.T) {
 	defer os.Chdir(originalWd)
 	os.Chdir(tempDir)
 
-	// Test development mode (should have debug level)
-	Init(true)
+	// Test development mode (should have debug level, console only for tests)
+	InitConsoleOnly(true)
 	if Sugar == nil {
 		t.Fatal("Sugar logger should not be nil after Init")
 	}
 
-	// Test production mode (should have info level)
-	Init(false)
+	// Test production mode (should have info level, console only for tests)
+	InitConsoleOnly(false)
 	if Sugar == nil {
 		t.Fatal("Sugar logger should not be nil after Init")
 	}
@@ -117,7 +117,7 @@ func TestInit_GlobalSugarVariable(t *testing.T) {
 	// Ensure Sugar is initially nil or set it to nil
 	Sugar = nil
 
-	Init(true)
+	InitConsoleOnly(true)
 
 	// Verify the global Sugar variable is set
 	if Sugar == nil {
@@ -145,17 +145,16 @@ func TestInit_LogFileCreation(t *testing.T) {
 	defer os.Chdir(originalWd)
 	os.Chdir(tempDir)
 
-	Init(true)
+	InitConsoleOnly(true)
 
-	// Log some messages to ensure file is created
+	// Log some messages - no files should be created in console-only mode
 	Sugar.Info("Test message for file creation")
 	Sugar.Sync() // Ensure messages are flushed
 
-	// Check if log file was created
-	logFile := filepath.Join(logsDir, "logfile")
-	if _, err := os.Stat(logFile); os.IsNotExist(err) {
-		// This test might fail in some environments, so we'll make it a warning
-		Test("Warning: Log file was not created at " + logFile)
+	// Check that log file was NOT created (since we're using console-only mode)
+	logFile := filepath.Join(logsDir, "logfile.log")
+	if _, err := os.Stat(logFile); !os.IsNotExist(err) {
+		Test("Warning: Log file was created unexpectedly at " + logFile)
 	}
 }
 
@@ -178,7 +177,7 @@ func TestEncoderConfig(t *testing.T) {
 		}
 	}()
 
-	Init(true)
+	InitConsoleOnly(true)
 
 	// Test different log levels to ensure encoder works
 	Sugar.Debug("Debug level test")

--- a/pkg/rpc/ethereum_client_test.go
+++ b/pkg/rpc/ethereum_client_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// Initialize logger for tests
-	logger.Init(true)
+	logger.InitConsoleOnly(true)
 
 	// Run tests
 	code := m.Run()
@@ -116,7 +116,7 @@ func TestEthereumClient_GetNetworkID_MockClient(t *testing.T) {
 
 func TestConvertGethBlock(t *testing.T) {
 	// Initialize logger for testing
-	logger.Init(true)
+	logger.InitConsoleOnly(true)
 
 	// Create a mock Geth block
 	header := &ethtypes.Header{


### PR DESCRIPTION
commit msg:
fixed issue #42 \
chore: modified StartIndexing to only call logger.init once or if uninitialized \
chore: updated all test files to use the new structure, InitConsoleOnly | InitWithFiles