### PR TITLE
new config: GETH-API-KEY-TYPE

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -262,6 +262,9 @@ func applyEnvOverrides(cfg *Config) {
 	if gethApiKey := os.Getenv("GETH_API_KEY"); gethApiKey != "" {
 		cfg.Geth.APIKey = gethApiKey
 	}
+	if gethApiKeyType := os.Getenv("GETH_API_KEY_TYPE"); gethApiKeyType != "" {
+		cfg.Geth.APIKeyType = gethApiKeyType
+	}
 
 	// Indexer configuration
 	if startHeight := os.Getenv("INDEXER_START_HEIGHT"); startHeight != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLoadConfig_ValidYAML(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.yaml")
 
@@ -61,7 +61,7 @@ logger:
 }
 
 func TestLoadConfig_InvalidPath(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	_, err := LoadConfig("/nonexistent/path/config.yaml")
 	if err == nil {
 		t.Error("Expected error for nonexistent config file")
@@ -69,7 +69,7 @@ t.Parallel()
 }
 
 func TestLoadConfig_InvalidYAML(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "invalid_config.yaml")
 
@@ -124,7 +124,7 @@ func TestDefraDBEmbeddedUrlMatrix(t *testing.T) {
 }
 
 func TestDefraDBConfig_Host(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	cfg := &DefraDBConfig{Url: "http://localhost:9181"}
 	if cfg.Host() != "http://localhost:9181" {
 		t.Errorf("Host() = %q, want %q", cfg.Host(), "http://localhost:9181")
@@ -132,7 +132,7 @@ t.Parallel()
 }
 
 func TestApplyDefaults_AllZeroValues(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	cfg := &Config{}
 	applyDefaults(cfg)
 
@@ -154,7 +154,7 @@ t.Parallel()
 }
 
 func TestApplyDefaults_PresetValuesPreserved(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	cfg := &Config{}
 	cfg.Indexer.ConcurrentBlocks = 4
 	cfg.Indexer.ReceiptWorkers = 8
@@ -182,7 +182,7 @@ t.Parallel()
 }
 
 func TestValidateConfig_NegativeStartHeight(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	cfg := &Config{}
 	cfg.DefraDB.Embedded = true
 	cfg.Indexer.StartHeight = -1
@@ -197,7 +197,7 @@ t.Parallel()
 }
 
 func TestValidateConfig_ExternalEmptyUrl(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	cfg := &Config{}
 	cfg.DefraDB.Embedded = false
 	cfg.DefraDB.Url = ""
@@ -209,7 +209,7 @@ t.Parallel()
 }
 
 func TestValidateConfig_Valid(t *testing.T) {
-t.Parallel()
+	t.Parallel()
 	cfg := &Config{}
 	cfg.DefraDB.Embedded = true
 	cfg.Indexer.StartHeight = 0
@@ -354,6 +354,7 @@ func TestApplyEnvOverrides_GethConfig(t *testing.T) {
 	t.Setenv("GETH_RPC_URL", "http://geth:8545")
 	t.Setenv("GETH_WS_URL", "ws://geth:8546")
 	t.Setenv("GETH_API_KEY", "myapikey")
+	t.Setenv("GETH_API_KEY_TYPE", "X-Api-Key")
 	applyEnvOverrides(cfg)
 
 	if cfg.Geth.NodeURL != "http://geth:8545" {


### PR DESCRIPTION
# Pull Request

## Description
This PR allows for someone to override the key type used in the build config.

## Changes
- Allows someone to set a key type with their env

## Related Issue
fixes #192 

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Verify core functionality works as expected (e.g., main page loads, API responds)

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing


