### PR TITLE
refactor(pruner): improved pruner error handling

### DIFF
--- a/pkg/pruner/pruner.go
+++ b/pkg/pruner/pruner.go
@@ -2,6 +2,7 @@ package pruner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -11,6 +12,19 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/node"
 )
+
+// ErrNoBlocks indicates that the query succeeded but no blocks were found.
+var ErrNoBlocks = errors.New("no blocks found")
+
+// ErrNoValidBlocks indicates that blocks exist in the database but none have
+// a parseable block number field. This is a data-integrity issue, not an
+// empty database — distinct from ErrNoBlocks.
+var ErrNoValidBlocks = errors.New("blocks exist but none have a valid block number")
+
+// ErrNoValidDocs indicates that documents exist in a collection but none have
+// a parseable block number field. This is a data-integrity issue, not an
+// empty result set — distinct from the (nil, nil) "no docs in range" return.
+var ErrNoValidDocs = errors.New("docs exist but none have a valid block number")
 
 // Pruner handles periodic removal of old blockchain documents from DefraDB.
 // It supports two queue types:
@@ -204,6 +218,7 @@ func (p *Pruner) runIndexerQueuePrune(ctx context.Context, q *IndexerQueue) erro
 func (p *Pruner) purgeFromDrainResult(ctx context.Context, result *DrainResult) error {
 	startTime := time.Now()
 	totalPurged := int64(0)
+	var depErrs []error
 
 	// Dependent collections first, block collection last
 	for _, colName := range p.collections.DependentCollections {
@@ -212,19 +227,17 @@ func (p *Pruner) purgeFromDrainResult(ctx context.Context, result *DrainResult) 
 			continue
 		}
 		purged, err := p.purgeByDocIDs(ctx, colName, docIDs)
+		totalPurged += purged
 		if err != nil {
-			logger.Sugar.Errorf("Failed to purge %s: %v", colName, err)
-		} else {
-			totalPurged += purged
+			depErrs = append(depErrs, fmt.Errorf("purge %s: %w", colName, err))
 		}
 	}
 
 	if blockIDs, ok := result.DocIDsByCollection[p.collections.BlockCollection]; ok && len(blockIDs) > 0 {
 		purged, err := p.purgeByDocIDs(ctx, p.collections.BlockCollection, blockIDs)
+		totalPurged += purged
 		if err != nil {
-			logger.Sugar.Errorf("Failed to purge blocks: %v", err)
-		} else {
-			totalPurged += purged
+			return fmt.Errorf("failed to purge blocks: %w", err)
 		}
 	}
 
@@ -238,24 +251,25 @@ func (p *Pruner) purgeFromDrainResult(ctx context.Context, result *DrainResult) 
 	p.lastPruneTime = time.Now()
 	p.mu.Unlock()
 
