### PR TITLE
fix(indexer): pass FullIdentity to NewBlockHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ coverage.html
 logs/
 
 .DS_Store
+reviews/

--- a/pkg/defra/block_handler_signing_test.go
+++ b/pkg/defra/block_handler_signing_test.go
@@ -1,0 +1,187 @@
+package defra
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"testing"
+
+	gocid "github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/node"
+
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/testutils"
+)
+
+// makeTestCID returns a deterministic CID derived from seed. Lets tests build
+// known collectors without depending on real document writes.
+func makeTestCID(t *testing.T, seed string) gocid.Cid {
+	t.Helper()
+	hash, err := multihash.Sum([]byte(seed), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+	return gocid.NewCidV1(gocid.Raw, hash)
+}
+
+// NewBlockHandler must select signBlockWithIdentity when given a non-nil
+// FullIdentity. The signing-from-struct path doesn't depend on identity being
+// in the context, which is the only way batch signing works for callers that
+// can't write to defradb's internal identity key.
+func TestNewBlockHandler_NonNilIdent_RoutesThroughSignBlockWithIdentity(t *testing.T) {
+	t.Parallel()
+	td := testutils.SetupTestDefraDB(t)
+	require.NotNil(t, td.Identity, "test setup must provide a real FullIdentity")
+
+	h, err := NewBlockHandler(td.Node, 1000, nil, td.Identity)
+	require.NoError(t, err)
+	require.NotNil(t, h.signBlockFn)
+
+	expectedFn := h.signBlockWithIdentity
+	assert.Equal(t,
+		reflect.ValueOf(expectedFn).Pointer(),
+		reflect.ValueOf(h.signBlockFn).Pointer(),
+		"with non-nil ident, signBlockFn must be h.signBlockWithIdentity",
+	)
+	assert.NotEqual(t,
+		reflect.ValueOf(node.SignBlock).Pointer(),
+		reflect.ValueOf(h.signBlockFn).Pointer(),
+		"with non-nil ident, signBlockFn must not be node.SignBlock",
+	)
+}
+
+// NewBlockHandler must fall back to node.SignBlock when ident is nil. This
+// path produces no signatures (node.SignBlock requires identity in defradb's
+// internal context key, which external code can't populate), but several
+// tests pass nil ident and depend on this branch existing.
+func TestNewBlockHandler_NilIdent_RoutesThroughNodeSignBlock(t *testing.T) {
+	t.Parallel()
+	td := testutils.SetupTestDefraDB(t)
+	h, err := NewBlockHandler(td.Node, 1000, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, h.signBlockFn)
+
+	assert.Equal(t,
+		reflect.ValueOf(node.SignBlock).Pointer(),
+		reflect.ValueOf(h.signBlockFn).Pointer(),
+		"with nil ident, signBlockFn must be node.SignBlock",
+	)
+}
+
+// signBlockWithIdentity must produce a cryptographically correct signature:
+// the merkle root must hash the supplied CIDs, the signature must verify
+// against the configured identity's public key, and the header fields
+// (signatureType, signatureIdentity) must match the configured identity.
+func TestSignBlockWithIdentity_ProducesValidSignature(t *testing.T) {
+	t.Parallel()
+	td := testutils.SetupTestDefraDB(t)
+	require.NotNil(t, td.Identity, "test setup must provide a real FullIdentity")
+
+	h, err := NewBlockHandler(td.Node, 1000, nil, td.Identity)
+	require.NoError(t, err)
+
+	collector := node.NewBlockCIDCollector()
+	cids := []gocid.Cid{
+		makeTestCID(t, "doc-A"),
+		makeTestCID(t, "doc-B"),
+		makeTestCID(t, "doc-C"),
+	}
+	for _, c := range cids {
+		collector.Add(c)
+	}
+
+	blockSig, err := h.signBlockWithIdentity(context.Background(), collector)
+	require.NoError(t, err)
+	require.NotNil(t, blockSig, "signing must produce a non-nil BlockSignature")
+
+	expectedRoot := node.ComputeMerkleRoot(cids)
+	require.Equal(t, len(expectedRoot), len(blockSig.MerkleRoot), "merkle root length mismatch")
+	assert.True(t, bytes.Equal(expectedRoot, blockSig.MerkleRoot),
+		"merkle root in signature must match ComputeMerkleRoot over the input CIDs")
+
+	assert.Equal(t, len(cids), blockSig.CIDCount)
+
+	switch td.Identity.PrivateKey().Type() {
+	case crypto.KeyTypeSecp256k1:
+		assert.Equal(t, "ES256K", blockSig.Header.Type,
+			"secp256k1 keys must produce ES256K signatures")
+	case crypto.KeyTypeEd25519:
+		assert.Equal(t, "EdDSA", blockSig.Header.Type,
+			"ed25519 keys must produce EdDSA signatures")
+	default:
+		t.Fatalf("test identity uses unexpected key type: %v", td.Identity.PrivateKey().Type())
+	}
+
+	expectedIdent := td.Identity.PublicKey().String()
+	assert.Equal(t, expectedIdent, string(blockSig.Header.Identity),
+		"signature must carry the handler's identity in the header")
+
+	valid, err := node.VerifyBlockSignatureCIDs(blockSig, cids)
+	require.NoError(t, err)
+	assert.True(t, valid, "signature must verify against the input CIDs")
+}
+
+// signBlockWithIdentity must short-circuit and return (nil, nil) when the
+// collector has no CIDs. Callers rely on this to skip signature creation
+// for blocks that produced no signed content.
+func TestSignBlockWithIdentity_EmptyCollector_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	td := testutils.SetupTestDefraDB(t)
+	h, err := NewBlockHandler(td.Node, 1000, nil, td.Identity)
+	require.NoError(t, err)
+
+	collector := node.NewBlockCIDCollector()
+	blockSig, err := h.signBlockWithIdentity(context.Background(), collector)
+	require.NoError(t, err)
+	assert.Nil(t, blockSig, "empty collector must produce a nil BlockSignature")
+}
+
+// signBlockWithIdentity must short-circuit when h.nodeIdentity is nil rather
+// than panicking on a nil PrivateKey() dereference. Guards the direct-call
+// path; callers normally avoid this via the routing logic in NewBlockHandler.
+func TestSignBlockWithIdentity_NilNodeIdentity_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	td := testutils.SetupTestDefraDB(t)
+	h, err := NewBlockHandler(td.Node, 1000, nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, h.nodeIdentity, "test precondition: h.nodeIdentity must be nil")
+
+	collector := node.NewBlockCIDCollector()
+	collector.Add(makeTestCID(t, "doc-A"))
+	blockSig, err := h.signBlockWithIdentity(context.Background(), collector)
+	require.NoError(t, err)
+	assert.Nil(t, blockSig, "nil h.nodeIdentity must produce a nil BlockSignature")
+}
+
+// Distinct CID sets must produce distinct merkle roots and distinct signature
+// values. Catches a class of bug where signing accidentally hashes a constant
+// or stale state instead of the current collector's contents.
+func TestSignBlockWithIdentity_DifferentCIDsProduceDifferentRoots(t *testing.T) {
+	t.Parallel()
+	td := testutils.SetupTestDefraDB(t)
+	h, err := NewBlockHandler(td.Node, 1000, nil, td.Identity)
+	require.NoError(t, err)
+
+	collector1 := node.NewBlockCIDCollector()
+	collector1.Add(makeTestCID(t, "alpha"))
+	collector1.Add(makeTestCID(t, "beta"))
+
+	collector2 := node.NewBlockCIDCollector()
+	collector2.Add(makeTestCID(t, "gamma"))
+	collector2.Add(makeTestCID(t, "delta"))
+
+	sig1, err := h.signBlockWithIdentity(context.Background(), collector1)
+	require.NoError(t, err)
+	require.NotNil(t, sig1)
+
+	sig2, err := h.signBlockWithIdentity(context.Background(), collector2)
+	require.NoError(t, err)
+	require.NotNil(t, sig2)
+
+	assert.False(t, bytes.Equal(sig1.MerkleRoot, sig2.MerkleRoot),
+		"distinct CID sets must produce distinct merkle roots")
+	assert.False(t, bytes.Equal(sig1.Value, sig2.Value),
+		"distinct merkle roots must produce distinct signature values")
+}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/types"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/node"
 
