### PR TITLE
feat: new chains prefix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,12 @@ func (d *DefraDBConfig) Host() string {
 	return d.Url
 }
 
+// ChainConfig represents the EVM chain being indexed
+type ChainConfig struct {
+	Name    string `yaml:"name"`    // e.g. "Ethereum", "Arbitrum", "Optimism", "Avalanche"
+	Network string `yaml:"network"` // e.g. "Mainnet", "Testnet"
+}
+
 // GethConfig represents Geth node configuration
 type GethConfig struct {
 	NodeURL string `yaml:"node_url"`
@@ -81,6 +87,7 @@ type LoggerConfig struct {
 
 // Config represents the main configuration structure
 type Config struct {
+	Chain    ChainConfig     `yaml:"chain"`
 	DefraDB  DefraDBConfig   `yaml:"defradb"`
 	Geth     GethConfig      `yaml:"geth"`
 	Indexer  IndexerConfig   `yaml:"indexer"`
@@ -121,6 +128,12 @@ func LoadConfig(path string) (*Config, error) {
 
 // applyDefaults sets default values for optional configuration
 func applyDefaults(cfg *Config) {
+	if cfg.Chain.Name == "" {
+		cfg.Chain.Name = "Ethereum"
+	}
+	if cfg.Chain.Network == "" {
+		cfg.Chain.Network = "Mainnet"
+	}
 	if cfg.Indexer.ConcurrentBlocks <= 0 {
 		cfg.Indexer.ConcurrentBlocks = 8
 	}
@@ -226,6 +239,14 @@ func applyEnvOverrides(cfg *Config) {
 		if n, err := strconv.Atoi(numL0TablesStall); err == nil {
 			cfg.DefraDB.Store.NumLevelZeroTablesStall = n
 		}
+	}
+
+	// Chain configuration
+	if chainName := os.Getenv("CHAIN_NAME"); chainName != "" {
+		cfg.Chain.Name = chainName
+	}
+	if chainNetwork := os.Getenv("CHAIN_NETWORK"); chainNetwork != "" {
+		cfg.Chain.Network = chainNetwork
 	}
 
 	// Geth configuration

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,12 @@
 # Default configuration - environment variables will override these
+
+# Chain configuration - identifies which EVM chain to index
+# Supported chains: Ethereum, Arbitrum, Optimism, Avalanche (or any EVM chain)
+# Collection names are derived as: {name}__{network}__Block, etc.
+chain:
+  name: "Ethereum"       # Chain name (env: CHAIN_NAME)
+  network: "Mainnet"     # Network name (env: CHAIN_NETWORK)
+
 defradb:
   url: "http://localhost:9181"  # Empty = embedded DefraDB
   keyring_secret: "" # over written by env var

--- a/pkg/constants/collections.go
+++ b/pkg/constants/collections.go
@@ -1,21 +1,60 @@
 package constants
 
-// DefraDB Collection Names - matches schema.graphql types
-const (
-	CollectionBlock           = "Ethereum__Mainnet__Block"
-	CollectionTransaction     = "Ethereum__Mainnet__Transaction"
-	CollectionLog             = "Ethereum__Mainnet__Log"
-	CollectionAccessListEntry = "Ethereum__Mainnet__AccessListEntry"
-	CollectionBlockSignature    = "Ethereum__Mainnet__BlockSignature"
-	CollectionSnapshotSignature = "Ethereum__Mainnet__SnapshotSignature"
-)
+import "fmt"
 
-// Collection name slice for bulk operations
-var AllCollections = []string{
-	CollectionBlock,
-	CollectionTransaction,
-	CollectionAccessListEntry,
-	CollectionLog,
-	CollectionBlockSignature,
-	CollectionSnapshotSignature,
+// Default collection prefix for backward compatibility
+const DefaultCollectionPrefix = "Ethereum__Mainnet"
+
+// CollectionNames holds the dynamically generated collection names for a chain.
+type CollectionNames struct {
+	Block             string
+	Transaction       string
+	Log               string
+	AccessListEntry   string
+	BlockSignature    string
+	SnapshotSignature string
 }
+
+// NewCollectionNames creates collection names using the given prefix (e.g. "Arbitrum__Mainnet").
+func NewCollectionNames(prefix string) *CollectionNames {
+	return &CollectionNames{
+		Block:             fmt.Sprintf("%s__Block", prefix),
+		Transaction:       fmt.Sprintf("%s__Transaction", prefix),
+		Log:               fmt.Sprintf("%s__Log", prefix),
+		AccessListEntry:   fmt.Sprintf("%s__AccessListEntry", prefix),
+		BlockSignature:    fmt.Sprintf("%s__BlockSignature", prefix),
+		SnapshotSignature: fmt.Sprintf("%s__SnapshotSignature", prefix),
+	}
+}
+
+// AllCollections returns all collection names as a slice.
+func (c *CollectionNames) AllCollections() []string {
+	return []string{
+		c.Block,
+		c.Transaction,
+		c.AccessListEntry,
+		c.Log,
+		c.BlockSignature,
+		c.SnapshotSignature,
+	}
+}
+
+// Default collection names for backward compatibility.
+// These are used when no chain config is specified.
+var (
+	CollectionBlock             = fmt.Sprintf("%s__Block", DefaultCollectionPrefix)
+	CollectionTransaction       = fmt.Sprintf("%s__Transaction", DefaultCollectionPrefix)
+	CollectionLog               = fmt.Sprintf("%s__Log", DefaultCollectionPrefix)
+	CollectionAccessListEntry   = fmt.Sprintf("%s__AccessListEntry", DefaultCollectionPrefix)
+	CollectionBlockSignature    = fmt.Sprintf("%s__BlockSignature", DefaultCollectionPrefix)
+	CollectionSnapshotSignature = fmt.Sprintf("%s__SnapshotSignature", DefaultCollectionPrefix)
+
+	AllCollections = []string{
+		CollectionBlock,
+		CollectionTransaction,
+		CollectionAccessListEntry,
+		CollectionLog,
+		CollectionBlockSignature,
+		CollectionSnapshotSignature,
+	}
+)

--- a/pkg/defra/block_handler.go
+++ b/pkg/defra/block_handler.go
@@ -53,9 +53,10 @@ type DocIDTrackerInterface interface {
 }
 
 type BlockHandler struct {
-	db            blockDB               // DB interface (from defraNode.DB)
-	maxDocsPerTxn int                   // Threshold for single-txn vs batched block creation
-	docIDTracker  DocIDTrackerInterface // Optional tracker for docIDs
+	db            blockDB                    // DB interface (from defraNode.DB)
+	maxDocsPerTxn int                        // Threshold for single-txn vs batched block creation
+	docIDTracker  DocIDTrackerInterface      // Optional tracker for docIDs
+	collections   *constants.CollectionNames // Chain-specific collection names
 
 	// Injectable functions for testability (set to defaults in NewBlockHandler)
 	signBlockFn      func(ctx context.Context, collector *node.BlockCIDCollector) (*node.BlockSignature, error)
@@ -84,7 +85,7 @@ type aleEntry struct {
 
 // NewBlockHandler creates a BlockHandler that uses direct DB calls.
 // maxDocsPerTxn is the threshold for single-txn vs batched block creation.
-func NewBlockHandler(defraNode *node.Node, maxDocsPerTxn int) (*BlockHandler, error) {
+func NewBlockHandler(defraNode *node.Node, maxDocsPerTxn int, collections *constants.CollectionNames) (*BlockHandler, error) {
 	if defraNode == nil {
 		return nil, errors.NewConfigurationError("defra", "NewBlockHandler",
 			"defraNode is nil", "", nil)
@@ -92,9 +93,13 @@ func NewBlockHandler(defraNode *node.Node, maxDocsPerTxn int) (*BlockHandler, er
 	if maxDocsPerTxn <= 0 {
 		maxDocsPerTxn = 1000
 	}
+	if collections == nil {
+		collections = constants.NewCollectionNames(constants.DefaultCollectionPrefix)
+	}
 	return &BlockHandler{
 		db:               defraNode.DB,
 		maxDocsPerTxn:    maxDocsPerTxn,
+		collections:      collections,
 		signBlockFn:      node.SignBlock,
 		verifyBlockSigFn: node.VerifyBlockSignatureCIDs,
 		collectDocCIDsFn: node.CollectDocumentCIDs,
@@ -166,27 +171,28 @@ func (h *BlockHandler) createBlockSingleTransaction(ctx context.Context, block *
 	collector := node.NewBlockCIDCollector()
 	ctx = node.ContextWithBlockSigning(ctx, collector)
 
-	colBlock, err := txn.GetCollectionByName(ctx, constants.CollectionBlock)
+	colBlock, err := txn.GetCollectionByName(ctx, h.collections.Block)
 	if err != nil {
 		txn.Discard()
 		return "", errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get block collection", err)
 	}
-	colTx, err := txn.GetCollectionByName(ctx, constants.CollectionTransaction)
+	colTx, err := txn.GetCollectionByName(ctx, h.collections.Transaction)
 	if err != nil {
 		txn.Discard()
 		return "", errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get tx collection", err)
 	}
-	colLog, err := txn.GetCollectionByName(ctx, constants.CollectionLog)
+	colLog, err := txn.GetCollectionByName(ctx, h.collections.Log)
 	if err != nil {
 		txn.Discard()
 		return "", errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get log collection", err)
 	}
-	colALE, err := txn.GetCollectionByName(ctx, constants.CollectionAccessListEntry)
+	colALE, err := txn.GetCollectionByName(ctx, h.collections.AccessListEntry)
 	if err != nil {
 		txn.Discard()
 		return "", errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get ALE collection", err)
 	}
-	colBlockSig, err := txn.GetCollectionByName(ctx, constants.CollectionBlockSignature)
+
+	colBlockSig, err := txn.GetCollectionByName(ctx, h.collections.BlockSignature)
 	if err != nil {
 		txn.Discard()
 		return "", errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get block signature collection", err)
@@ -485,22 +491,22 @@ func (h *BlockHandler) CreateBlockSignatureForExistingBlock(
 	}
 	tmpCtx := h.db.InitContext(ctx, tmpTxn)
 
-	colBlock, err := tmpTxn.GetCollectionByName(tmpCtx, constants.CollectionBlock)
+	colBlock, err := tmpTxn.GetCollectionByName(tmpCtx, h.collections.Block)
 	if err != nil {
 		tmpTxn.Discard()
 		return "", fmt.Errorf("failed to get block collection: %w", err)
 	}
-	colTx, err := tmpTxn.GetCollectionByName(tmpCtx, constants.CollectionTransaction)
+	colTx, err := tmpTxn.GetCollectionByName(tmpCtx, h.collections.Transaction)
 	if err != nil {
 		tmpTxn.Discard()
 		return "", fmt.Errorf("failed to get transaction collection: %w", err)
 	}
-	colLog, err := tmpTxn.GetCollectionByName(tmpCtx, constants.CollectionLog)
+	colLog, err := tmpTxn.GetCollectionByName(tmpCtx, h.collections.Log)
 	if err != nil {
 		tmpTxn.Discard()
 		return "", fmt.Errorf("failed to get log collection: %w", err)
 	}
-	colALE, err := tmpTxn.GetCollectionByName(tmpCtx, constants.CollectionAccessListEntry)
+	colALE, err := tmpTxn.GetCollectionByName(tmpCtx, h.collections.AccessListEntry)
 	if err != nil {
 		tmpTxn.Discard()
 		return "", fmt.Errorf("failed to get ALE collection: %w", err)
@@ -652,8 +658,7 @@ func (h *BlockHandler) CreateBlockSignatureForExistingBlock(
 		return "", fmt.Errorf("signing returned nil (no identity?)")
 	}
 
-	// Step 4: Create the BlockSignature document and commit
-	colBlockSig, err := sigTxn.GetCollectionByName(sigCtx, constants.CollectionBlockSignature)
+	colBlockSig, err := sigTxn.GetCollectionByName(sigCtx, h.collections.BlockSignature)
 	if err != nil {
 		sigTxn.Discard()
 		return "", fmt.Errorf("failed to get block signature collection: %w", err)
@@ -704,7 +709,7 @@ func (h *BlockHandler) createBlockBatched(ctx context.Context, block *types.Bloc
 
 	ctx = h.db.InitContext(ctx, txn)
 
-	colBlock, err := txn.GetCollectionByName(ctx, constants.CollectionBlock)
+	colBlock, err := txn.GetCollectionByName(ctx, h.collections.Block)
 	if err != nil {
 		txn.Discard()
 		return "", errors.NewQueryFailed("defra", "createBlockBatched", "failed to get block collection", err)
@@ -754,7 +759,7 @@ func (h *BlockHandler) createBlockBatched(ctx context.Context, block *types.Bloc
 		}
 		ctx = h.db.InitContext(ctx, txn)
 
-		colTx, err := txn.GetCollectionByName(ctx, constants.CollectionTransaction)
+		colTx, err := txn.GetCollectionByName(ctx, h.collections.Transaction)
 		if err != nil {
 			txn.Discard()
 			batchErrors = append(batchErrors, fmt.Errorf("get tx collection: %w", err))
@@ -828,7 +833,7 @@ func (h *BlockHandler) createBlockBatched(ctx context.Context, block *types.Bloc
 		}
 		ctx = h.db.InitContext(ctx, txn)
 
-		colLog, err := txn.GetCollectionByName(ctx, constants.CollectionLog)
+		colLog, err := txn.GetCollectionByName(ctx, h.collections.Log)
 		if err != nil {
 			txn.Discard()
 			batchErrors = append(batchErrors, fmt.Errorf("get log collection: %w", err))
@@ -893,7 +898,7 @@ func (h *BlockHandler) createBlockBatched(ctx context.Context, block *types.Bloc
 		}
 		ctx = h.db.InitContext(ctx, txn)
 
-		colALE, err := txn.GetCollectionByName(ctx, constants.CollectionAccessListEntry)
+		colALE, err := txn.GetCollectionByName(ctx, h.collections.AccessListEntry)
 		if err != nil {
 			txn.Discard()
 			batchErrors = append(batchErrors, fmt.Errorf("get ALE collection: %w", err))
@@ -955,7 +960,7 @@ func (h *BlockHandler) createBlockBatched(ctx context.Context, block *types.Bloc
 					logger.Sugar.Warnf("Block %d: block signature verification FAILED", blockInt)
 				}
 
-				colBlockSig, err := sigTxn.GetCollectionByName(sigCtx, constants.CollectionBlockSignature)
+				colBlockSig, err := sigTxn.GetCollectionByName(sigCtx, h.collections.BlockSignature)
 				if err != nil {
 					sigTxn.Discard()
 					logger.Sugar.Warnf("Block %d: failed to get block signature collection: %v", blockInt, err)
@@ -1007,7 +1012,7 @@ func (h *BlockHandler) createBlockBatched(ctx context.Context, block *types.Bloc
 
 // GetHighestBlockNumber returns the highest block number stored in DefraDB
 func (h *BlockHandler) GetHighestBlockNumber(ctx context.Context) (int64, error) {
-	query := `query {` + constants.CollectionBlock + ` (order: {number: DESC}, limit: 1) { number }}`
+	query := `query {` + h.collections.Block + ` (order: {number: DESC}, limit: 1) { number }}`
 
 	result := h.db.ExecRequest(ctx, query)
 	if len(result.GQL.Errors) > 0 {
@@ -1016,28 +1021,27 @@ func (h *BlockHandler) GetHighestBlockNumber(ctx context.Context) (int64, error)
 
 	data, ok := result.GQL.Data.(map[string]any)
 	if !ok {
-		return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", constants.CollectionBlock, "no data")
+		return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", h.collections.Block, "no data")
 	}
 
-	// DefraDB ExecRequest may return []any or []map[string]any depending on context
 	var block map[string]any
-	switch arr := data[constants.CollectionBlock].(type) {
+	switch arr := data[h.collections.Block].(type) {
 	case []any:
 		if len(arr) == 0 {
-			return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", constants.CollectionBlock, "no blocks")
+			return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", h.collections.Block, "no blocks")
 		}
 		var ok bool
 		block, ok = arr[0].(map[string]any)
 		if !ok {
-			return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", constants.CollectionBlock, "invalid format")
+			return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", h.collections.Block, "invalid format")
 		}
 	case []map[string]any:
 		if len(arr) == 0 {
-			return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", constants.CollectionBlock, "no blocks")
+			return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", h.collections.Block, "no blocks")
 		}
 		block = arr[0]
 	default:
-		return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", constants.CollectionBlock, "no blocks")
+		return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", h.collections.Block, "no blocks")
 	}
 
 	switch v := block["number"].(type) {
@@ -1049,5 +1053,5 @@ func (h *BlockHandler) GetHighestBlockNumber(ctx context.Context) (int64, error)
 		return int64(v), nil
 	}
 
-	return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", constants.CollectionBlock, "invalid number type")
+	return 0, errors.NewDocumentNotFound("defra", "GetHighestBlockNumber", h.collections.Block, "invalid number type")
 }

--- a/pkg/defra/block_handler_test.go
+++ b/pkg/defra/block_handler_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 
 func TestNewBlockHandler_NilNode(t *testing.T) {
 	// Test that nil node returns error
-	handler, err := NewBlockHandler(nil, 1000)
+	handler, err := NewBlockHandler(nil, 1000, nil)
 	if err == nil {
 		t.Error("Expected error for nil node, got nil")
 	}

--- a/pkg/defra/error_logging_test.go
+++ b/pkg/defra/error_logging_test.go
@@ -213,7 +213,7 @@ func TestBlockHandlerErrorLogging(t *testing.T) {
 	testLogger := testutils.NewTestLogger(t)
 
 	// Create a block handler with nil node to trigger the error path
-	_, err := NewBlockHandler(nil, 1000)
+	_, err := NewBlockHandler(nil, 1000, nil)
 	if err == nil {
 		t.Fatal("Expected error for nil node")
 	}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -52,6 +52,7 @@ const defaultListenAddress string = "/ip4/127.0.0.1/tcp/9171"
 
 type ChainIndexer struct {
 	cfg                       *config.Config
+	collections               *constants.CollectionNames
 	shouldIndex               bool
 	isStarted                 bool
 	hasIndexedAtLeastOneBlock bool
@@ -94,10 +95,28 @@ func CreateIndexer(cfg *config.Config) (*ChainIndexer, error) {
 	}
 	return &ChainIndexer{
 		cfg:                       cfg,
+		collections:               constants.NewCollectionNames(chainPrefixFromConfig(cfg)),
 		shouldIndex:               false,
 		isStarted:                 false,
 		hasIndexedAtLeastOneBlock: false,
 	}, nil
+}
+
+// chainPrefixFromConfig returns the collection name prefix for the configured chain.
+// Falls back to the default Ethereum mainnet prefix for backward compatibility.
+func chainPrefixFromConfig(cfg *config.Config) string {
+	if cfg == nil {
+		return constants.DefaultCollectionPrefix
+	}
+	name := cfg.Chain.Name
+	network := cfg.Chain.Network
+	if name == "" {
+		name = "Ethereum"
+	}
+	if network == "" {
+		network = "Mainnet"
+	}
+	return fmt.Sprintf("%s__%s", name, network)
 }
 
 func toAppConfig(cfg *config.Config) *appConfig.Config {
@@ -145,6 +164,8 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 		logger.Init(cfg.Logger.Development)
 	}
 
+	logger.Sugar.Infof("Indexing chain: %s (prefix: %s)", cfg.Chain.Name+"__"+cfg.Chain.Network, chainPrefixFromConfig(cfg))
+
 	if !defraStarted {
 		// Use app-sdk to start DefraDB instance with persistent keys
 		// Convert indexer config to app-sdk config
@@ -165,7 +186,7 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 		}
 
 		defraNode, networkHandler, err := appsdk.StartDefraInstance(appCfg,
-			appsdk.NewSchemaApplierFromProvidedSchema(schema.GetSchemaForBuild()), nil, replicationFilter, constants.AllCollections...)
+			appsdk.NewSchemaApplierFromProvidedSchema(schema.GetSchemaForChain(chainPrefixFromConfig(cfg))), nil, replicationFilter, i.collections.AllCollections()...)
 		if err != nil {
 			return fmt.Errorf("Failed to start DefraDB instance with app-sdk: %v", err)
 		}
@@ -196,7 +217,7 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 			return err
 		}
 
-		err = applySchemaViaHTTP(cfg.DefraDB.Url)
+		err = applySchemaViaHTTP(cfg.DefraDB.Url, chainPrefixFromConfig(cfg))
 		if err != nil && !errors.IsErrAlreadyExists(err) {
 			return fmt.Errorf("failed to apply schema to external DefraDB: %v", err)
 		}
@@ -206,7 +227,7 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 		return fmt.Errorf("defraNode is required - external DefraDB via HTTP is no longer supported")
 	}
 
-	blockHandler, err := defra.NewBlockHandler(i.defraNode, cfg.Indexer.MaxDocsPerTxn)
+	blockHandler, err := defra.NewBlockHandler(i.defraNode, cfg.Indexer.MaxDocsPerTxn, i.collections)
 	if err != nil {
 		return fmt.Errorf("failed to create block handler: %v", err)
 	}
@@ -323,7 +344,10 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 		}
 
 		i.pruner.SetQueue(pruneQueue)
-		blockHandler.SetDocIDTracker(&indexerQueueTracker{queue: pruneQueue})
+		blockHandler.SetDocIDTracker(&indexerQueueTracker{
+			queue:       pruneQueue,
+			collections: i.collections,
+		})
 		logger.Sugar.Infof("Prune queue ready (queue=%d, max_blocks=%d)", pruneQueue.Len(), cfg.Pruner.MaxBlocks)
 
 		if err := i.pruner.Start(ctx); err != nil {
@@ -713,13 +737,13 @@ func openBrowser(url string) {
 	logger.Sugar.Infof("Opened health page in browser: %s", url)
 }
 
-func applySchemaViaHTTP(defraUrl string) error {
+func applySchemaViaHTTP(defraUrl string, chainPrefix string) error {
 	fmt.Println("Applying schema via HTTP...")
 
-	schema := schema.GetSchema()
+	schemaStr := schema.GetSchemaForChain(chainPrefix)
 	// Apply schema via REST API endpoint
 	schemaURL := fmt.Sprintf("%s/api/v0/schema", defraUrl)
-	resp, err := http.Post(schemaURL, "application/schema", bytes.NewBuffer([]byte(schema)))
+	resp, err := http.Post(schemaURL, "application/schema", bytes.NewBuffer([]byte(schemaStr)))
 	if err != nil {
 		return fmt.Errorf("Failed to send schema: %v", err)
 	}
@@ -784,14 +808,15 @@ func (i *ChainIndexer) GetPrunerMetrics() *pruner.Metrics {
 
 // indexerQueueTracker adapts app-sdk's IndexerQueue to the local DocIDTrackerInterface.
 type indexerQueueTracker struct {
-	queue *pruner.IndexerQueue
+	queue       *pruner.IndexerQueue
+	collections *constants.CollectionNames
 }
 
 func (t *indexerQueueTracker) TrackBlock(_ context.Context, blockNumber int64, result *defra.BlockCreationResult) error {
 	otherDocIDs := map[string][]string{
-		constants.CollectionTransaction:     result.TransactionIDs,
-		constants.CollectionLog:             result.LogIDs,
-		constants.CollectionAccessListEntry: result.AccessListIDs,
+		t.collections.Transaction:     result.TransactionIDs,
+		t.collections.Log:             result.LogIDs,
+		t.collections.AccessListEntry: result.AccessListIDs,
 	}
 	return t.queue.TrackBlockDocIDs(blockNumber, result.BlockID, otherDocIDs, result.BlockSignatureID)
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	_ "embed"
+	"strings"
 )
 
 //go:embed schema_standard.graphql
@@ -30,4 +31,14 @@ func schemaForBuild(branchable bool) string {
 		return GetBranchableSchema()
 	}
 	return GetSchema()
+}
+
+// GetSchemaForChain returns the schema with collection names adapted for the given chain prefix.
+// It replaces the default "Ethereum__Mainnet" prefix with the provided one.
+func GetSchemaForChain(prefix string) string {
+	s := GetSchemaForBuild()
+	if prefix == "" || prefix == "Ethereum__Mainnet" {
+		return s
+	}
+	return strings.ReplaceAll(s, "Ethereum__Mainnet", prefix)
 }


### PR DESCRIPTION
# Pull Request

## Description
This PR adds multi-chain EVM support by making all DefraDB collection names configurable per chain, instead of being hard-coded to `Ethereum__Mainnet`. The indexer, schema, block handler, and pruner now derive collection/type names from a chain prefix based on config or environment variables.

## Changes
- Add `chain` section to config (`ChainConfig` with `name` and `network`), including defaults (`Ethereum` / `Mainnet`) and `CHAIN_NAME` / `CHAIN_NETWORK` env overrides.
- Introduce `CollectionNames` and `DefaultCollectionPrefix` in `constants` for generating chain-specific collection names (e.g. `Arbitrum__Mainnet__Block`) while keeping existing `constants.Collection*` and `constants.AllCollections` for backward compatibility.
- Extend schema handling with `GetSchemaForChain`, which rewrites the embedded GraphQL schema’s `Ethereum__Mainnet__*` types to the configured chain prefix.
- Update `BlockHandler` to hold a `*CollectionNames` and use it for all DefraDB collection accesses (including batch creation, batch signatures, and highest-block queries).
- Update `ChainIndexer` to:
  - Construct per-chain `CollectionNames` from config.
  - Apply chain-specific schema (embedded and external DefraDB) via `GetSchemaForChain`.
  - Pass the chain-specific collections into `BlockHandler` and pruner queue tracking.
  - Log the active chain and prefix at startup.
- Update unit and integration tests to work with the new constructor signatures and dynamic collection naming.

## Related Issue
Resolves #130 

## Steps to Test
1. Pull branch locally.
2. Build and run tests:
   - `go test ./...`
3. Run the indexer with default config (Ethereum Mainnet):
   - Confirm collections/types are created as `Ethereum__Mainnet__*` and indexing still works.
4. Run the indexer with a non-default chain, e.g.:
   - Set `CHAIN_NAME=Arbitrum`, `CHAIN_NETWORK=Mainnet` (or update `config.yaml` accordingly).
   - Start the indexer and ensure:
     - Schema types/collections are created as `Arbitrum__Mainnet__Block`, `Arbitrum__Mainnet__Transaction`, etc.
     - Blocks, transactions, logs, and access list entries are written to those collections.
     - Pruner still operates correctly on the new collection names.
5. Optionally verify external DefraDB mode:
   - Point `DEFRADB_URL` to an external DefraDB instance.
   - Ensure schema application succeeds and indexing works with the configured chain prefix.

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [ ] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing


## Notes
- The naming convention used is `{chainName}__{network}__Type` (e.g. `Arbitrum__Mainnet__Block`) rather than a numeric `chainID__EVM__Type`; if the project wants the literal `chainID__EVM` pattern, we can adjust `chainPrefixFromConfig` / `ChainConfig` in a follow-up.