+	if len(depErrs) > 0 {
+		return fmt.Errorf("dependent collection errors: %w", errors.Join(depErrs...))
+	}
 	return nil
 }
 
 // startupCleanup removes blocks left over from previous runs that aren't in the queue.
 func (p *Pruner) startupCleanup(ctx context.Context) error {
-	lowest, err := p.getLowestBlockNumber(ctx)
+	lowest, highest, err := p.getBlockRange(ctx)
 	if err != nil {
-		return err
-	}
-
-	highest, err := p.getHighestBlockNumber(ctx)
-	if err != nil {
-		return err
-	}
-
-	if lowest == 0 && highest == 0 {
-		logger.Sugar.Debugf("No existing blocks in database")
-		return nil
+		if errors.Is(err, ErrNoBlocks) {
+			logger.Sugar.Debugf("No existing blocks in database")
+			return nil
+		}
+		if errors.Is(err, ErrNoValidBlocks) {
+			logger.Sugar.Warnf("Blocks exist but none have valid block numbers, skipping cleanup")
+			return nil
+		}
+		return fmt.Errorf("startup cleanup: get block range: %w", err)
 	}
 
 	currentCount := highest - lowest + 1
@@ -291,18 +305,16 @@ func (p *Pruner) startupCleanup(ctx context.Context) error {
 // filterBasedPrune checks the actual DB block count and prunes excess blocks.
 // Used by the indexer queue (no P2P) and as a fallback when the queue is underfilled.
 func (p *Pruner) filterBasedPrune(ctx context.Context) error {
-	highest, err := p.getHighestBlockNumber(ctx)
+	lowest, highest, err := p.getBlockRange(ctx)
 	if err != nil {
-		return err
-	}
-
-	lowest, err := p.getLowestBlockNumber(ctx)
-	if err != nil {
-		return err
-	}
-
-	if highest == 0 && lowest == 0 {
-		return nil
+		if errors.Is(err, ErrNoBlocks) {
+			return nil
+		}
+		if errors.Is(err, ErrNoValidBlocks) {
+			logger.Sugar.Warnf("Blocks exist but none have valid block numbers, skipping prune")
+			return nil
+		}
+		return fmt.Errorf("filter-based prune: get block range: %w", err)
 	}
 
 	dbBlockCount := highest - lowest + 1
@@ -335,6 +347,7 @@ func (p *Pruner) filterBasedPrune(ctx context.Context) error {
 // Safe to call with concurrent P2P replication — merge handles missing blocks gracefully.
 func (p *Pruner) pruneBlockRange(ctx context.Context, startBlock, endBlock int64) (int64, error) {
 	totalPurged := int64(0)
+	var depErrs []error
 
 	logger.Sugar.Infof("pruneBlockRange: deleting blocks %d-%d (%d blocks)",
 		startBlock, endBlock, endBlock-startBlock+1)
@@ -343,15 +356,14 @@ func (p *Pruner) pruneBlockRange(ctx context.Context, startBlock, endBlock int64
 	for _, colName := range p.collections.DependentCollections {
 		docIDs, err := p.queryOldestDocIDs(ctx, colName, constants.BlockNumberKeyValue, endBlock)
 		if err != nil {
-			logger.Sugar.Warnf("pruneBlockRange: query failed for %s (skipping): %v", colName, err)
+			depErrs = append(depErrs, fmt.Errorf("query %s: %w", colName, err))
 			continue
 		}
 		if len(docIDs) > 0 {
 			purged, err := p.purgeByDocIDs(ctx, colName, docIDs)
+			totalPurged += purged
 			if err != nil {
-				logger.Sugar.Warnf("pruneBlockRange: failed to purge %s: %v", colName, err)
-			} else {
-				totalPurged += purged
+				depErrs = append(depErrs, fmt.Errorf("purge %s: %w", colName, err))
 			}
 		}
 	}
@@ -362,13 +374,17 @@ func (p *Pruner) pruneBlockRange(ctx context.Context, startBlock, endBlock int64
 	}
 	if len(blockDocIDs) > 0 {
 		purged, err := p.purgeByDocIDs(ctx, p.collections.BlockCollection, blockDocIDs)
+		totalPurged += purged
 		if err != nil {
 			return totalPurged, fmt.Errorf("failed to purge blocks: %w", err)
 		}
-		totalPurged += purged
 	}
 
 	logger.Sugar.Infof("pruneBlockRange: purged %d docs for blocks %d-%d", totalPurged, startBlock, endBlock)
+
+	if len(depErrs) > 0 {
+		return totalPurged, fmt.Errorf("dependent collection errors: %w", errors.Join(depErrs...))
+	}
 	return totalPurged, nil
 }
 
@@ -390,51 +406,88 @@ func (p *Pruner) queryOldestDocIDs(ctx context.Context, collectionName, fieldNam
 		return nil, fmt.Errorf("query failed for %s: %w", collectionName, result.GQL.Errors[0])
 	}
 
+	// Data is nil when the query returns no result set at all (no errors, no data key).
+	if result.GQL.Data == nil {
+		return nil, nil // This is a legitimate empty result, not an error.
+	}
+
 	data, ok := result.GQL.Data.(map[string]any)
 	if !ok {
-		return nil, nil
+		return nil, fmt.Errorf("unexpected GQL data type %T for %s", result.GQL.Data, collectionName)
 	}
 
 	// DefraDB may return []map[string]interface{} or []interface{} depending on context.
 	// In Go these are distinct types, so we must handle both.
-	raw := data[collectionName]
-
-	var docIDs []string
+	raw, ok := data[collectionName]
+	if !ok {
+		return nil, fmt.Errorf("collection %s not found in GQL response", collectionName)
+	}
+	// The collection key exists but maps to nil — DefraDB returns nil for
+	// collections that exist in the schema but contain zero documents.
+	if raw == nil {
+		return nil, nil // This is a legitimate empty result, not an error.
+	}
 
 	switch docs := raw.(type) {
 	case []map[string]any:
-		for _, docMap := range docs {
-			bn, err := parseBlockNumber(docMap[fieldName])
-			if err != nil || bn > maxBlockNumber {
-				break // ordered ASC, so once we exceed maxBlockNumber we're done
-			}
-			if docID, ok := docMap["_docID"].(string); ok {
-				docIDs = append(docIDs, docID)
-			}
-		}
+		return extractDocIDs(docs, fieldName, maxBlockNumber, collectionName)
 	case []any:
+		typed := make([]map[string]any, 0, len(docs))
 		for _, doc := range docs {
 			docMap, ok := doc.(map[string]any)
 			if !ok {
-				continue
+				return nil, fmt.Errorf("unexpected element type %T in %s", doc, collectionName)
 			}
-			bn, err := parseBlockNumber(docMap[fieldName])
-			if err != nil || bn > maxBlockNumber {
-				break
-			}
-			if docID, ok := docMap["_docID"].(string); ok {
-				docIDs = append(docIDs, docID)
-			}
+			typed = append(typed, docMap)
 		}
+		return extractDocIDs(typed, fieldName, maxBlockNumber, collectionName)
 	default:
-		// Unknown format or nil data
-		return nil, nil
+		return nil, fmt.Errorf("unexpected collection result type %T for %s", raw, collectionName)
 	}
+}
 
-	return docIDs, nil //nolint:nilerr
+// extractDocIDs collects docIDs for documents whose block number is within the
+// allowed range. Docs with nil or unparseable block numbers, or non-string
+// _docID fields, are counted and skipped — a single corrupt doc must not
+// prevent pruning of all other valid docs. A single summary warning is logged
+// if any docs were skipped, instead of one log line per corrupt doc.
+//
+// Returns (nil, ErrNoValidDocs) when docs exist but none have a parseable
+// block number — this is a data-integrity issue distinct from "no docs in
+// range", which returns (nil, nil).
+func extractDocIDs(docs []map[string]any, fieldName string, maxBlockNumber int64, collectionName string) ([]string, error) {
+	var docIDs []string
+	skipped := 0
+	parsedAny := false
+	for _, docMap := range docs {
+		blockNumber, err := parseBlockNumber(docMap[fieldName])
+		if err != nil {
+			skipped++
+			continue
+		}
+		parsedAny = true
+		if blockNumber > maxBlockNumber {
+			break
+		}
+		docID, ok := docMap["_docID"].(string)
+		if !ok {
+			skipped++
+			continue
+		}
+		docIDs = append(docIDs, docID)
+	}
+	if skipped > 0 {
+		logger.Sugar.Warnf("Skipped %d doc(s) in %s with missing or unparseable fields", skipped, collectionName)
+	}
+	if len(docs) > 0 && !parsedAny {
+		return nil, fmt.Errorf("%s: %w", collectionName, ErrNoValidDocs)
+	}
+	return docIDs, nil
 }
 
 // purgeByDocIDs deletes documents by their docIDs.
+// Returns the count of successfully purged documents and an error if any
+// docIDs were invalid (skipped) or if the purge operation itself failed.
 func (p *Pruner) purgeByDocIDs(ctx context.Context, collectionName string, docIDs []string) (int64, error) {
 	if len(docIDs) == 0 {
 		return 0, nil
@@ -449,10 +502,12 @@ func (p *Pruner) purgeByDocIDs(ctx context.Context, collectionName string, docID
 	}
 
 	clientDocIDs := make([]client.DocID, 0, len(docIDs))
+	skipped := 0
 	for _, id := range docIDs {
 		docID, err := client.NewDocIDFromString(id)
 		if err != nil {
 			logger.Sugar.Warnf("Skipping invalid docID %s: %v", id, err)
+			skipped++
 			continue
 		}
 		clientDocIDs = append(clientDocIDs, docID)
@@ -465,21 +520,42 @@ func (p *Pruner) purgeByDocIDs(ctx context.Context, collectionName string, docID
 	count := int64(len(clientDocIDs))
 	logger.Sugar.Infof("Purged %d/%d documents from %s in %v",
 		count, len(docIDs), collectionName, time.Since(startTime))
+
+	if skipped > 0 {
+		return count, fmt.Errorf("skipped %d invalid docID(s) out of %d", skipped, len(docIDs))
+	}
 	return count, nil
 }
 
 // ─── Block number queries ────────────────────────────────────────────────────
 
+// getBlockRange returns the lowest and highest block numbers from the database.
+// Returns (0, 0, ErrNoBlocks) if the database has no blocks.
+// Returns (0, 0, ErrNoValidBlocks) if blocks exist but none have parseable numbers.
+// Returns (0, 0, err) for query or type errors.
+// Returns (lowest, highest, nil) when valid block numbers are found.
+func (p *Pruner) getBlockRange(ctx context.Context) (lowest, highest int64, err error) {
+	lowest, err = p.getLowestBlockNumber(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	highest, err = p.getHighestBlockNumber(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	return lowest, highest, nil
+}
+
 func (p *Pruner) getLowestBlockNumber(ctx context.Context) (int64, error) {
 	query := `query {
-		` + p.collections.BlockCollection + ` (order: {` + p.collections.BlockNumberField + `: ASC}, limit: 1) {
+		` + p.collections.BlockCollection + ` (order: {` + p.collections.BlockNumberField + `: ASC}, limit: 7) {
 			` + p.collections.BlockNumberField + `
 		}
 	}`
 
 	result := p.defraNode.DB.ExecRequest(ctx, query)
 	if len(result.GQL.Errors) > 0 {
-		return 0, result.GQL.Errors[0]
+		return 0, fmt.Errorf("lowest block query failed: %w", result.GQL.Errors[0])
 	}
 
 	return p.extractBlockNumber(result.GQL.Data)
@@ -487,51 +563,88 @@ func (p *Pruner) getLowestBlockNumber(ctx context.Context) (int64, error) {
 
 func (p *Pruner) getHighestBlockNumber(ctx context.Context) (int64, error) {
 	query := `query {
-		` + p.collections.BlockCollection + ` (order: {` + p.collections.BlockNumberField + `: DESC}, limit: 1) {
+		` + p.collections.BlockCollection + ` (order: {` + p.collections.BlockNumberField + `: DESC}, limit: 7) {
 			` + p.collections.BlockNumberField + `
 		}
 	}`
 
 	result := p.defraNode.DB.ExecRequest(ctx, query)
 	if len(result.GQL.Errors) > 0 {
-		return 0, result.GQL.Errors[0]
+		return 0, fmt.Errorf("highest block query failed: %w", result.GQL.Errors[0])
 	}
 
 	return p.extractBlockNumber(result.GQL.Data)
 }
 
 func (p *Pruner) extractBlockNumber(gqlData any) (int64, error) {
-	data, ok := gqlData.(map[string]any)
-	if !ok {
-		return 0, nil
+	if gqlData == nil {
+		return 0, ErrNoBlocks
 	}
 
-	blocksRaw := data[p.collections.BlockCollection]
+	data, ok := gqlData.(map[string]any)
+	if !ok {
+		return 0, fmt.Errorf("unexpected GQL data type %T", gqlData)
+	}
+
+	blocksRaw, ok := data[p.collections.BlockCollection]
+	if !ok {
+		return 0, fmt.Errorf("collection %s not found in GQL response", p.collections.BlockCollection)
+	}
 
 	if blocksTyped, ok := blocksRaw.([]map[string]any); ok {
 		if len(blocksTyped) == 0 {
-			return 0, nil
+			return 0, ErrNoBlocks
 		}
-		if number, ok := blocksTyped[0][p.collections.BlockNumberField]; ok {
-			return parseBlockNumber(number)
-		}
-		return 0, nil
+		return p.findFirstValidBlockNumber(blocksTyped)
 	}
 
 	blocks, ok := blocksRaw.([]any)
-	if !ok || len(blocks) == 0 {
-		return 0, nil
-	}
-
-	block, ok := blocks[0].(map[string]any)
 	if !ok {
-		return 0, nil
+		if blocksRaw == nil {
+			return 0, ErrNoBlocks
+		}
+		return 0, fmt.Errorf("unexpected blocks type %T", blocksRaw)
+	}
+	if len(blocks) == 0 {
+		return 0, ErrNoBlocks
 	}
 
-	if number, ok := block[p.collections.BlockNumberField]; ok {
-		return parseBlockNumber(number)
+	typed := make([]map[string]any, 0, len(blocks))
+	for _, block := range blocks {
+		blockMap, ok := block.(map[string]any)
+		if !ok {
+			return 0, fmt.Errorf("unexpected block element type %T", block)
+		}
+		typed = append(typed, blockMap)
 	}
-	return 0, nil
+	return p.findFirstValidBlockNumber(typed)
+}
+
+// findFirstValidBlockNumber iterates through blocks and returns the first valid
+// block number. Blocks with missing or unparseable number fields are counted and
+// skipped — this is not propagated as an error because a single corrupt block
+// (e.g. from P2P replication with a nil number field) must not prevent pruning
+// of all other valid blocks. A single summary warning is logged if any blocks
+// were skipped, instead of one log line per corrupt block.
+func (p *Pruner) findFirstValidBlockNumber(blocks []map[string]any) (int64, error) {
+	skipped := 0
+	for _, block := range blocks {
+		number, ok := block[p.collections.BlockNumberField]
+		if !ok {
+			skipped++
+			continue
+		}
+		blockNumber, err := parseBlockNumber(number)
+		if err != nil {
+			skipped++
+			continue
+		}
+		if skipped > 0 {
+			logger.Sugar.Warnf("Skipped %d block(s) with missing or unparseable number fields", skipped)
+		}
+		return blockNumber, nil
+	}
+	return 0, ErrNoValidBlocks
 }
 
 func parseBlockNumber(number any) (int64, error) {
@@ -543,5 +656,5 @@ func parseBlockNumber(number any) (int64, error) {
 	case int:
 		return int64(v), nil
 	}
-	return 0, nil
+	return 0, fmt.Errorf("unexpected block number type %T", number)
 }

--- a/pkg/pruner/pruner_test.go
+++ b/pkg/pruner/pruner_test.go
@@ -200,21 +200,26 @@ func TestPrunerStop_WithQueue(t *testing.T) {
 
 func TestParseBlockNumber(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    any
-		expected int64
+		name        string
+		input       any
+		expected    int64
+		expectError bool
 	}{
-		{"float64", float64(42), 42},
-		{"int64", int64(100), 100},
-		{"int", int(200), 200},
-		{"string (unknown type)", "300", 0},
-		{"nil", nil, 0},
+		{"float64", float64(42), 42, false},
+		{"int64", int64(100), 100, false},
+		{"int", int(200), 200, false},
+		{"string (unknown type)", "300", 0, true},
+		{"nil", nil, 0, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := parseBlockNumber(tt.input)
-			assert.NoError(t, err)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -225,24 +230,24 @@ func TestExtractBlockNumber(t *testing.T) {
 	cols := DefaultCollectionConfig()
 	p := NewPruner(cfg, nil, cols)
 
-	t.Run("nil data", func(t *testing.T) {
+	t.Run("nil data returns ErrNoBlocks", func(t *testing.T) {
 		result, err := p.extractBlockNumber(nil)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, ErrNoBlocks)
 		assert.Equal(t, int64(0), result)
 	})
 
-	t.Run("wrong type", func(t *testing.T) {
-		result, err := p.extractBlockNumber("not a map")
-		assert.NoError(t, err)
-		assert.Equal(t, int64(0), result)
+	t.Run("wrong type returns error", func(t *testing.T) {
+		_, err := p.extractBlockNumber("not a map")
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNoBlocks)
 	})
 
-	t.Run("empty blocks array ([]interface{})", func(t *testing.T) {
+	t.Run("empty blocks array ([]interface{}) returns ErrNoBlocks", func(t *testing.T) {
 		data := map[string]any{
 			constants.CollectionBlock: []any{},
 		}
 		result, err := p.extractBlockNumber(data)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, ErrNoBlocks)
 		assert.Equal(t, int64(0), result)
 	})
 
@@ -268,55 +273,181 @@ func TestExtractBlockNumber(t *testing.T) {
 		assert.Equal(t, int64(99), result)
 	})
 
-	t.Run("empty typed map array", func(t *testing.T) {
+	t.Run("empty typed map array returns ErrNoBlocks", func(t *testing.T) {
 		data := map[string]any{
 			constants.CollectionBlock: []map[string]any{},
 		}
 		result, err := p.extractBlockNumber(data)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, ErrNoBlocks)
 		assert.Equal(t, int64(0), result)
 	})
 
-	t.Run("typed map array missing number field", func(t *testing.T) {
+	t.Run("typed map array missing number field skips to next valid block", func(t *testing.T) {
 		data := map[string]any{
 			constants.CollectionBlock: []map[string]any{
 				{"other_field": "value"},
+				{constants.NumberFieldValue: float64(42)},
 			},
 		}
 		result, err := p.extractBlockNumber(data)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(0), result)
+		assert.Equal(t, int64(42), result)
 	})
 
-	t.Run("interface array with non-map element", func(t *testing.T) {
+	t.Run("typed map array all blocks missing number field returns error", func(t *testing.T) {
+		data := map[string]any{
+			constants.CollectionBlock: []map[string]any{
+				{"other_field": "value"},
+				{"another_field": 123},
+			},
+		}
+		_, err := p.extractBlockNumber(data)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoValidBlocks)
+	})
+
+	t.Run("block with nil number field skips to next valid block", func(t *testing.T) {
+		data := map[string]any{
+			constants.CollectionBlock: []map[string]any{
+				{constants.NumberFieldValue: nil},
+				{constants.NumberFieldValue: float64(7)},
+			},
+		}
+		result, err := p.extractBlockNumber(data)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(7), result)
+	})
+
+	t.Run("all blocks have nil number field returns error", func(t *testing.T) {
+		data := map[string]any{
+			constants.CollectionBlock: []map[string]any{
+				{constants.NumberFieldValue: nil},
+				{constants.NumberFieldValue: nil},
+			},
+		}
+		_, err := p.extractBlockNumber(data)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoValidBlocks)
+	})
+
+	t.Run("interface array with non-map element returns error", func(t *testing.T) {
 		data := map[string]any{
 			constants.CollectionBlock: []any{
 				"not a map",
 			},
 		}
-		result, err := p.extractBlockNumber(data)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(0), result)
+		_, err := p.extractBlockNumber(data)
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNoBlocks)
 	})
 
-	t.Run("interface array missing number field", func(t *testing.T) {
+	t.Run("interface array missing number field skips to next valid block", func(t *testing.T) {
 		data := map[string]any{
 			constants.CollectionBlock: []any{
 				map[string]any{"other": "value"},
+				map[string]any{constants.NumberFieldValue: float64(55)},
 			},
 		}
 		result, err := p.extractBlockNumber(data)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(0), result)
+		assert.Equal(t, int64(55), result)
 	})
 
-	t.Run("missing block collection key", func(t *testing.T) {
+	t.Run("missing block collection key returns error", func(t *testing.T) {
 		data := map[string]any{
 			"Other_Collection": []any{},
 		}
-		result, err := p.extractBlockNumber(data)
+		_, err := p.extractBlockNumber(data)
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNoBlocks)
+	})
+}
+
+func TestExtractDocIDs(t *testing.T) {
+	t.Run("valid docs within max", func(t *testing.T) {
+		docs := []map[string]any{
+			{"_docID": "bae-aaa", "number": float64(1)},
+			{"_docID": "bae-bbb", "number": float64(2)},
+		}
+		ids, err := extractDocIDs(docs, "number", 10, "TestBlock")
 		assert.NoError(t, err)
-		assert.Equal(t, int64(0), result)
+		assert.Equal(t, []string{"bae-aaa", "bae-bbb"}, ids)
+	})
+
+	t.Run("stops at maxBlockNumber", func(t *testing.T) {
+		docs := []map[string]any{
+			{"_docID": "bae-aaa", "number": float64(1)},
+			{"_docID": "bae-bbb", "number": float64(5)},
+			{"_docID": "bae-ccc", "number": float64(10)},
+		}
+		ids, err := extractDocIDs(docs, "number", 3, "TestBlock")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"bae-aaa"}, ids)
+	})
+
+	t.Run("parse error skips doc and continues", func(t *testing.T) {
+		docs := []map[string]any{
+			{"_docID": "bae-aaa", "number": "not-a-number"},
+			{"_docID": "bae-bbb", "number": float64(2)},
+		}
+		ids, err := extractDocIDs(docs, "number", 10, "TestBlock")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"bae-bbb"}, ids)
+	})
+
+	t.Run("nil block number skips doc and continues", func(t *testing.T) {
+		docs := []map[string]any{
+			{"_docID": "bae-aaa", "number": nil},
+			{"_docID": "bae-bbb", "number": float64(2)},
+		}
+		ids, err := extractDocIDs(docs, "number", 10, "TestBlock")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"bae-bbb"}, ids)
+	})
+
+	t.Run("non-string _docID skips doc and continues", func(t *testing.T) {
+		docs := []map[string]any{
+			{"_docID": 123, "number": float64(1)},
+			{"_docID": "bae-bbb", "number": float64(2)},
+		}
+		ids, err := extractDocIDs(docs, "number", 10, "TestBlock")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"bae-bbb"}, ids)
+	})
+
+	t.Run("empty docs returns nil", func(t *testing.T) {
+		ids, err := extractDocIDs(nil, "number", 10, "TestBlock")
+		assert.NoError(t, err)
+		assert.Nil(t, ids)
+	})
+
+	t.Run("all docs corrupt returns ErrNoValidDocs", func(t *testing.T) {
+		docs := []map[string]any{
+			{"_docID": "bae-aaa", "number": nil},
+			{"_docID": "bae-bbb", "number": "not-a-number"},
+		}
+		ids, err := extractDocIDs(docs, "number", 10, "TestBlock")
+		assert.Nil(t, ids)
+		assert.ErrorIs(t, err, ErrNoValidDocs)
+	})
+
+	t.Run("all docs above range returns nil without error", func(t *testing.T) {
+		docs := []map[string]any{
+			{"_docID": "bae-aaa", "number": float64(100)},
+		}
+		ids, err := extractDocIDs(docs, "number", 10, "TestBlock")
+		assert.NoError(t, err)
+		assert.Nil(t, ids)
+	})
+
+	t.Run("some corrupt, rest above range returns nil without error", func(t *testing.T) {
+		docs := []map[string]any{
+			{"_docID": "bae-aaa", "number": nil},
+			{"_docID": "bae-bbb", "number": float64(100)},
+		}
+		ids, err := extractDocIDs(docs, "number", 10, "TestBlock")
+		assert.NoError(t, err)
+		assert.Nil(t, ids)
 	})
 }
 
@@ -508,11 +639,11 @@ func TestGetLowestAndHighestBlockNumber(t *testing.T) {
 
 	// Empty DB
 	lowest, err := p.getLowestBlockNumber(ctx)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, ErrNoBlocks)
 	assert.Equal(t, int64(0), lowest)
 
 	highest, err := p.getHighestBlockNumber(ctx)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, ErrNoBlocks)
 	assert.Equal(t, int64(0), highest)
 
 	// Insert blocks
@@ -527,6 +658,34 @@ func TestGetLowestAndHighestBlockNumber(t *testing.T) {
 	highest, err = p.getHighestBlockNumber(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(30), highest)
+}
+
+func TestGetBlockRange(t *testing.T) {
+	n := startTestNode(t)
+	cols := testCollections()
+	cfg := &Config{Enabled: true, MaxBlocks: 100}
+	p := NewPruner(cfg, n, cols)
+	ctx := context.Background()
+
+	t.Run("empty database returns ErrNoBlocks", func(t *testing.T) {
+		lowest, highest, err := p.getBlockRange(ctx)
+		assert.ErrorIs(t, err, ErrNoBlocks)
+		assert.Equal(t, int64(0), lowest)
+		assert.Equal(t, int64(0), highest)
+	})
+
+	t.Run("populated database returns valid range", func(t *testing.T) {
+		for _, num := range []int64{10, 30, 20} {
+			mutation := fmt.Sprintf(`mutation { add_TestBlock(input: [{number: %d, hash: "hash%d"}]) { _docID } }`, num, num)
+			result := n.DB.ExecRequest(ctx, mutation)
+			require.Empty(t, result.GQL.Errors, "insert block %d failed: %v", num, result.GQL.Errors)
+		}
+
+		lowest, highest, err := p.getBlockRange(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(10), lowest)
+		assert.Equal(t, int64(30), highest)
+	})
 }
 
 func TestQueryOldestDocIDs(t *testing.T) {
@@ -555,6 +714,33 @@ func TestQueryOldestDocIDs(t *testing.T) {
 	docIDs, err = p.queryOldestDocIDs(ctx, "TestBlock", constants.NumberFieldValue, 100)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(docIDs))
+}
+
+func TestQueryOldestDocIDs_EmptyCollection(t *testing.T) {
+	n := startTestNode(t)
+	cols := testCollections()
+	cfg := &Config{Enabled: true, MaxBlocks: 100}
+	p := NewPruner(cfg, n, cols)
+	ctx := context.Background()
+
+	// TestTx collection exists in schema but has zero documents
+	docIDs, err := p.queryOldestDocIDs(ctx, "TestTx", "blockNumber", 100)
+	assert.NoError(t, err)
+	assert.Nil(t, docIDs)
+}
+
+func TestQueryOldestDocIDs_NonExistentCollection(t *testing.T) {
+	n := startTestNode(t)
+	cols := testCollections()
+	cfg := &Config{Enabled: true, MaxBlocks: 100}
+	p := NewPruner(cfg, n, cols)
+	ctx := context.Background()
+
+	// DefraDB returns a GQL error for unknown collections (caught at the GQL layer).
+	// The comma-ok check in queryOldestDocIDs is a defensive fallback for the case
+	// where DefraDB returns a valid Data map without the collection key.
+	_, err := p.queryOldestDocIDs(ctx, "NonExistent", "number", 100)
+	assert.Error(t, err)
 }
 
 func TestPurgeByDocIDs(t *testing.T) {
@@ -589,6 +775,30 @@ func TestPurgeByDocIDs(t *testing.T) {
 	// Purge with invalid collection name
 	_, err = p.purgeByDocIDs(ctx, "NonExistent", []string{"bae-550e8400-e29b-41d4-a716-446655440000"})
 	assert.Error(t, err)
+}
+
+func TestPurgeByDocIDs_InvalidDocID(t *testing.T) {
+	n := startTestNode(t)
+	cols := testCollections()
+	cfg := &Config{Enabled: true, MaxBlocks: 100, PruneHistory: false}
+	p := NewPruner(cfg, n, cols)
+	ctx := context.Background()
+
+	insertTestBlock(t, n, 1, 0)
+	insertTestBlock(t, n, 2, 0)
+
+	validDocIDs, err := p.queryOldestDocIDs(ctx, "TestBlock", constants.NumberFieldValue, 2)
+	require.NoError(t, err)
+	require.Len(t, validDocIDs, 2)
+
+	// Mix valid and invalid docIDs
+	mixedDocIDs := append([]string{"not-a-valid-docid"}, validDocIDs...)
+
+	purged, err := p.purgeByDocIDs(ctx, "TestBlock", mixedDocIDs)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "skipped 1 invalid docID")
+	assert.Equal(t, int64(2), purged)
+	assert.Equal(t, 0, countDocs(t, n, "TestBlock"))
 }
 
 func TestPruneBlockRange(t *testing.T) {
@@ -749,6 +959,59 @@ func TestPurgeFromDrainResult_EmptyCollections(t *testing.T) {
 
 	err := p.purgeFromDrainResult(ctx, drainResult)
 	assert.NoError(t, err)
+}
+
+func TestPurgeFromDrainResult_PurgeError(t *testing.T) {
+	t.Run("dependent_collection_error_propagates", func(t *testing.T) {
+		n := startTestNode(t)
+		cols := testCollections()
+		cfg := &Config{Enabled: true, MaxBlocks: 100, PruneHistory: false}
+		p := NewPruner(cfg, n, cols)
+		ctx := context.Background()
+
+		insertTestBlock(t, n, 1, 1)
+
+		blockDocIDs, err := p.queryOldestDocIDs(ctx, "TestBlock", constants.NumberFieldValue, 1)
+		require.NoError(t, err)
+		require.Len(t, blockDocIDs, 1)
+
+		drainResult := &DrainResult{
+			DocIDsByCollection: map[string][]string{
+				"TestBlock": blockDocIDs,
+				"TestTx":    {"not-a-valid-docid"},
+			},
+			BlockCount: 1,
+		}
+
+		err = p.purgeFromDrainResult(ctx, drainResult)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "dependent collection errors")
+		assert.Contains(t, err.Error(), "purge TestTx")
+		assert.Equal(t, int64(1), p.totalBlocksPruned)
+		assert.False(t, p.lastPruneTime.IsZero())
+	})
+
+	t.Run("block_collection_error_is_fatal", func(t *testing.T) {
+		n := startTestNode(t)
+		cols := testCollections()
+		cfg := &Config{Enabled: true, MaxBlocks: 100, PruneHistory: false}
+		p := NewPruner(cfg, n, cols)
+		ctx := context.Background()
+
+		drainResult := &DrainResult{
+			DocIDsByCollection: map[string][]string{
+				"TestBlock": {"not-a-valid-docid"},
+			},
+			BlockCount: 1,
+		}
+
+		err := p.purgeFromDrainResult(ctx, drainResult)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to purge blocks")
+		assert.NotContains(t, err.Error(), "dependent collection errors")
+		assert.Equal(t, int64(0), p.totalBlocksPruned)
+		assert.True(t, p.lastPruneTime.IsZero())
+	})
 }
 
 func TestRunIndexerQueuePrune_WithRealNode(t *testing.T) {


### PR DESCRIPTION
# Pull Request

## Description
This PR refactors error handling in `pkg/pruner/pruner.go` to cleanly separate three distinct conditions that were previously conflated or silently ignored: (1) the database/collection is empty, (2) data exists but all records have unparseable block numbers (data integrity issue), and (3) query or type errors (structural failures).

## Changes
- Block queries limit: 1 → 7 
- `findFirstValidBlockNumber` skips corrupt blocks, logs one summary `WARN`, returns `ErrNoValidBlocks` if all corrupt.
- `extractBlockNumber` - iterates instead of first-only; distinguishes `ErrNoBlocks` (empty) vs `ErrNoValidBlocks` (all corrupt) vs error (bad types).
- new helper `extractDocIDs` - skips bad docs, returns `ErrNoValidDocs` when all corrupt, `(nil, nil)` when none in range.
- `queryOldestDocIDs` - missing collection key → error (was conflated with nil/empty)
-  GQL errors wrapped with context.
- new helper `getBlockRange` 
-  `startupCleanup` and `filterBasedPrune` branch on sentinel: `ErrNoBlocks`→debug+skip, `ErrNoValidBlocks`→warn+skip, other→propagate.
- `purgeByDocIDs` / `pruneBlockRange` / `purgeFromDrainResult `- invalid `docIDs` counted + returned as error. Dependent errors joined via `errors.Join`, block errors fatal. Metrics always updated.
- `parseBlockNumber` - returns error for unknown types including `nil` (was `(0, nil)`).

## Related Issue
<!-- Link to the issue this PR addresses, if any -->

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Verify core functionality works as expected (e.g., main page loads, API responds)

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
<!-- Any additional context for reviewers -->
