### PR TITLE
Update/docker compose with key type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,8 +131,8 @@ COPY --from=builder /usr/local/include/ /usr/local/include/
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
 # Create non-root user for security
-RUN groupadd -g 1001 indexer && \
-    useradd -u 1001 -g indexer -m -s /bin/bash indexer
+RUN groupadd -g 1001 shinzo-indexer && \
+    useradd -u 1001 -g shinzo-indexer -m -s /bin/bash shinzo-indexer
 
 # Set working directory
 WORKDIR /app
@@ -147,12 +147,12 @@ COPY --from=builder /app/pkg/schema/ /app/pkg/schema/
 # Create necessary directories with proper permissions
 RUN mkdir -p /app/.defra /app/logs /tmp && \
     touch /app/logs/logfile && \
-    chown -R indexer:indexer /app && \
+    chown -R shinzo-indexer:shinzo-indexer /app && \
     chmod -R 755 /app && \
     chmod +x /app/block_poster
 
 # Switch to non-root user
-USER indexer
+USER shinzo-indexer
 
 # Health check with better error handling
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -12,6 +12,7 @@ services:
       - GETH_RPC_URL=${GETH_RPC_URL}
       - GETH_WS_URL=${GETH_WS_URL}
       - GETH_API_KEY=${GETH_API_KEY}
+      - GETH_API_KEY_TYPE=${GETH_API_KEY_TYPE}
       
       # DefraDB Configuration (embedded)
       - DEFRADB_KEYRING_SECRET=${DEFRADB_KEYRING_SECRET:-}

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,3 +1,7 @@
+networks:
+  shinzo-net:
+    driver: bridge
+
 services:
   indexer:
     container_name: shinzo-indexer
@@ -36,7 +40,7 @@ services:
         max-size: "50m"
         max-file: "3"
     volumes:
-      - ~/data/defradb:/app/.defra
+      - ~/shinzo-data/defradb:/app/.defra
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,31 +1,42 @@
 services:
   indexer:
+    container_name: shinzo-indexer
+    platform: linux/amd64
     image: shinzo-indexer:latest
+    restart: unless-stopped 
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: shinzo-indexer
-    restart: unless-stopped
-    network_mode: host
+    user: "1001:1001" # shinzo-indexer identity
+    networks:
+      - shinzo-net
+    mem_limit: 16g 
+    mem_reservation: 13g
+    ports: 
+      - "9171:9171" #open ports to connect with hosts.
     environment:
       # Ethereum Node Configuration
       - GETH_RPC_URL=${GETH_RPC_URL}
       - GETH_WS_URL=${GETH_WS_URL}
       - GETH_API_KEY=${GETH_API_KEY}
-      - GETH_API_KEY_TYPE=${GETH_API_KEY_TYPE}
+      - GETH_API_KEY_TYPE=${GETH_API_KEY_TYPE} # this is your api key type
       
       # DefraDB Configuration (embedded)
       - DEFRADB_KEYRING_SECRET=${DEFRADB_KEYRING_SECRET:-}
       
       # Indexer Configuration
       - INDEXER_START_HEIGHT=${INDEXER_START_HEIGHT:-0}
-    
-    # volumes:
-    #   # DefraDB data
-    #   - /mnt/defradb-data:/app/.defra 
-    #   # Logs
-    #   - /mnt/defradb-data/logs:/app/logs 
-
+      - GOMEMLIMIT=14GiB
+      - SNAPSHOT_ENABLED=false
+      - LOG_LEVEL=error
+      - LOG_SOURCE=false
+      - LOG_STACKTRACE=false
+    logging:
+      options:
+        max-size: "50m"
+        max-file: "3"
+    volumes:
+      - ~/data/defradb:/app/.defra
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -8,9 +8,10 @@ networks:
 
 services:
   shinzo-indexer:
-    image: ghcr.io/shinzonetwork/shinzo-indexer-client:standard
-    user: "0:0"
     container_name: shinzo-indexer
+    platform: linux/amd64
+    image: ghcr.io/shinzonetwork/shinzo-indexer-client:standard
+    user: "1001:1001" # shinzo-indexer identity
     restart: unless-stopped
     networks:
       - shinzo-net
@@ -19,12 +20,12 @@ services:
     ports:
       - "9171:9171"
     volumes:
-      - ~/data/defradb:/app/.defra
-      - ~/data/lens:/app/.defra/lens
+      - ~/shinzo-data/defradb:/app/.defra
     environment:
       - GETH_RPC_URL=https://json-rpc.aouzyll7wj7e9xe4g7t82w88c.blockchainnodeengine.com
       - GETH_WS_URL=wss://ws.aouzyll7wj7e9xe4g7t82w88c.blockchainnodeengine.com
       - GETH_API_KEY=<YOUR_API_KEY_HERE>
+      - GETH_API_KEY_TYPE=x-goog-api-key
       - INDEXER_START_HEIGHT=0
       - DEFRADB_KEYRING_SECRET=pingpong
       - GOMEMLIMIT=14GiB