@@ -166,10 +167,12 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 
 	logger.Sugar.Infof("Indexing chain: %s (prefix: %s)", cfg.Chain.Name+"__"+cfg.Chain.Network, chainPrefixFromConfig(cfg))
 
+	// Convert indexer config to app-sdk config (used for both defraNode startup
+	// and node-identity loading below).
+	appCfg := toAppConfig(cfg)
+
 	if !defraStarted {
 		// Use app-sdk to start DefraDB instance with persistent keys
-		// Convert indexer config to app-sdk config
-		appCfg := toAppConfig(cfg)
 		// Note: app-sdk P2P config has no Enabled field - P2P should be enabled by ListenAddr
 
 		logger.Sugar.Debugf("P2P config: ListenAddr: '%s', BootstrapPeers: %v",
@@ -201,15 +204,6 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 			return err
 		}
 
-		// Get the identity context for block signing
-		identityCtx, err := appsdk.GetIdentityContext(ctx, appCfg)
-		if err != nil {
-			logger.Sugar.Warnf("Failed to get identity context for block signing: %v (block signatures may not work)", err)
-		} else {
-			ctx = identityCtx
-			logger.Sugar.Info("Identity context initialized for block signing")
-		}
-
 	} else {
 		// Using external DefraDB - wait for it and apply schema via HTTP
 		err := defra.WaitForDefraDB(cfg.DefraDB.Url)
@@ -227,7 +221,17 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 		return fmt.Errorf("defraNode is required - external DefraDB via HTTP is no longer supported")
 	}
 
