### PR TITLE
feat: chain abstraction adapter selection through config and GetDocIDsByBlockRange implementation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,9 @@ import (
 // CollectionName is the legacy collection name for the shinzo network.
 const CollectionName = "shinzo"
 
+// DefaultChainAdapter is the default and currently only supported chain adapter type.
+const DefaultChainAdapter = "evm"
+
 // DefraDBP2PConfig represents P2P configuration for DefraDB.
 type DefraDBP2PConfig struct {
 	BootstrapPeers      []string `yaml:"bootstrap_peers"`
@@ -58,11 +61,12 @@ func (d *DefraDBConfig) Host() string {
 	return d.URL
 }
 
-// ChainConfig represents the EVM chain being indexed.
+// ChainConfig represents the chain being indexed.
 type ChainConfig struct {
 	Name    string `yaml:"name"`    // e.g. "Ethereum", "Arbitrum", "Optimism", "Avalanche"
 	Network string `yaml:"network"` // e.g. "Mainnet", "Testnet"
 	Hub     string `yaml:"hub"`     // ShinzoHub hostname only — no scheme, no port (e.g. "testnet.shinzo.network")
+	Adapter string `yaml:"adapter"` // chain adapter: DefaultChainAdapter (default). Future: "cosmos", etc. (env: CHAIN_ADAPTER)
 }
 
 // GethConfig represents Geth node configuration.
@@ -150,6 +154,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Chain.Network == "" {
 		cfg.Chain.Network = "Mainnet"
 	}
+	if cfg.Chain.Adapter == "" {
+		cfg.Chain.Adapter = DefaultChainAdapter
+	}
 	if cfg.Indexer.ConcurrentBlocks <= 0 {
 		cfg.Indexer.ConcurrentBlocks = 8
 	}
@@ -179,6 +186,10 @@ func applyDefaults(cfg *Config) {
 
 // validateConfig validates the configuration.
 func validateConfig(cfg *Config) error {
+	if cfg.Chain.Adapter != DefaultChainAdapter {
+		return fmt.Errorf("chain adapter %q not yet implemented: only %q is supported", cfg.Chain.Adapter, DefaultChainAdapter)
+	}
+
 	if cfg.Indexer.StartHeight < 0 {
 		return fmt.Errorf("start_height must be >= 0")
 	}
@@ -286,6 +297,9 @@ func applyChainEnvOverrides(cfg *Config) {
 	}
 	if shinzoHubHost := os.Getenv("SHINZOHUB_REST_BASE"); shinzoHubHost != "" {
 		cfg.Chain.Hub = shinzoHubHost
+	}
+	if chainAdapter := os.Getenv("CHAIN_ADAPTER"); chainAdapter != "" {
+		cfg.Chain.Adapter = chainAdapter
 	}
 	if gethRPCURL := os.Getenv("GETH_RPC_URL"); gethRPCURL != "" {
 		cfg.Geth.NodeURL = gethRPCURL

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,7 @@
 chain:
   name: "Ethereum"       # Chain name (env: CHAIN_NAME)
   network: "Mainnet"     # Network name (env: CHAIN_NETWORK)
+  adapter: "evm"         # Chain adapter: "evm" (default). Future: "cosmos", etc. (env: CHAIN_ADAPTER)
   hub: "testnet.shinzo.network"
 defradb:
   url: "http://localhost:9181"  # Empty = embedded DefraDB

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -143,6 +143,7 @@ func TestValidateConfig_NegativeStartHeight(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{}
 	cfg.DefraDB.Embedded = true
+	cfg.Chain.Adapter = DefaultChainAdapter
 	cfg.Indexer.StartHeight = -1
 
 	err := validateConfig(cfg)
@@ -153,6 +154,7 @@ func TestValidateConfig_NegativeStartHeight(t *testing.T) {
 func TestValidateConfig_ExternalEmptyUrl(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{}
+	cfg.Chain.Adapter = DefaultChainAdapter
 	cfg.DefraDB.Embedded = false
 	cfg.DefraDB.URL = ""
 
@@ -164,6 +166,7 @@ func TestValidateConfig_Valid(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{}
 	cfg.DefraDB.Embedded = true
+	cfg.Chain.Adapter = DefaultChainAdapter
 	cfg.Indexer.StartHeight = 0
 	cfg.Indexer.SchemaAuthMode = constants.SchemaAuthModeToken
 
@@ -490,6 +493,7 @@ func TestValidateConfig_AuthModes(t *testing.T) {
 			t.Parallel()
 			cfg := &Config{}
 			cfg.DefraDB.Embedded = true
+			cfg.Chain.Adapter = DefaultChainAdapter
 			cfg.Indexer.SchemaAuthMode = tt.mode
 			err := validateConfig(cfg)
 			if tt.shouldError {
@@ -500,4 +504,110 @@ func TestValidateConfig_AuthModes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChainAdapter_DefaultEVM(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{}
+	applyDefaults(cfg)
+	assert.Equal(t, DefaultChainAdapter, cfg.Chain.Adapter, "Chain.Adapter should default to evm")
+}
+
+func TestChainAdapter_EnvOverride(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string
+		want   string
+	}{
+		{"evm", DefaultChainAdapter, DefaultChainAdapter},
+		{"cosmos", "cosmos", "cosmos"},
+		{"custom", "solana", "solana"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{}
+			t.Setenv("CHAIN_ADAPTER", tt.envVal)
+			applyChainEnvOverrides(cfg)
+			assert.Equal(t, tt.want, cfg.Chain.Adapter, "Chain.Adapter")
+		})
+	}
+}
+
+func TestChainAdapter_EnvOverrideEmptyIgnored(t *testing.T) {
+	cfg := &Config{}
+	cfg.Chain.Adapter = DefaultChainAdapter
+	t.Setenv("CHAIN_ADAPTER", "")
+	applyChainEnvOverrides(cfg)
+	assert.Equal(t, DefaultChainAdapter, cfg.Chain.Adapter, "empty CHAIN_ADAPTER should not override")
+}
+
+func TestValidateConfig_InvalidChainAdapter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		chainAdapter string
+		shouldError  bool
+		errContains  string
+	}{
+		{"evm valid", DefaultChainAdapter, false, ""},
+		{"cosmos rejected", "cosmos", true, "not yet implemented"},
+		{"solana rejected", "solana", true, "not yet implemented"},
+		{"empty rejected", "", true, "not yet implemented"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{}
+			cfg.DefraDB.Embedded = true
+			cfg.Chain.Adapter = tt.chainAdapter
+			cfg.Indexer.SchemaAuthMode = constants.SchemaAuthModeToken
+			err := validateConfig(cfg)
+			if tt.shouldError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_DefaultChainAdapter(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+
+	configContent := `
+defradb:
+  embedded: true
+indexer:
+  start_height: 0
+`
+
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+
+	cfg, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultChainAdapter, cfg.Chain.Adapter, "Chain.Adapter should default to evm")
+}
+
+func TestLoadConfig_InvalidChainAdapter(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+
+	configContent := `
+chain:
+  adapter: "cosmos"
+defradb:
+  embedded: true
+indexer:
+  start_height: 0
+`
+
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+
+	_, err := LoadConfig(configPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not yet implemented")
 }

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -61,7 +61,6 @@ type Chain interface {
 	// The returned map is keyed by collection name. SnapshotSignature docIDs are
 	// intentionally excluded (the snapshotter owns those); BlockSignature
 	// docIDs are included.
-	// TODO: Implement For EVM Adapter
 	GetDocIDsByBlockRange(ctx context.Context, from, to int64) (map[string][]string, error)
 
 	// GetSchema returns the GraphQL SDL for the configured chain, with

--- a/pkg/chain/evm_adapter.go
+++ b/pkg/chain/evm_adapter.go
@@ -369,19 +369,18 @@ func (a *EVMAdapter) GetLowestStoredBlockNumber(ctx context.Context) (int64, err
 	return a.blockHandler.GetLowestBlockNumber(ctx)
 }
 
-// GetDocIDsByBlockRange implements Chain. SnapshotSignature is excluded;
-// BlockSignature is included.
+// GetDocIDsByBlockRange implements Chain. It returns document IDs for every
+// collection whose block-number field falls in [from, to] inclusive.
+// SnapshotSignature is excluded; BlockSignature is included.
 //
-// NOTE: This method is a stub pending a DefraDB query mechanism that supports
-// range filters (the initial _gte/_lte GQL approach is not supported by
-// DefraDB). It will be implemented in a later step once the query strategy is
-// resolved (e.g. per-block _eq queries, document scans, or a DefraDB API
-// enhancement).
-func (a *EVMAdapter) GetDocIDsByBlockRange(_ context.Context, _, _ int64) (map[string][]string, error) {
+// Delegates to BlockHandler, which uses chunked _geq/_leq GraphQL range
+// filters on the indexer's local DefraDB instance — the same approach the
+// snapshotter uses (pkg/snapshot/kv_snapshot.go).
+func (a *EVMAdapter) GetDocIDsByBlockRange(ctx context.Context, from, to int64) (map[string][]string, error) {
 	if a.blockHandler == nil {
 		return nil, ErrAdapterNotInitialized
 	}
-	return nil, fmt.Errorf("not yet implemented")
+	return a.blockHandler.GetDocIDsByBlockRange(ctx, from, to)
 }
 
 // GetSchema implements Chain.
@@ -402,5 +401,3 @@ func (a *EVMAdapter) SetDocIDTracker(tracker defra.DocIDTrackerInterface) {
 		a.blockHandler.SetDocIDTracker(tracker)
 	}
 }
-
-// TODO: Implement GetDocIDsByBlockRange For EVM Adapter

--- a/pkg/chain/evm_adapter_test.go
+++ b/pkg/chain/evm_adapter_test.go
@@ -269,7 +269,7 @@ func TestEVMAdapter_FetchHighestBlockNumber(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// GetHighest/GetLowestStoredBlockNumber delegation (to BlockHandler)
+// GetHighest/GetLowestStoredBlockNumber/GetDocIDsByBlockRange delegation (to BlockHandler)
 // ---------------------------------------------------------------------------
 
 func TestEVMAdapter_StoredBlockNumberDelegation(t *testing.T) {
@@ -305,6 +305,15 @@ func TestEVMAdapter_StoredBlockNumberDelegation(t *testing.T) {
 	lowest, err := a.GetLowestStoredBlockNumber(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int64(100), lowest)
+
+	// GetDocIDsByBlockRange delegates to BlockHandler and returns the stored
+	// Block document for block 100. fakeBlock has no transactions, so only the
+	// Block collection is populated. No identity context means no BlockSignature.
+	docIDs, err := a.GetDocIDsByBlockRange(context.Background(), 100, 100)
+	require.NoError(t, err)
+	assert.Contains(t, docIDs, "Ethereum__Mainnet__Block")
+	assert.Len(t, docIDs["Ethereum__Mainnet__Block"], 1)
+	assert.NotContains(t, docIDs, "Ethereum__Mainnet__SnapshotSignature")
 
 	// Tip still delegates to the fake client.
 	tip, err := a.FetchHighestBlockNumber(context.Background())

--- a/pkg/defra/block_handler.go
+++ b/pkg/defra/block_handler.go
@@ -784,27 +784,26 @@ func (h *BlockHandler) CreateBlockSignatureForExistingBlock(
 // collectExistingBlockDocIDs queries the DB for all docIDs associated with the given block number.
 func (h *BlockHandler) collectExistingBlockDocIDs(ctx context.Context, blockNumber int64) ([]string, error) {
 	var allDocIDs []string
-	blockNumStr := strconv.FormatInt(blockNumber, 10)
 
-	blockDocIDs, err := h.queryDocIDsByBlockNumber(ctx, h.collections.Block, "number", blockNumStr)
+	blockDocIDs, err := h.queryCollectionDocIDs(ctx, h.collections.Block, constants.NumberFieldValue, blockNumber, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("query block docIDs: %w", err)
 	}
 	allDocIDs = append(allDocIDs, blockDocIDs...)
 
-	txDocIDs, err := h.queryDocIDsByBlockNumber(ctx, h.collections.Transaction, "blockNumber", blockNumStr)
+	txDocIDs, err := h.queryCollectionDocIDs(ctx, h.collections.Transaction, constants.BlockNumberKeyValue, blockNumber, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("query tx docIDs: %w", err)
 	}
 	allDocIDs = append(allDocIDs, txDocIDs...)
 
-	logDocIDs, err := h.queryDocIDsByBlockNumber(ctx, h.collections.Log, "blockNumber", blockNumStr)
+	logDocIDs, err := h.queryCollectionDocIDs(ctx, h.collections.Log, constants.BlockNumberKeyValue, blockNumber, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("query log docIDs: %w", err)
 	}
 	allDocIDs = append(allDocIDs, logDocIDs...)
 
-	aleDocIDs, err := h.queryDocIDsByBlockNumber(ctx, h.collections.AccessListEntry, "blockNumber", blockNumStr)
+	aleDocIDs, err := h.queryCollectionDocIDs(ctx, h.collections.AccessListEntry, constants.BlockNumberKeyValue, blockNumber, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("query ale docIDs: %w", err)
 	}
@@ -813,35 +812,98 @@ func (h *BlockHandler) collectExistingBlockDocIDs(ctx context.Context, blockNumb
 	return allDocIDs, nil
 }
 
-// queryDocIDsByBlockNumber queries a collection for docIDs filtered by a block number field.
-func (h *BlockHandler) queryDocIDsByBlockNumber(ctx context.Context, colName, filterField, value string) ([]string, error) {
-	query := `query { ` + colName + `(filter: {` + filterField + `: {_eq: ` + value + `}}) { _docID } }`
-	result := h.db.ExecRequest(ctx, query)
-	if len(result.GQL.Errors) > 0 {
-		return nil, result.GQL.Errors[0]
+// GetDocIDsByBlockRange queries all relevant collections for document IDs
+// whose block-number field falls in [from, to] inclusive. Returns docIDs
+// grouped by collection name. SnapshotSignature is excluded; BlockSignature
+// is included.
+//
+// Queries use chunked _geq/_leq GraphQL range filters, matching the
+// snapshotter's approach (pkg/snapshot/kv_snapshot.go). This works on
+// locally-indexed data; P2P-replicated data may require a different
+// strategy (see pruner).
+func (h *BlockHandler) GetDocIDsByBlockRange(ctx context.Context, from, to int64) (map[string][]string, error) {
+	collections := []struct {
+		name  string
+		field string
+	}{
+		{h.collections.Block, constants.NumberFieldValue},
+		{h.collections.Transaction, constants.BlockNumberKeyValue},
+		{h.collections.Log, constants.BlockNumberKeyValue},
+		{h.collections.AccessListEntry, constants.BlockNumberKeyValue},
+		{h.collections.BlockSignature, constants.BlockNumberKeyValue},
 	}
-	data, ok := result.GQL.Data.(map[string]any)
-	if !ok {
-		return nil, nil
+
+	result := make(map[string][]string)
+	for _, col := range collections {
+		docIDs, err := h.queryCollectionDocIDs(ctx, col.name, col.field, from, to)
+		if err != nil {
+			return nil, fmt.Errorf("query docIDs for %s: %w", col.name, err)
+		}
+		if len(docIDs) > 0 {
+			result[col.name] = docIDs
+		}
 	}
-	var docIDs []string
-	switch results := data[colName].(type) {
-	case []any:
-		for _, r := range results {
-			if m, ok := r.(map[string]any); ok {
-				if id, ok := m["_docID"].(string); ok {
-					docIDs = append(docIDs, id)
-				}
+	return result, nil
+}
+
+// queryCollectionDocIDs queries a single collection for all document IDs
+// whose block-number field falls in [from, to] inclusive. It uses chunked
+// _geq/_leq GraphQL range filters, matching the snapshotter's queryDocIDs
+// pattern. When from == to, a single _geq/_leq query is issued (equivalent
+// to _eq).
+func (h *BlockHandler) queryCollectionDocIDs(ctx context.Context, colName, field string, from, to int64) ([]string, error) {
+	var allDocIDs []string
+	const chunkSize = 100
+
+	for chunkStart := from; chunkStart <= to; chunkStart += chunkSize {
+		chunkEnd := chunkStart + chunkSize - 1
+		chunkEnd = min(chunkEnd, to)
+
+		query := fmt.Sprintf(
+			`query { %s(filter: {%s: {_geq: %d, _leq: %d}}) { _docID } }`,
+			colName, field, chunkStart, chunkEnd,
+		)
+
+		result := h.db.ExecRequest(ctx, query)
+		if len(result.GQL.Errors) > 0 {
+			return nil, fmt.Errorf("query %s [%d-%d]: %w", colName, chunkStart, chunkEnd, result.GQL.Errors[0])
+		}
+
+		data, ok := result.GQL.Data.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		raw := data[colName]
+		if raw == nil {
+			continue
+		}
+
+		var docs []any
+		switch typed := raw.(type) {
+		case []any:
+			docs = typed
+		case []map[string]any:
+			docs = make([]any, len(typed))
+			for i, d := range typed {
+				docs[i] = d
+			}
+		default:
+			continue
+		}
+
+		for _, doc := range docs {
+			m, ok := doc.(map[string]any)
+			if !ok {
+				continue
+			}
+			if docID, ok := m["_docID"].(string); ok {
+				allDocIDs = append(allDocIDs, docID)
 			}
 		}
-	case []map[string]any:
-		for _, m := range results {
-			if id, ok := m["_docID"].(string); ok {
-				docIDs = append(docIDs, id)
-			}
-		}
 	}
-	return docIDs, nil
+
+	return allDocIDs, nil
 }
 
 // waitForCIDs collects the CIDs for allDocIDs, retrying while they are still arriving (P2P data

--- a/pkg/defra/block_handler_defra_test.go
+++ b/pkg/defra/block_handler_defra_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"math/big"
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
@@ -1145,4 +1146,136 @@ func TestGetHighestBlockNumber_ThreeBlocksDescOrder(t *testing.T) {
 	highest, err := handler.GetHighestBlockNumber(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int64(3600), highest)
+}
+
+// ---------------------------------------------------------------------------
+// GetDocIDsByBlockRange
+// ---------------------------------------------------------------------------
+
+func TestGetDocIDsByBlockRange(t *testing.T) {
+	t.Parallel()
+
+	type blockSeed struct {
+		num     int64
+		txCount int
+	}
+
+	type collectionExpect struct {
+		name  string
+		count int
+	}
+
+	hexNum := func(n int64) string {
+		return "0x" + big.NewInt(n).Text(16)
+	}
+
+	cases := []struct {
+		name        string
+		seeds       []blockSeed
+		from        int64
+		to          int64
+		expects     []collectionExpect
+		expectEmpty bool
+	}{
+		{
+			name:        "EmptyStore",
+			from:        100,
+			to:          200,
+			expectEmpty: true,
+		},
+		{
+			name:  "SingleBlockWithTx",
+			seeds: []blockSeed{{100, 2}},
+			from:  100,
+			to:    100,
+			expects: []collectionExpect{
+				{"Ethereum__Mainnet__Block", 1},
+				{"Ethereum__Mainnet__Transaction", 2},
+				{"Ethereum__Mainnet__Log", 2},
+				{"Ethereum__Mainnet__AccessListEntry", 2},
+				{"Ethereum__Mainnet__BlockSignature", 1},
+			},
+		},
+		{
+			name:  "MultiBlockFullRange",
+			seeds: []blockSeed{{100, 0}, {101, 0}, {102, 0}},
+			from:  100,
+			to:    102,
+			expects: []collectionExpect{
+				{"Ethereum__Mainnet__Block", 3},
+				{"Ethereum__Mainnet__BlockSignature", 3},
+			},
+		},
+		{
+			name:  "MultiBlockSingleBlockRange",
+			seeds: []blockSeed{{100, 0}, {101, 0}, {102, 0}},
+			from:  100,
+			to:    100,
+			expects: []collectionExpect{
+				{"Ethereum__Mainnet__Block", 1},
+				{"Ethereum__Mainnet__BlockSignature", 1},
+			},
+		},
+		{
+			name:        "EmptyRangeNoMatch",
+			seeds:       []blockSeed{{100, 0}, {101, 0}, {102, 0}},
+			from:        200,
+			to:          300,
+			expectEmpty: true,
+		},
+		{
+			name:  "PartialRange",
+			seeds: []blockSeed{{100, 0}, {101, 0}, {102, 0}, {103, 0}, {104, 0}, {105, 0}},
+			from:  102,
+			to:    103,
+			expects: []collectionExpect{
+				{"Ethereum__Mainnet__Block", 2},
+				{"Ethereum__Mainnet__BlockSignature", 2},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			td := testutils.SetupTestDefraDB(t)
+			handler, err := NewBlockHandler(td.Node, 1000, nil)
+			require.NoError(t, err)
+
+			ctx := ctxWithIdentity(t)
+
+			for _, s := range tc.seeds {
+				block := mockBlock(hexNum(s.num))
+				var txs []*types.Transaction
+				var receipts []*types.TransactionReceipt
+				for i := range s.txCount {
+					txHash := deterministicHash("tx-" + big.NewInt(s.num).String() + "-" + big.NewInt(int64(i)).String())
+					tx := mockTransaction(txHash, big.NewInt(s.num).String())
+					tx.AccessList = []types.AccessListEntry{{
+						Address:     "0x0000000000000000000000000000000000000010",
+						StorageKeys: []string{"0x0000000000000000000000000000000000000000000000000000000000000001"},
+					}}
+					txs = append(txs, tx)
+					receipts = append(receipts, mockReceipt(txHash, hexNum(s.num)))
+				}
+				_, err := handler.CreateBlockBatch(ctx, block, txs, receipts)
+				require.NoError(t, err)
+			}
+
+			result, err := handler.GetDocIDsByBlockRange(ctx, tc.from, tc.to)
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+
+			if tc.expectEmpty {
+				assert.Empty(t, result)
+				return
+			}
+
+			for _, exp := range tc.expects {
+				assert.Contains(t, result, exp.name)
+				assert.Len(t, result[exp.name], exp.count, "collection %s", exp.name)
+			}
+			assert.NotContains(t, result, "Ethereum__Mainnet__SnapshotSignature")
+		})
+	}
 }


### PR DESCRIPTION
# Pull Request

## Description
This PR introduces adapter config option and implementation of `GetDocIDByBlockRange`.

## Changes
- New `adapter` config parameter defaulting to `evm` used to select the adapter that it will be used.
- Implementation of `GetDocIDByBlockRange`.

## Related Issue
#132 

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Verify core functionality works as expected (e.g., main page loads, API responds)

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
<!-- Any additional context for reviewers -->
