### PR TITLE
Fix syntax in indexer-prod-setup.sh

### DIFF
--- a/indexer-prod-setup.sh
+++ b/indexer-prod-setup.sh
@@ -48,8 +48,6 @@ services:
     restart: unless-stopped
 EOF
 
-&&
-
 sudo tee ~/nginx.conf <<'EOF'
 events { worker_connections 1024; }
 


### PR DESCRIPTION
# Pull Request

## Description

Removed unnecessary '&&' from the script.

## Changes

Removed the `&&` and the two empty lines surrounding it.

## Related Issue

https://github.com/shinzonetwork/shinzo-indexer-client/issues/176

## Steps to Test

1. Pull branch locally
2. Run the app or service
3. Verify core functionality works as expected (e.g., main page loads, API responds)

## Checklist
- [ ] Code compiles / runs
- [ ] Tests added / updated
- [ ] Documentation updated if needed
- [ ] PR is self-contained and focused
- [ ] Code does not break any existing features
- [ ] Code passes personal internal testing

## Notes
<!-- Any additional context for reviewers -->