@@ -36,6 +37,12 @@ services:
       options:
         max-size: "50m"
         max-file: "3"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
   nginx:
     image: nginx:alpine
     ports:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,6 +1,6 @@
 # Use this to deploy to a vm with nginx reverse proxy.
 # This file users the root user 
-# user: "0:0" for docker permissions.
+# user: "1001:1001" [shinzo-indexer] for docker permissions.
 
 networks:
   shinzo-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - GETH_RPC_URL=${GETH_RPC_URL}
       - GETH_WS_URL=${GETH_WS_URL}
       - GETH_API_KEY=${GETH_API_KEY}
+      - GETH_API_KEY_TYPE=${GETH_API_KEY_TYPE}
+
       
       # DefraDB Configuration (embedded)
       - DEFRADB_KEYRING_SECRET=${DEFRADB_KEYRING_SECRET:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,16 @@
 services:
   indexer:
-    image: ghcr.io/shinzonetwork/shinzo-indexer-client:standard
-    platform: linux/amd64
     container_name: shinzo-indexer
+    platform: linux/amd64
+    image: ghcr.io/shinzonetwork/shinzo-indexer-client:standard
+    user: "1001:1001" # shinzo-indexer identity
     restart: unless-stopped
-    network_mode: host
+    networks:
+      - shinzo-net
+    mem_limit: 16g
+    mem_reservation: 13g
+    ports:
+      - "9171:9171"
     environment:
       # Ethereum Node Configuration
       - GETH_RPC_URL=${GETH_RPC_URL}
@@ -12,19 +18,22 @@ services:
       - GETH_API_KEY=${GETH_API_KEY}
       - GETH_API_KEY_TYPE=${GETH_API_KEY_TYPE}
 
-      
       # DefraDB Configuration (embedded)
       - DEFRADB_KEYRING_SECRET=${DEFRADB_KEYRING_SECRET:-}
       
       # Indexer Configuration
       - INDEXER_START_HEIGHT=${INDEXER_START_HEIGHT:-0}
-    
+      - GOMEMLIMIT=14GiB
+      - SNAPSHOT_ENABLED=false
+      - LOG_LEVEL=error
+      - LOG_SOURCE=false
+      - LOG_STACKTRACE=false
+    logging:
+      options:
+        max-size: "50m"
+        max-file: "3"
     volumes:
-      # DefraDB data
-      - /mnt/defradb-data:/app/.defra 
-      # Logs
-      - /mnt/defradb-data/logs:/app/logs 
-
+      - ~/shinzo-data/defradb:/app/.defra
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+networks:
+  shinzo-net:
+    driver: bridge
+
 services:
   indexer:
     container_name: shinzo-indexer

--- a/indexer-prod-setup.sh
+++ b/indexer-prod-setup.sh
@@ -16,8 +16,8 @@ services:
     ports:
       - "9171:9171"
     volumes:
-      - ~/data/defradb:/app/.defra
-      - ~/data/lens:/app/.defra/lens
+      - ~/shinzo-data/defradb:/app/.defra
+      - ~/shinzo-data/lens:/app/.defra/lens
     environment:
       - GETH_RPC_URL=https://json-rpc.che8qim8flet1lfjpapfmtl42.blockchainnodeengine.com
       - GETH_WS_URL=ws://ws.che8qim8flet1lfjpapfmtl42.blockchainnodeengine.com

--- a/indexer-prod.sh
+++ b/indexer-prod.sh
@@ -8,6 +8,6 @@ sudo rm /tmp/nginx.csr
 
 sudo apt-get update &&
 sudo apt-get install -y docker.io docker-compose &&
-sudo mkdir -p ~/data/defradb ~/data/lens &&
-sudo chown -R 0:0 ~/data/defradb ~/data/lens &&
+sudo mkdir -p ~/shinzo-data/defradb ~/shinzo-data/lens &&
+sudo chown -R 1001:1001 ~/shinzo-data/defradb ~/shinzo-data/lens &&
 docker-compose up -d


### PR DESCRIPTION
# Pull Request

## Description
Replaces root user with a dedicated non-root shinzo-indexer user (UID/GID 1001:1001) across the Dockerfile and all compose files. Standardizes service configuration fields across docker-compose.yml, docker-compose-local.yml, and docker-compose-prod.yml to ensure consistency between environments.
Changes:

## Changes
- Added `GETH_API_KEY_TYPE` to the docker-compose files we offer.
- Added shinzo-indexer system user/group with pinned UID/GID 1001:1001 in Dockerfile
- Replaced user: "0:0" with user: "1001:1001" in all compose files
- Added missing networks, ports, logging, healthcheck, and env vars to docker-compose.yml and - docker-compose-local.yml
- Standardized volume paths to ~/shinzo-data/defradb across all environments
- Added healthcheck to docker-compose-prod.yml
- Fixed stale comment referencing root user in docker-compose-prod.yml

## Related Issue
item 4 on #217 
closes https://github.com/shinzonetwork/shinzo-indexer-client/issues/217?issue=shinzonetwork%7Cshinzo-indexer-client%7C224

## Steps to Test
docker-compose up 

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
<!-- Any additional context for reviewers -->