-	blockHandler, err := defra.NewBlockHandler(i.defraNode, cfg.Indexer.MaxDocsPerTxn, i.collections, nil)
+	nodeIdent, err := appsdk.GetOrCreateNodeIdentity(appCfg)
+	if err != nil {
+		return fmt.Errorf("failed to load node identity for block signing: %w",
+			err)
+	}
+	fullIdent, ok := nodeIdent.(identity.FullIdentity)
+	if !ok {
+		return fmt.Errorf("loaded node identity is not a FullIdentity (noprivate key)")
+	}
+
+	blockHandler, err := defra.NewBlockHandler(i.defraNode, cfg.Indexer.MaxDocsPerTxn, i.collections, fullIdent)
 	if err != nil {
 		return fmt.Errorf("failed to create block handler: %v", err)
 	}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/defra"
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/errors"
+	shinzoIdentity "github.com/shinzonetwork/shinzo-indexer-client/pkg/identity"
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/rpc"
 	"github.com/shinzonetwork/shinzo-indexer-client/pkg/schema"
@@ -30,6 +31,7 @@ import (
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/node"
+	"github.com/sourcenetwork/immutable"
 
 	appConfig "github.com/shinzonetwork/shinzo-app-sdk/pkg/config"
 	appsdk "github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
@@ -230,6 +232,11 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 	if !ok {
 		return fmt.Errorf("loaded node identity is not a FullIdentity (noprivate key)")
 	}
+
+	// Carry the identity on ctx so downstream subsystems that sign with it
+	// (snapshotter Merkle root signing) can recover it without the indexer
+	// having to thread it through every constructor.
+	ctx = shinzoIdentity.WithContext(ctx, immutable.Some(fullIdent))
 
 	blockHandler, err := defra.NewBlockHandler(i.defraNode, cfg.Indexer.MaxDocsPerTxn, i.collections, fullIdent)
 	if err != nil {

--- a/pkg/indexer/indexer_block_signature_test.go
+++ b/pkg/indexer/indexer_block_signature_test.go
@@ -1,0 +1,217 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appsdk "github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-app-sdk/pkg/pruner"
+	"github.com/shinzonetwork/shinzo-indexer-client/config"
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/logger"
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/snapshot"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/node"
+)
+
+// End-to-end check that the embedded-defra startup path produces real
+// BlockSignature documents in DefraDB. Exercises the full chain: SDK
+// startup, keyring identity load, BlockHandler construction, block creation,
+// signing, and persistence. The cryptographic verification at the end pins
+// that the signing identity is the same one the SDK loaded into the node,
+// which catches both "no signature produced" and "signature with wrong key"
+// regressions.
+//
+// Not t.Parallel(): reads indexer.defraNode (a package-private field) while
+// StartIndexing's goroutine assigns to it. Running parallel with other
+// embedded-defra tests would surface that as a race under -race.
+func TestStartIndexing_Embedded_ProducesValidBlockSignatures(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	logger.InitConsoleOnly(true)
+
+	tmpDir := t.TempDir()
+
+	// blockCh satisfies newMockRPCServerForIntegration's signature; we don't
+	// consume it here.
+	blockCh := make(chan struct{}, 100)
+	rpcServer := newMockRPCServerForIntegration(blockCh)
+	t.Cleanup(rpcServer.Close)
+
+	cfg := newBlockSigTestConfig(tmpDir, rpcServer)
+
+	indexer, err := CreateIndexer(cfg)
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- indexer.StartIndexing(false)
+	}()
+
+	// queryBlockSignatureCountSafe short-circuits on a nil defraNode, so this
+	// single condition covers both "indexer is up" and "at least one block
+	// has been signed and committed."
+	require.Eventually(t, func() bool {
+		return queryBlockSignatureCountSafe(indexer) >= 1
+	}, 60*time.Second, 250*time.Millisecond,
+		"expected at least one BlockSignature document to be written end-to-end")
+
+	// Capture defraNode now: StopIndexing nils the field, and we still need
+	// to query for the signature contents and re-load the keyring identity.
+	defraNode := indexer.defraNode
+	require.NotNil(t, defraNode, "indexer.defraNode must still be live for assertions")
+
+	sigs := querySignaturesAgainst(t, defraNode)
+	require.NotEmpty(t, sigs, "BlockSignature collection must contain at least one document")
+
+	sig := sigs[0]
+	require.NotEmpty(t, sig["merkleRoot"], "merkleRoot must be set on the BlockSignature document")
+	require.NotEmpty(t, sig["signatureValue"], "signatureValue must be set")
+	require.NotEmpty(t, sig["signatureIdentity"], "signatureIdentity must be set")
+	require.Contains(t, []string{"ES256K", "EdDSA"}, sig["signatureType"],
+		"signatureType must be a known algorithm")
+
+	// Re-load the node identity from the same keyring path the indexer used.
+	// If the wiring is correct, this is the same identity that signed the
+	// block, so the public key string in the signature must match.
+	appCfg := toAppConfig(cfg)
+	loadedIdent, err := appsdk.GetOrCreateNodeIdentity(appCfg)
+	require.NoError(t, err)
+	loadedFullIdent, ok := loadedIdent.(acpIdentity.FullIdentity)
+	require.True(t, ok, "loaded node identity must be a FullIdentity")
+	expectedDID := loadedFullIdent.PublicKey().String()
+
+	assert.Equal(t, expectedDID, sig["signatureIdentity"],
+		"signatureIdentity must match the keyring-loaded node identity DID")
+
+	indexer.StopIndexing()
+	require.Eventually(t, func() bool {
+		return !indexer.IsStarted()
+	}, 5*time.Second, 50*time.Millisecond, "indexer must report stopped after StopIndexing")
+
+	// Drain the StartIndexing goroutine. Best-effort: the inner block-fetcher
+	// may not return immediately, so we don't fail on timeout.
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// newBlockSigTestConfig builds a config with embedded defra in tmpDir and a
+// keyring secret long enough to satisfy the SDK. P2P, snapshotter, and
+// pruner are disabled to keep the test deterministic and fast.
+func newBlockSigTestConfig(tmpDir string, rpcServer *httptest.Server) *config.Config {
+	return &config.Config{
+		DefraDB: config.DefraDBConfig{
+			Url:           "",
+			KeyringSecret: "test-secret-for-keyring-12345678",
+			P2P: config.DefraDBP2PConfig{
+				Enabled: false,
+			},
+			Store: config.DefraDBStoreConfig{
+				Path: tmpDir,
+			},
+		},
+		Geth: config.GethConfig{
+			NodeURL: rpcServer.URL,
+		},
+		Indexer: config.IndexerConfig{
+			StartHeight:      0,
+			ConcurrentBlocks: 1,
+			ReceiptWorkers:   2,
+			MaxDocsPerTxn:    100,
+			HealthServerPort: 0,
+			StartBuffer:      10,
+		},
+		Pruner: pruner.Config{
+			Enabled:         false,
+			MaxBlocks:       1000,
+			PruneThreshold:  500,
+			IntervalSeconds: 3600,
+		},
+		Snapshot: snapshot.Config{
+			Enabled:         false,
+			Dir:             filepath.Join(tmpDir, "snapshots"),
+			BlocksPerFile:   1000,
+			IntervalSeconds: 3600,
+		},
+		Logger: config.LoggerConfig{Development: true},
+	}
+}
+
+// queryBlockSignatureCountSafe counts BlockSignature documents currently in
+// the indexer's embedded defra. Returns 0 on any error so the caller can
+// retry — used as a polling predicate, not for assertions.
+func queryBlockSignatureCountSafe(indexer *ChainIndexer) int {
+	if indexer.defraNode == nil {
+		return 0
+	}
+	query := fmt.Sprintf(
+		`query { %s { _docID } }`,
+		constants.CollectionBlockSignature,
+	)
+	result := indexer.defraNode.DB.ExecRequest(context.Background(), query)
+	if len(result.GQL.Errors) > 0 {
+		return 0
+	}
+	data, ok := result.GQL.Data.(map[string]any)
+	if !ok {
+		return 0
+	}
+	raw, ok := data[constants.CollectionBlockSignature]
+	if !ok || raw == nil {
+		return 0
+	}
+	switch typed := raw.(type) {
+	case []any:
+		return len(typed)
+	case []map[string]any:
+		return len(typed)
+	}
+	return 0
+}
+
+// querySignaturesAgainst returns the full BlockSignature documents on the
+// given node and fails the test on a query error. Takes *node.Node (not the
+// owning ChainIndexer) so callers can hold a stable reference past
+// StopIndexing, which nils the indexer's defraNode field.
+func querySignaturesAgainst(t *testing.T, defraNode *node.Node) []map[string]any {
+	t.Helper()
+	require.NotNil(t, defraNode, "defraNode must be non-nil")
+	query := fmt.Sprintf(
+		`query { %s { _docID merkleRoot signatureValue signatureIdentity signatureType cidCount } }`,
+		constants.CollectionBlockSignature,
+	)
+	result := defraNode.DB.ExecRequest(context.Background(), query)
+	require.Empty(t, result.GQL.Errors, "BlockSignature query must succeed: %v", result.GQL.Errors)
+
+	data, ok := result.GQL.Data.(map[string]any)
+	require.True(t, ok, "GQL response must be a map")
+	raw, ok := data[constants.CollectionBlockSignature]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch typed := raw.(type) {
+	case []any:
+		out := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			m, ok := item.(map[string]any)
+			require.True(t, ok, "expected each document to be a map[string]any, got %T", item)
+			out = append(out, m)
+		}
+		return out
+	case []map[string]any:
+		return typed
+	default:
+		t.Fatalf("unexpected document list shape: %T", raw)
+		return nil
+	}
+}

