### PR TITLE
Refactor: hardcoded network values 

### DIFF
--- a/pkg/constants/collections_test.go
+++ b/pkg/constants/collections_test.go
@@ -5,18 +5,19 @@ import (
 )
 
 func TestCollectionConstants(t *testing.T) {
-t.Parallel()
+	t.Parallel()
+	prefix := DefaultCollectionPrefix
 	tests := []struct {
 		name     string
 		constant string
 		expected string
 	}{
-		{"Block", CollectionBlock, "Ethereum__Mainnet__Block"},
-		{"Transaction", CollectionTransaction, "Ethereum__Mainnet__Transaction"},
-		{"Log", CollectionLog, "Ethereum__Mainnet__Log"},
-		{"AccessListEntry", CollectionAccessListEntry, "Ethereum__Mainnet__AccessListEntry"},
-		{"BlockSignature", CollectionBlockSignature, "Ethereum__Mainnet__BlockSignature"},
-		{"SnapshotSignature", CollectionSnapshotSignature, "Ethereum__Mainnet__SnapshotSignature"},
+		{"Block", CollectionBlock, prefix + "__Block"},
+		{"Transaction", CollectionTransaction, prefix + "__Transaction"},
+		{"Log", CollectionLog, prefix + "__Log"},
+		{"AccessListEntry", CollectionAccessListEntry, prefix + "__AccessListEntry"},
+		{"BlockSignature", CollectionBlockSignature, prefix + "__BlockSignature"},
+		{"SnapshotSignature", CollectionSnapshotSignature, prefix + "__SnapshotSignature"},
 	}
 
 	for _, tt := range tests {
@@ -29,7 +30,7 @@ t.Parallel()
 }
 
 func TestAllCollections(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	if AllCollections == nil {
 		t.Fatal("AllCollections should not be nil")
 	}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -3,6 +3,8 @@ package schema
 import (
 	_ "embed"
 	"strings"
+
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/constants"
 )
 
 //go:embed schema.graphql
@@ -14,8 +16,8 @@ func GetSchema() string {
 }
 
 // GetSchemaForChain returns the schema with collection names adapted for the given chain prefix.
-// It replaces the default "Ethereum__Mainnet" prefix with the provided one.
+// It replaces the default prefix with the provided one.
 func GetSchemaForChain(prefix string) string {
-	s := GetSchema();
-	return strings.ReplaceAll(s, "Ethereum__Mainnet", prefix)
+	s := GetSchema()
+	return strings.ReplaceAll(s, constants.DefaultCollectionPrefix, prefix)
 }

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -6,15 +6,18 @@ package schema
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/constants"
 )
 
 func TestGetSchema(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	s := GetSchema()
 	if s == "" {
 		t.Fatal("GetSchema() returned empty string")
 	}
-	if !strings.Contains(s, "Ethereum__Mainnet__Block") {
-		t.Error("schema should contain Ethereum__Mainnet__Block type")
+	expectedType := constants.DefaultCollectionPrefix + "__Block"
+	if !strings.Contains(s, expectedType) {
+		t.Errorf("schema should contain %s type", expectedType)
 	}
 }

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/defra"
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/testutils"
@@ -26,6 +27,15 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+// Test collection names derived from the default prefix
+var (
+	testBlockCollection          = constants.DefaultCollectionPrefix + "__Block"
+	testTransactionCollection    = constants.DefaultCollectionPrefix + "__Transaction"
+	testLogCollection            = constants.DefaultCollectionPrefix + "__Log"
+	testAccessListCollection     = constants.DefaultCollectionPrefix + "__AccessListEntry"
+	testBlockSignatureCollection = constants.DefaultCollectionPrefix + "__BlockSignature"
 )
 
 func TestMain(m *testing.M) {
@@ -1667,7 +1677,7 @@ func TestQueryDocIDs_EmptyDB(t *testing.T) {
 	s := New(cfg, td.Node)
 	ctx := context.Background()
 
-	docIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__Block", "number", 0, 1000)
+	docIDs, err := s.queryDocIDs(ctx, testBlockCollection, "number", 0, 1000)
 	require.NoError(t, err)
 	assert.Empty(t, docIDs)
 }
@@ -1682,7 +1692,7 @@ func TestQueryDocIDs_WithBlocks(t *testing.T) {
 	ctx := context.Background()
 
 	// Query Block collection (uses "number" field)
-	blockDocIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__Block", "number", 100, 102)
+	blockDocIDs, err := s.queryDocIDs(ctx, testBlockCollection, "number", 100, 102)
 	require.NoError(t, err)
 	assert.Len(t, blockDocIDs, 3, "should find 3 block doc IDs")
 
@@ -1702,7 +1712,7 @@ func TestQueryDocIDs_PartialRange(t *testing.T) {
 	ctx := context.Background()
 
 	// Query only blocks 101-103
-	blockDocIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__Block", "number", 101, 103)
+	blockDocIDs, err := s.queryDocIDs(ctx, testBlockCollection, "number", 101, 103)
 	require.NoError(t, err)
 	assert.Len(t, blockDocIDs, 3, "should find 3 block doc IDs for range 101-103")
 }
@@ -1716,7 +1726,7 @@ func TestQueryDocIDs_Transactions(t *testing.T) {
 	s := New(cfg, td.Node)
 	ctx := context.Background()
 
-	txDocIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__Transaction", "blockNumber", 200, 202)
+	txDocIDs, err := s.queryDocIDs(ctx, testTransactionCollection, "blockNumber", 200, 202)
 	require.NoError(t, err)
 	assert.Len(t, txDocIDs, 3, "should find 3 transaction doc IDs")
 }
@@ -1730,7 +1740,7 @@ func TestQueryDocIDs_Logs(t *testing.T) {
 	s := New(cfg, td.Node)
 	ctx := context.Background()
 
-	logDocIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__Log", "blockNumber", 300, 301)
+	logDocIDs, err := s.queryDocIDs(ctx, testLogCollection, "blockNumber", 300, 301)
 	require.NoError(t, err)
 	assert.Len(t, logDocIDs, 2, "should find 2 log doc IDs")
 }
@@ -1745,7 +1755,7 @@ func TestQueryDocIDs_OutOfRange(t *testing.T) {
 	ctx := context.Background()
 
 	// Query a range that has no blocks
-	docIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__Block", "number", 500, 600)
+	docIDs, err := s.queryDocIDs(ctx, testBlockCollection, "number", 500, 600)
 	require.NoError(t, err)
 	assert.Empty(t, docIDs)
 }
@@ -2266,11 +2276,11 @@ func TestCheckAndSnapshot_ImportKV_EndToEnd(t *testing.T) {
 	assert.Equal(t, int64(104), highest)
 
 	// Also verify we can query doc IDs in the imported node
-	blockDocIDs, err := s2.queryDocIDs(ctx, "Ethereum__Mainnet__Block", "number", 100, 104)
+	blockDocIDs, err := s2.queryDocIDs(ctx, testBlockCollection, "number", 100, 104)
 	require.NoError(t, err)
 	assert.Len(t, blockDocIDs, 5, "should find 5 block doc IDs after import")
 
-	txDocIDs, err := s2.queryDocIDs(ctx, "Ethereum__Mainnet__Transaction", "blockNumber", 100, 104)
+	txDocIDs, err := s2.queryDocIDs(ctx, testTransactionCollection, "blockNumber", 100, 104)
 	require.NoError(t, err)
 	assert.Len(t, txDocIDs, 5, "should find 5 transaction doc IDs after import")
 }
@@ -2291,12 +2301,12 @@ func TestQueryDocIDs_ChunkedQuery(t *testing.T) {
 	ctx := context.Background()
 
 	// Query across a range that spans exactly one chunk
-	docIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__Block", "number", 100, 104)
+	docIDs, err := s.queryDocIDs(ctx, testBlockCollection, "number", 100, 104)
 	require.NoError(t, err)
 	assert.Len(t, docIDs, 5)
 
 	// Query across a range that starts before and ends after our blocks
-	docIDs, err = s.queryDocIDs(ctx, "Ethereum__Mainnet__Block", "number", 0, 200)
+	docIDs, err = s.queryDocIDs(ctx, testBlockCollection, "number", 0, 200)
 	require.NoError(t, err)
 	assert.Len(t, docIDs, 5, "should still find only our 5 blocks")
 }
@@ -3588,7 +3598,7 @@ func TestQueryDocIDs_AccessListEntry(t *testing.T) {
 	ctx := context.Background()
 
 	// AccessListEntry docs may or may not exist depending on test transaction data
-	docIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__AccessListEntry", "blockNumber", 600, 601)
+	docIDs, err := s.queryDocIDs(ctx, testAccessListCollection, "blockNumber", 600, 601)
 	require.NoError(t, err)
 	// Just verify no error; count depends on test data
 	_ = docIDs
@@ -3602,7 +3612,7 @@ func TestQueryDocIDs_BlockSignature(t *testing.T) {
 	s := New(cfg, td.Node)
 	ctx := context.Background()
 
-	docIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__BlockSignature", "blockNumber", 700, 701)
+	docIDs, err := s.queryDocIDs(ctx, testBlockSignatureCollection, "blockNumber", 700, 701)
 	require.NoError(t, err)
 	_ = docIDs
 }
@@ -3948,7 +3958,7 @@ func insertBlockSignature(t *testing.T, td *testutils.TestDefraDB, blockNumber i
 	txn, err := td.Node.DB.NewBlindWriteTxn()
 	require.NoError(t, err)
 
-	col, err := txn.GetCollectionByName(ctx, "Ethereum__Mainnet__BlockSignature")
+	col, err := txn.GetCollectionByName(ctx, testBlockSignatureCollection)
 	require.NoError(t, err)
 
 	data := map[string]any{
@@ -4565,17 +4575,17 @@ func TestQueryDocIDs_WithIdentityBlocks(t *testing.T) {
 	ctx := context.Background()
 
 	// Query Block docs
-	blockDocIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__Block", "number", 400, 402)
+	blockDocIDs, err := s.queryDocIDs(ctx, testBlockCollection, "number", 400, 402)
 	require.NoError(t, err)
 	assert.Len(t, blockDocIDs, 3)
 
 	// Query Transaction docs
-	txDocIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__Transaction", "blockNumber", 400, 402)
+	txDocIDs, err := s.queryDocIDs(ctx, testTransactionCollection, "blockNumber", 400, 402)
 	require.NoError(t, err)
 	assert.Len(t, txDocIDs, 3)
 
 	// Query BlockSignature docs (should exist with identity)
-	sigDocIDs, err := s.queryDocIDs(ctx, "Ethereum__Mainnet__BlockSignature", "blockNumber", 400, 402)
+	sigDocIDs, err := s.queryDocIDs(ctx, testBlockSignatureCollection, "blockNumber", 400, 402)
 	require.NoError(t, err)
 	assert.Len(t, sigDocIDs, 3, "should have 3 block signature docs")
 }


### PR DESCRIPTION
# Pull Request

## Description
Removes hardcoded values from being used throughout tests and unifies them into a single point being set in constants. 

## Changes
- Removed hardcoded network names from tests
- Uses constants.DefaultCollectionPrefix instead of `Ethereum__Mainnet`

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Verify core functionality works as expected (e.g., main page loads, API responds)

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
Something that came up when working on Sepolia