### PR TITLE
fixes bug 304 - hardcoded testnet url

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,7 @@ func (d *DefraDBConfig) Host() string {
 type ChainConfig struct {
 	Name    string `yaml:"name"`    // e.g. "Ethereum", "Arbitrum", "Optimism", "Avalanche"
 	Network string `yaml:"network"` // e.g. "Mainnet", "Testnet"
+	Hub     string `yaml:"hub"`     // ShinzoHub hostname only — no scheme, no port (e.g. "testnet.shinzo.network")
 }
 
 // GethConfig represents Geth node configuration.
@@ -282,6 +283,9 @@ func applyChainEnvOverrides(cfg *Config) {
 	}
 	if chainNetwork := os.Getenv("CHAIN_NETWORK"); chainNetwork != "" {
 		cfg.Chain.Network = chainNetwork
+	}
+	if shinzoHubHost := os.Getenv("SHINZOHUB_REST_BASE"); shinzoHubHost != "" {
+		cfg.Chain.Hub = shinzoHubHost
 	}
 	if gethRPCURL := os.Getenv("GETH_RPC_URL"); gethRPCURL != "" {
 		cfg.Geth.NodeURL = gethRPCURL

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,7 +6,7 @@
 chain:
   name: "Ethereum"       # Chain name (env: CHAIN_NAME)
   network: "Mainnet"     # Network name (env: CHAIN_NETWORK)
-
+  hub: "testnet.shinzo.network"
 defradb:
   url: "http://localhost:9181"  # Empty = embedded DefraDB
   keyring_secret: "" # over written by env var

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -323,43 +323,8 @@ func newSchemaAuthenticator(cfg *config.Config) (server.Authenticator, error) {
 // initServices starts the health server, pruner, and snapshotter if configured.
 func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, blockHandler *defra.BlockHandler) error {
 	if cfg.Indexer.HealthServerPort > 0 {
-		var healthDefraURL string
-		if cfg.DefraDB.URL != "" {
-			healthDefraURL = cfg.DefraDB.URL
-		} else if i.defraNode != nil {
-			healthDefraURL = fmt.Sprintf("http://localhost:%d", defra.GetPort(i.defraNode))
-		}
-		i.healthServer = server.NewHealthServer(cfg.Indexer.HealthServerPort, i, healthDefraURL)
-		if i.defraNode != nil {
-			i.healthServer.SetDefraNode(i.defraNode)
-		}
-		if cfg.Chain.Hub != "" {
-			i.healthServer.SetShinzoHubRESTBase(server.ShinzoHubAPIURL(cfg.Chain.Hub, server.ShinzoHubProtoAPIPort))
-		}
-
-		auth, err := newSchemaAuthenticator(cfg)
-		if err != nil {
+		if err := i.initHealthServer(cfg); err != nil {
 			return err
-		}
-		prefix := chainPrefixFromConfig(cfg)
-		sdl, err := schema.GetSchemaForChain(prefix)
-		if err != nil {
-			return fmt.Errorf("load schema for chain %s: %w", prefix, err)
-		}
-		if err := i.healthServer.EnableSchemaEndpoint(sdl, prefix, auth); err != nil {
-			return fmt.Errorf("enable schema endpoint: %w", err)
-		}
-		go func() {
-			if err := i.healthServer.Start(); err != nil {
-				logger.Sugar.Errorf("Health server failed: %v", err)
-			}
-		}()
-		if cfg.Indexer.OpenBrowserOnStart {
-			go func() {
-				time.Sleep(ShortDelayTime)
-				openBrowser(fmt.Sprintf("http://localhost:%d/health", cfg.Indexer.HealthServerPort))
-				logger.Sugar.Infof("Opened health page in browser")
-			}()
 		}
 	}
 
@@ -387,6 +352,49 @@ func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, blo
 		}
 	}
 
+	return nil
+}
+
+// initHealthServer creates and starts the health server with schema and hub endpoints configured.
+func (i *ChainIndexer) initHealthServer(cfg *config.Config) error {
+	var healthDefraURL string
+	if cfg.DefraDB.URL != "" {
+		healthDefraURL = cfg.DefraDB.URL
+	} else if i.defraNode != nil {
+		healthDefraURL = fmt.Sprintf("http://localhost:%d", defra.GetPort(i.defraNode))
+	}
+	i.healthServer = server.NewHealthServer(cfg.Indexer.HealthServerPort, i, healthDefraURL)
+	if i.defraNode != nil {
+		i.healthServer.SetDefraNode(i.defraNode)
+	}
+	if cfg.Chain.Hub != "" {
+		i.healthServer.SetShinzoHubRESTBase(server.ShinzoHubAPIURL(cfg.Chain.Hub, server.ShinzoHubProtoAPIPort))
+	}
+
+	auth, err := newSchemaAuthenticator(cfg)
+	if err != nil {
+		return err
+	}
+	prefix := chainPrefixFromConfig(cfg)
+	sdl, err := schema.GetSchemaForChain(prefix)
+	if err != nil {
+		return fmt.Errorf("load schema for chain %s: %w", prefix, err)
+	}
+	if err := i.healthServer.EnableSchemaEndpoint(sdl, prefix, auth); err != nil {
+		return fmt.Errorf("enable schema endpoint: %w", err)
+	}
+	go func() {
+		if err := i.healthServer.Start(); err != nil {
+			logger.Sugar.Errorf("Health server failed: %v", err)
+		}
+	}()
+	if cfg.Indexer.OpenBrowserOnStart {
+		go func() {
+			time.Sleep(ShortDelayTime)
+			openBrowser(fmt.Sprintf("http://localhost:%d/health", cfg.Indexer.HealthServerPort))
+			logger.Sugar.Infof("Opened health page in browser")
+		}()
+	}
 	return nil
 }
 

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -333,6 +333,9 @@ func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, blo
 		if i.defraNode != nil {
 			i.healthServer.SetDefraNode(i.defraNode)
 		}
+		if cfg.Chain.Hub != "" {
+			i.healthServer.SetShinzoHubRESTBase(server.ShinzoHubAPIURL(cfg.Chain.Hub, server.ShinzoHubProtoAPIPort))
+		}
 
 		auth, err := newSchemaAuthenticator(cfg)
 		if err != nil {

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -41,7 +41,22 @@ const (
 
 	// DefraDBCheckTimeout is the timeout for checking DefraDB connectivity.
 	DefraDBCheckTimeout = 5 * time.Second
+
+	// ShinzoHubProtoAPIPort is the port for the ShinzoHub Cosmos LCD / protobuf REST API.
+	ShinzoHubProtoAPIPort = 1317
+
+	// ShinzoHubCosmosAPIPort is the port for the ShinzoHub Cosmos RPC API.
+	ShinzoHubCosmosAPIPort = 25567
 )
+
+// ShinzoHubAPIURL builds a full base URL from a hostname and port.
+// Returns an empty string when hostname is empty so callers can skip hub queries gracefully.
+func ShinzoHubAPIURL(hostname string, port int) string {
+	if hostname == "" {
+		return ""
+	}
+	return fmt.Sprintf("http://%s:%d", hostname, port)
+}
 
 // HealthServer provides HTTP endpoints for health checks and metrics.
 type HealthServer struct {
@@ -54,6 +69,7 @@ type HealthServer struct {
 	startTime            time.Time
 	healthStatusPagePath string
 	querySnapshotSigsFn  func(ctx context.Context, n *node.Node) (map[string]*snapshot.SnapshotSignatureData, error)
+	shinzoHubRESTBase    string // full base URL injected into the health page template, e.g. "http://testnet.shinzo.network:1317"
 }
 
 // HealthChecker interface for checking indexer health.
@@ -144,6 +160,13 @@ func (hs *HealthServer) SetSnapshotter(s *snapshot.Snapshotter) {
 func (hs *HealthServer) SetDefraNode(n *node.Node) {
 	hs.defraNode = n
 	hs.mux.HandleFunc("/snapshots/import", hs.snapshotImportHandler)
+}
+
+// SetShinzoHubRESTBase sets the ShinzoHub REST base URL injected into the health status page.
+// url should be the full base URL including scheme and port, e.g. "http://testnet.shinzo.network:1317".
+// Use shinzoHubAPIURL to build it from a hostname config value.
+func (hs *HealthServer) SetShinzoHubRESTBase(url string) {
+	hs.shinzoHubRESTBase = url
 }
 
 // Start starts the health server.
@@ -487,11 +510,16 @@ func normalizeHex(s string) string {
 	return "0x" + s
 }
 
-// getHealthStatusPageHTML reads the HTML file from disk at runtime, falling back to embedded version.
-// This allows hot-reloading during development without rebuilding.
+// getHealthStatusPageHTML reads the HTML template and renders it with runtime config values.
 func (hs *HealthServer) getHealthStatusPageHTML() []byte {
-	// Try to read from disk first (for development hot-reload).
-	// Check multiple possible paths relative to where the binary might be running.
+	raw := hs.loadHealthStatusPageTemplate()
+	rendered := strings.ReplaceAll(string(raw), "{{SHINZOHUB_REST_BASE}}", hs.shinzoHubRESTBase)
+	return []byte(rendered)
+}
+
+// loadHealthStatusPageTemplate reads the raw HTML template from disk at runtime, falling back to
+// the embedded version. Disk reads allow hot-reloading during development without rebuilding.
+func (hs *HealthServer) loadHealthStatusPageTemplate() []byte {
 	possiblePaths := []string{
 		hs.healthStatusPagePath,
 		filepath.Join(".", "health_status_page.html"),
@@ -504,7 +532,6 @@ func (hs *HealthServer) getHealthStatusPageHTML() []byte {
 		}
 	}
 
-	// Fallback to embedded version (for production or if file not found).
 	logger.Sugar.Debug("Using embedded health status page")
 	return []byte(embeddedHealthStatusPageHTML)
 }

--- a/pkg/server/health_status_page.html
+++ b/pkg/server/health_status_page.html
@@ -366,7 +366,7 @@
     </div>
 
     <script>
-        const SHINZOHUB_REST_BASE = 'http://testnet.shinzo.network:1317';
+        const SHINZOHUB_REST_BASE = '{{SHINZOHUB_REST_BASE}}';
         let refreshInterval;
 
         function formatNumber(num) {


### PR DESCRIPTION

# Pull Request

## Description
Removes hardcoded testnet url from html page. Testnet URL is now a config value, ports are now constants decided at the time of use.

## Changes
- removes hardcoded value from binary
- adds config for testnet url
- adds const for ports

## Related Issue
#304 

## Steps to Test
go test ./... 

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
chore: update hardcoded testnet to a config value.
chore: removed port from url and made a constant which is determined on the use of the url
