### PR TITLE
Use `Shinzo Network` in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Shinzo
+Copyright (c) 2025 Shinzo Network
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description
This is the only repository with just `Shinzo` as copyright holder, and this should be unified to `Shinzo Network`.

## Changes
Fix copyright holder in LICENSE to `Shinzo Network`.