--- a/pkg/indexer/indexer_snapshot_signature_test.go
+++ b/pkg/indexer/indexer_snapshot_signature_test.go
@@ -1,0 +1,212 @@
+package indexer
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appsdk "github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-app-sdk/pkg/pruner"
+	"github.com/shinzonetwork/shinzo-indexer-client/config"
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/logger"
+	"github.com/shinzonetwork/shinzo-indexer-client/pkg/snapshot"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/node"
+)
+
+// End-to-end check that the embedded-defra startup path produces real
+// SnapshotSignature documents in DefraDB with valid cryptographic content.
+// Asserts the signature DID matches the keyring identity, the merkle root
+// is a valid 32-byte hash, and signatureValue decodes as hex.
+//
+// Not t.Parallel(): reads a package-private field that StartIndexing's
+// goroutine writes.
+func TestStartIndexing_Embedded_ProducesValidSnapshotSignatures(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	logger.InitConsoleOnly(true)
+
+	tmpDir := t.TempDir()
+
+	blockCh := make(chan struct{}, 100)
+	rpcServer := newMockRPCServerForIntegration(blockCh)
+	t.Cleanup(rpcServer.Close)
+
+	cfg := newSnapshotSigTestConfig(tmpDir, rpcServer)
+
+	indexer, err := CreateIndexer(cfg)
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- indexer.StartIndexing(false)
+	}()
+
+	require.Eventually(t, func() bool {
+		return querySnapshotSignatureCountSafe(indexer) >= 1
+	}, 90*time.Second, 500*time.Millisecond,
+		"expected at least one SnapshotSignature document to be written end-to-end")
+
+	defraNode := indexer.defraNode
+	require.NotNil(t, defraNode, "indexer.defraNode must still be live for assertions")
+
+	sigs := querySnapshotSignaturesAgainst(t, defraNode)
+	require.NotEmpty(t, sigs, "SnapshotSignature collection must contain at least one document")
+
+	sig := sigs[0]
+	require.NotEmpty(t, sig["merkleRoot"], "merkleRoot must be set on the SnapshotSignature document")
+	require.NotEmpty(t, sig["signatureValue"], "signatureValue must be set")
+	require.NotEmpty(t, sig["signatureIdentity"], "signatureIdentity must be set")
+	require.Contains(t, []string{"ES256K", "Ed25519"}, sig["signatureType"],
+		"signatureType must be a known algorithm")
+
+	// signatureValue is stored as hex; decode to confirm it is well-formed.
+	sigValueStr, ok := sig["signatureValue"].(string)
+	require.True(t, ok, "signatureValue must be a string")
+	sigBytes, err := hex.DecodeString(sigValueStr)
+	require.NoError(t, err, "signatureValue must be valid hex")
+	assert.NotEmpty(t, sigBytes, "decoded signatureValue must be non-empty")
+
+	merkleRootStr, ok := sig["merkleRoot"].(string)
+	require.True(t, ok, "merkleRoot must be a string")
+	merkleBytes, err := hex.DecodeString(merkleRootStr)
+	require.NoError(t, err, "merkleRoot must be valid hex")
+	assert.Len(t, merkleBytes, 32, "merkle root must be a 32-byte SHA256 hash")
+
+	// Re-load the node identity from the same keyring and confirm the
+	// signature carries that DID.
+	appCfg := toAppConfig(cfg)
+	loadedIdent, err := appsdk.GetOrCreateNodeIdentity(appCfg)
+	require.NoError(t, err)
+	loadedFullIdent, ok := loadedIdent.(acpIdentity.FullIdentity)
+	require.True(t, ok, "loaded node identity must be a FullIdentity")
+	expectedDID := loadedFullIdent.PublicKey().String()
+	assert.Equal(t, expectedDID, sig["signatureIdentity"],
+		"signatureIdentity must match the keyring-loaded node identity DID")
+
+	indexer.StopIndexing()
+	require.Eventually(t, func() bool {
+		return !indexer.IsStarted()
+	}, 5*time.Second, 50*time.Millisecond, "indexer must report stopped after StopIndexing")
+
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// newSnapshotSigTestConfig enables the snapshotter with a small block window
+// and a 1-second tick so a snapshot fires within the test deadline.
+func newSnapshotSigTestConfig(tmpDir string, rpcServer *httptest.Server) *config.Config {
+	return &config.Config{
+		DefraDB: config.DefraDBConfig{
+			Url:           "",
+			KeyringSecret: "test-secret-for-keyring-12345678",
+			P2P: config.DefraDBP2PConfig{
+				Enabled: false,
+			},
+			Store: config.DefraDBStoreConfig{
+				Path: tmpDir,
+			},
+		},
+		Geth: config.GethConfig{
+			NodeURL: rpcServer.URL,
+		},
+		Indexer: config.IndexerConfig{
+			StartHeight:      0,
+			ConcurrentBlocks: 1,
+			ReceiptWorkers:   2,
+			MaxDocsPerTxn:    100,
+			HealthServerPort: 0,
+			StartBuffer:      10,
+		},
+		Pruner: pruner.Config{
+			Enabled:         false,
+			MaxBlocks:       1000,
+			PruneThreshold:  500,
+			IntervalSeconds: 3600,
+		},
+		Snapshot: snapshot.Config{
+			Enabled:         true,
+			Dir:             filepath.Join(tmpDir, "snapshots"),
+			BlocksPerFile:   2,
+			IntervalSeconds: 1,
+		},
+		Logger: config.LoggerConfig{Development: true},
+	}
+}
+
+// querySnapshotSignatureCountSafe counts SnapshotSignature documents in the
+// indexer's embedded defra. Returns 0 on any error so polling can retry.
+func querySnapshotSignatureCountSafe(indexer *ChainIndexer) int {
+	if indexer.defraNode == nil {
+		return 0
+	}
+	query := fmt.Sprintf(
+		`query { %s { _docID } }`,
+		constants.CollectionSnapshotSignature,
+	)
+	result := indexer.defraNode.DB.ExecRequest(context.Background(), query)
+	if len(result.GQL.Errors) > 0 {
+		return 0
+	}
+	data, ok := result.GQL.Data.(map[string]any)
+	if !ok {
+		return 0
+	}
+	raw, ok := data[constants.CollectionSnapshotSignature]
+	if !ok || raw == nil {
+		return 0
+	}
+	switch typed := raw.(type) {
+	case []any:
+		return len(typed)
+	case []map[string]any:
+		return len(typed)
+	}
+	return 0
+}
+
+// querySnapshotSignaturesAgainst returns the full SnapshotSignature documents
+// on the given node and fails the test on a query error.
+func querySnapshotSignaturesAgainst(t *testing.T, defraNode *node.Node) []map[string]any {
+	t.Helper()
+	require.NotNil(t, defraNode, "defraNode must be non-nil")
+	query := fmt.Sprintf(
+		`query { %s { _docID merkleRoot signatureValue signatureIdentity signatureType blockCount snapshotFile startBlock endBlock } }`,
+		constants.CollectionSnapshotSignature,
+	)
+	result := defraNode.DB.ExecRequest(context.Background(), query)
+	require.Empty(t, result.GQL.Errors, "SnapshotSignature query must succeed: %v", result.GQL.Errors)
+
+	data, ok := result.GQL.Data.(map[string]any)
+	require.True(t, ok, "GQL response must be a map")
+	raw, ok := data[constants.CollectionSnapshotSignature]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch typed := raw.(type) {
+	case []any:
+		out := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			m, ok := item.(map[string]any)
+			require.True(t, ok, "expected each document to be a map[string]any, got %T", item)
+			out = append(out, m)
+		}
+		return out
+	case []map[string]any:
+		return typed
+	default:
+		t.Fatalf("unexpected document list shape: %T", raw)
+		return nil
+	}
+}

--- a/pkg/testutils/mock_server.go
+++ b/pkg/testutils/mock_server.go
@@ -49,7 +49,7 @@ func CreateMockServer(config MockServerConfig) *httptest.Server {
 func CreateGraphQLCreateResponse(collectionName, docID string) string {
 	return `{
 		"data": {
-			"create_` + collectionName + `": [
+			"add_` + collectionName + `": [
 				{
 					"_docID": "` + docID + `"
 				}


### PR DESCRIPTION
## The Issue
Two paths were silently producing no signatures in production:
  1. BlockHandler was constructed with nil ident, so signBlockFn fell back to node.SignBlock which reads from defradb's internal identity context key. External code can't write to that key, so it returned (nil, nil) and signature creation was skipped.                                                                                                                   
  2. signMerkleRoot reads the FullIdentity from a context wrapper that production never populated, so snapshots were written without SnapshotSignature documents.                                                                                       

This PR loads the keyring identity once in StartIndexing and uses it for both paths.
##                                                
###  Changes
                                                                                                                             
  - Load the node identity, type-assert to FullIdentity, and pass it to NewBlockHandler (was nil).
  - Wrap the same identity onto ctx via shinzoIdentity.WithContext before the snapshotter starts.                            
  - Remove the dead appsdk.GetIdentityContext call.         
  - New end-to-end tests for both paths plus unit tests on signBlockFn routing and signBlockWithIdentity correctness.        
                                              
### Related Issue                                                                                                              
                                                                                                                             
  Closes #210                                                                                                                
                                                                                                                             
### Steps to Test                                                                                                              
                                                            
  1. go build ./...                           
  2. go test ./pkg/indexer ./pkg/snapshot ./pkg/defra ./pkg/identity -count=1 -timeout=600s
  3. Run the new sentinel tests directly if you want verbose output:
    - go test ./pkg/indexer -run TestStartIndexing_Embedded_ProducesValidBlockSignatures -v                                  
    - go test ./pkg/indexer -run TestStartIndexing_Embedded_ProducesValidSnapshotSignatures -v
                                                                                                                             
### Checklist                                                                                                                  
   
- [x] Code compiles / runs                                                                                                     
- [x] Tests added / updated                                   
- [x] Documentation updated if needed                                                                                          
- [x] PR is self-contained and focused                        
- [x] Code does not break any existing features
- [x] Code passes personal internal testing                                                                                    
                                              

                                          