### PR TITLE
feat(indexer): chain-agnostic indexer wiring

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -19,6 +19,9 @@ package chain
 import (
 	"context"
 	stderrors "errors"
+
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/defra"
+	"github.com/sourcenetwork/defradb/node"
 )
 
 // ErrAdapterNotInitialized is returned by methods that require a DefraDB-backed
@@ -72,4 +75,27 @@ type Chain interface {
 	// GetCollections returns the names of all collections for the configured
 	// chain in dependency-safe order.
 	GetCollections() []string
+}
+
+// Adapter extends Chain with the lifecycle methods needed only by the indexer
+// orchestrator. Pruner, snapshotter, and the concurrent block processor depend
+// solely on Chain — their interfaces stay narrow per the Interface Segregation
+// Principle.
+//
+// *EVMAdapter satisfies Adapter via structural typing.
+type Adapter interface {
+	Chain
+
+	// Init connects to the chain RPC endpoint and prepares the adapter for
+	// block processing. Must be called exactly once after DefraDB is started
+	// and before any fetch/store methods are invoked.
+	Init(ctx context.Context, node *node.Node) error
+
+	// Close releases the adapter's RPC connection and background resources.
+	// Safe to call multiple times.
+	Close() error
+
+	// SetDocIDTracker wires the pruner's DocIDTracker so the adapter can
+	// enqueue docIDs for pruning as blocks are stored.
+	SetDocIDTracker(tracker defra.DocIDTrackerInterface)
 }

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -36,12 +36,14 @@ type Chain interface {
 	// FetchAndStoreBlock fetches the block and its receipts at the given height
 	// from the chain and persists them via the configured BlockHandler.
 	//
-	// When the block already exists in DefraDB a background signing job is
-	// enqueued and the method returns nil.
+	// It returns the DefraDB docID of the newly created block document. When the
+	// block already exists in DefraDB a background signing job is enqueued, the
+	// method returns nil, and the returned docID is empty (no new document was
+	// created).
 	//
 	// When the block is not yet available on chain the returned error matches
 	// errors.IsErrNotFound so the caller (e.g. the block processor) can retry.
-	FetchAndStoreBlock(ctx context.Context, height int64) error
+	FetchAndStoreBlock(ctx context.Context, height int64) (string, error)
 
 	// FetchHighestBlockNumber returns the latest block number known to the
 	// chain (the on-chain tip), querying the RPC endpoint directly.

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	stderrors "errors"
 
+	"github.com/shinzonetwork/shinzo-generator-client/config"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/defra"
 	"github.com/sourcenetwork/defradb/node"
 )
@@ -98,4 +99,22 @@ type Adapter interface {
 	// SetDocIDTracker wires the pruner's DocIDTracker so the adapter can
 	// enqueue docIDs for pruning as blocks are stored.
 	SetDocIDTracker(tracker defra.DocIDTrackerInterface)
+}
+
+// NewAdapter constructs the chain adapter for the configured chain backend.
+//
+// In Phase 1 the only implementation is the EVM adapter, so this function
+// delegates to NewEVMAdapter unconditionally — no runtime dispatch on
+// cfg.Chain.Adapter. The config value stays validation-only (config.go
+// rejects unknowns); the binary itself determines which chain package is
+// linked, not the config string.
+//
+// pkg/indexer calls this instead of NewEVMAdapter directly so the indexer
+// names only the chain-agnostic Adapter interface and this factory — never
+// an EVM-specific constructor symbol. When a second chain package arrives
+// (Phase 2 per-chain binaries), this default returns to per-chain packages
+// and the indexer receives its factory via constructor injection; the
+// indexer stays untouched.
+func NewAdapter(cfg *config.Config) (Adapter, error) {
+	return NewEVMAdapter(cfg)
 }

--- a/pkg/chain/evm_adapter.go
+++ b/pkg/chain/evm_adapter.go
@@ -201,13 +201,13 @@ func (a *EVMAdapter) Close() error {
 }
 
 // FetchAndStoreBlock implements Chain.
-func (a *EVMAdapter) FetchAndStoreBlock(ctx context.Context, height int64) error {
+func (a *EVMAdapter) FetchAndStoreBlock(ctx context.Context, height int64) (string, error) {
 	if a.blockHandler == nil {
-		return ErrAdapterNotInitialized
+		return "", ErrAdapterNotInitialized
 	}
 	block, err := a.fetchBlockWithRetry(ctx, height)
 	if err != nil {
-		return err
+		return "", err
 	}
 	transactions, receipts := a.fetchTransactionsAndReceipts(ctx, block, height)
 	return a.createBlockBatchWithRetry(ctx, block, height, transactions, receipts)
@@ -303,15 +303,15 @@ func (a *EVMAdapter) fetchTransactionsAndReceipts(ctx context.Context, block *ty
 // createBlockBatchWithRetry persists the block batch via the BlockHandler. When
 // the block already exists a signing job is enqueued and nil is returned.
 // Transaction conflicts are retried up to maxRPCRetries times.
-func (a *EVMAdapter) createBlockBatchWithRetry(ctx context.Context, block *types.Block, blockNum int64, transactions []*types.Transaction, receipts []*types.TransactionReceipt) error {
+func (a *EVMAdapter) createBlockBatchWithRetry(ctx context.Context, block *types.Block, blockNum int64, transactions []*types.Transaction, receipts []*types.TransactionReceipt) (string, error) {
 	for attempt := range maxRPCRetries {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return "", ctx.Err()
 		}
 
-		_, err := a.blockHandler.CreateBlockBatch(ctx, block, transactions, receipts)
+		blockID, err := a.blockHandler.CreateBlockBatch(ctx, block, transactions, receipts)
 		if err == nil {
-			return nil
+			return blockID, nil
 		}
 
 		if errors.IsErrAlreadyExists(err) {
@@ -326,22 +326,22 @@ func (a *EVMAdapter) createBlockBatchWithRetry(ctx context.Context, block *types
 			default:
 				logger.Sugar.Warnf("Block %d: signing queue full, skipping block signature", blockNum)
 			}
-			return nil
+			return "", nil
 		}
 
 		if errors.IsErrTransactionConflict(err) && attempt < maxRPCRetries-1 {
 			logger.Sugar.Infof("Block %d transaction conflict, retrying (attempt %d/%d)", blockNum, attempt+1, maxRPCRetries)
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return "", ctx.Err()
 			case <-time.After(time.Duration(attempt+1) * transactionConflictRetryBaseDelay):
 			}
 			continue
 		}
 
-		return fmt.Errorf("failed to create block batch: %w", err)
+		return "", fmt.Errorf("failed to create block batch: %w", err)
 	}
-	return nil
+	return "", nil
 }
 
 // FetchHighestBlockNumber implements Chain.

--- a/pkg/chain/evm_adapter_test.go
+++ b/pkg/chain/evm_adapter_test.go
@@ -126,7 +126,8 @@ func TestEVMAdapter_PreInitGuard(t *testing.T) {
 			return err
 		}},
 		{"FetchAndStoreBlock", func() error {
-			return a.FetchAndStoreBlock(ctx, 1)
+			_, err := a.FetchAndStoreBlock(ctx, 1)
+			return err
 		}},
 	}
 
@@ -213,7 +214,8 @@ func TestEVMAdapter_StoredBlockNumberDelegation(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 
 	// Persist block 100 via the adapter.
-	require.NoError(t, a.FetchAndStoreBlock(context.Background(), 100))
+	_, err = a.FetchAndStoreBlock(context.Background(), 100)
+	require.NoError(t, err)
 
 	highest, err := a.GetHighestStoredBlockNumber(context.Background())
 	require.NoError(t, err)
@@ -295,7 +297,8 @@ func TestEVMAdapter_FetchAndStoreBlock(t *testing.T) {
 			require.NoError(t, a.Init(context.Background(), td.Node))
 
 			for range tc.calls {
-				require.NoError(t, a.FetchAndStoreBlock(context.Background(), tc.blockNum))
+				_, err := a.FetchAndStoreBlock(context.Background(), tc.blockNum)
+				require.NoError(t, err)
 			}
 
 			highest, err := a.GetHighestStoredBlockNumber(context.Background())
@@ -370,7 +373,8 @@ func TestEVMAdapter_ReceiptFallback(t *testing.T) {
 			t.Cleanup(func() { _ = a.Close() })
 			require.NoError(t, a.Init(context.Background(), td.Node))
 
-			require.NoError(t, a.FetchAndStoreBlock(context.Background(), tc.blockNum))
+			_, err := a.FetchAndStoreBlock(context.Background(), tc.blockNum)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -432,7 +436,7 @@ func TestEVMAdapter_ReceiptFallback_ContextCancelTiming(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
 
-			err := a.FetchAndStoreBlock(ctx, tc.blockNum)
+			_, err := a.FetchAndStoreBlock(ctx, tc.blockNum)
 			t.Logf("FetchAndStoreBlock error: %v", err)
 		})
 	}
@@ -472,7 +476,8 @@ func TestEVMAdapter_ReceiptFallback_ContextCancelDuringSemaphoreWait(t *testing.
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- a.FetchAndStoreBlock(ctx, 0xddd0)
+		_, err := a.FetchAndStoreBlock(ctx, 0xddd0)
+		errCh <- err
 	}()
 
 	select {
@@ -509,13 +514,14 @@ func TestEVMAdapter_FetchAndStoreBlock_ContextCancelDuringBatch(t *testing.T) {
 	require.NoError(t, a.Init(context.Background(), td.Node))
 
 	// First call: block persists.
-	require.NoError(t, a.FetchAndStoreBlock(context.Background(), 0xdead))
+	_, err := a.FetchAndStoreBlock(context.Background(), 0xdead)
+	require.NoError(t, err)
 
 	// Second call with pre-canceled ctx — either already-exists or ctx error.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := a.FetchAndStoreBlock(ctx, 0xdead)
+	_, err = a.FetchAndStoreBlock(ctx, 0xdead)
 	if err != nil {
 		assert.Error(t, err)
 	}

--- a/pkg/chain/evm_adapter_test.go
+++ b/pkg/chain/evm_adapter_test.go
@@ -2,11 +2,11 @@ package chain
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	stderrors "errors"
+	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,89 +17,6 @@ import (
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/testutils"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/types"
 )
-
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-func testConfig() *config.Config {
-	return &config.Config{
-		Chain: config.ChainConfig{
-			Name:    "Ethereum",
-			Network: "Mainnet",
-		},
-		Geth: config.GethConfig{},
-		Indexer: config.IndexerConfig{
-			MaxDocsPerTxn:      1000,
-			MaxTxDocsPerBatch:  100,
-			MaxLogDocsPerBatch: 100,
-			MaxALEDocsPerBatch: 100,
-			ReceiptWorkers:     8,
-		},
-	}
-}
-
-func fakeHash(seed string) string {
-	h := sha256.Sum256([]byte(seed))
-	return "0x" + hex.EncodeToString(h[:])
-}
-
-func fakeBlock(num int64) *types.Block {
-	return &types.Block{
-		Hash:             fakeHash("block-" + big.NewInt(num).String()),
-		Number:           "0x" + big.NewInt(num).Text(16),
-		Timestamp:        "1640995200",
-		ParentHash:       "0x0000000000000000000000000000000000000000000000000000000000000000",
-		Difficulty:       "1000000",
-		TotalDifficulty:  "1000000",
-		GasUsed:          "21000",
-		GasLimit:         "8000000",
-		Nonce:            "0x0",
-		Miner:            "0x0000000000000000000000000000000000000001",
-		Size:             "1024",
-		StateRoot:        "0x0000000000000000000000000000000000000000000000000000000000000001",
-		Sha3Uncles:       "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-		TransactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-		ReceiptsRoot:     "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-		LogsBloom:        "0x00",
-		ExtraData:        "0x",
-		MixHash:          "0x0000000000000000000000000000000000000000000000000000000000000000",
-	}
-}
-
-// fakeRPCClient is a lightweight in-memory rpcClient for testing delegation.
-type fakeRPCClient struct {
-	latestNum     *big.Int
-	latestErr     error
-	block         *types.Block
-	blockErr      error
-	batchReceipts []*types.TransactionReceipt
-	batchErr      error
-	txReceipt     *types.TransactionReceipt
-	txErr         error
-	closed        bool
-}
-
-func (f *fakeRPCClient) GetLatestBlockNumber(_ context.Context) (*big.Int, error) {
-	return f.latestNum, f.latestErr
-}
-
-func (f *fakeRPCClient) GetBlockByNumber(_ context.Context, _ *big.Int) (*types.Block, error) {
-	return f.block, f.blockErr
-}
-
-func (f *fakeRPCClient) GetBlockReceipts(_ context.Context, _ *big.Int) ([]*types.TransactionReceipt, error) {
-	return f.batchReceipts, f.batchErr
-}
-
-func (f *fakeRPCClient) GetTransactionReceipt(_ context.Context, _ string) (*types.TransactionReceipt, error) {
-	return f.txReceipt, f.txErr
-}
-
-func (f *fakeRPCClient) Close() error {
-	f.closed = true
-	return nil
-}
 
 // ---------------------------------------------------------------------------
 // Construction
@@ -319,6 +236,289 @@ func TestEVMAdapter_StoredBlockNumberDelegation(t *testing.T) {
 	tip, err := a.FetchHighestBlockNumber(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int64(100), tip)
+}
+
+// ---------------------------------------------------------------------------
+// FetchAndStoreBlock: persistence, duplicate, batch receipts
+// ---------------------------------------------------------------------------
+
+func TestEVMAdapter_FetchAndStoreBlock(t *testing.T) {
+	t.Parallel()
+
+	txHash := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	cases := []struct {
+		name          string
+		blockNum      int64
+		txs           []types.Transaction
+		batchReceipts []*types.TransactionReceipt
+		calls         int
+	}{
+		{
+			name:          "NoTx_Success",
+			blockNum:      500,
+			batchReceipts: []*types.TransactionReceipt{},
+			calls:         1,
+		},
+		{
+			name:          "DuplicateBlock",
+			blockNum:      700,
+			batchReceipts: []*types.TransactionReceipt{},
+			calls:         2,
+		},
+		{
+			name:          "WithTxAndBatchReceipts",
+			blockNum:      0xbbb0,
+			txs:           []types.Transaction{fakeTx(txHash)},
+			batchReceipts: []*types.TransactionReceipt{fakeReceipt(txHash, 0xbbb0)},
+			calls:         1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			td := testutils.SetupTestDefraDB(t)
+			cfg := testConfig()
+
+			block := fakeBlock(tc.blockNum)
+			if len(tc.txs) > 0 {
+				block = fakeBlockWithTxs(tc.blockNum, tc.txs...)
+			}
+
+			client := &fakeRPCClient{
+				block:         block,
+				batchReceipts: tc.batchReceipts,
+			}
+			a := newEVMAdapter(cfg, client)
+			t.Cleanup(func() { _ = a.Close() })
+			require.NoError(t, a.Init(context.Background(), td.Node))
+
+			for range tc.calls {
+				require.NoError(t, a.FetchAndStoreBlock(context.Background(), tc.blockNum))
+			}
+
+			highest, err := a.GetHighestStoredBlockNumber(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, tc.blockNum, highest)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Receipt fallback (batch fails → individual GetTransactionReceipt)
+// ---------------------------------------------------------------------------
+
+func TestEVMAdapter_ReceiptFallback(t *testing.T) {
+	t.Parallel()
+
+	txHash := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	cases := []struct {
+		name        string
+		blockNum    int64
+		txs         []types.Transaction
+		txReceiptFn func(_ context.Context, _ string) (*types.TransactionReceipt, error)
+	}{
+		{
+			name:     "NoTxns",
+			blockNum: 100000,
+		},
+		{
+			name:     "IndividualSuccess",
+			blockNum: 100000,
+			txs:      []types.Transaction{fakeTx(txHash)},
+			txReceiptFn: func(_ context.Context, _ string) (*types.TransactionReceipt, error) {
+				return fakeReceipt(txHash, 100000), nil
+			},
+		},
+		{
+			name:     "IndividualFail",
+			blockNum: 100001,
+			txs:      []types.Transaction{fakeTx(txHash)},
+			txReceiptFn: func(_ context.Context, _ string) (*types.TransactionReceipt, error) {
+				return nil, fmt.Errorf("receipt not available")
+			},
+		},
+		{
+			name:     "IndividualReceiptSuccess",
+			blockNum: 0xccc0,
+			txs:      []types.Transaction{fakeTx(txHash)},
+			txReceiptFn: func(_ context.Context, _ string) (*types.TransactionReceipt, error) {
+				return fakeReceipt(txHash, 0xccc0), nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			td := testutils.SetupTestDefraDB(t)
+			cfg := testConfig()
+
+			block := fakeBlock(tc.blockNum)
+			if len(tc.txs) > 0 {
+				block = fakeBlockWithTxs(tc.blockNum, tc.txs...)
+			}
+
+			client := &fakeRPCClient{
+				block:       block,
+				batchErr:    fmt.Errorf("eth_getBlockReceipts not supported"),
+				txReceiptFn: tc.txReceiptFn,
+			}
+			a := newEVMAdapter(cfg, client)
+			t.Cleanup(func() { _ = a.Close() })
+			require.NoError(t, a.Init(context.Background(), td.Node))
+
+			require.NoError(t, a.FetchAndStoreBlock(context.Background(), tc.blockNum))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Context cancellation during receipt fetch
+// ---------------------------------------------------------------------------
+
+func TestEVMAdapter_ReceiptFallback_ContextCancelTiming(t *testing.T) {
+	t.Parallel()
+
+	txHash := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	cases := []struct {
+		name        string
+		blockNum    int64
+		txSleep     time.Duration
+		ctxTimeout  time.Duration
+		returnError bool
+	}{
+		{
+			name:        "ContextCancel",
+			blockNum:    100002,
+			txSleep:     2 * time.Second,
+			ctxTimeout:  500 * time.Millisecond,
+			returnError: true,
+		},
+		{
+			name:        "ContextCancelDuringFetch",
+			blockNum:    1000,
+			txSleep:     500 * time.Millisecond,
+			ctxTimeout:  200 * time.Millisecond,
+			returnError: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			td := testutils.SetupTestDefraDB(t)
+			cfg := testConfig()
+
+			block := fakeBlockWithTxs(tc.blockNum, fakeTx(txHash))
+			client := &fakeRPCClient{
+				block:    block,
+				batchErr: fmt.Errorf("not supported"),
+				txReceiptFn: func(_ context.Context, _ string) (*types.TransactionReceipt, error) {
+					time.Sleep(tc.txSleep)
+					if tc.returnError {
+						return nil, fmt.Errorf("timeout")
+					}
+					return fakeReceipt(txHash, tc.blockNum), nil
+				},
+			}
+			a := newEVMAdapter(cfg, client)
+			t.Cleanup(func() { _ = a.Close() })
+			require.NoError(t, a.Init(context.Background(), td.Node))
+
+			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
+			defer cancel()
+
+			err := a.FetchAndStoreBlock(ctx, tc.blockNum)
+			t.Logf("FetchAndStoreBlock error: %v", err)
+		})
+	}
+}
+
+func TestEVMAdapter_ReceiptFallback_ContextCancelDuringSemaphoreWait(t *testing.T) {
+	t.Parallel()
+	td := testutils.SetupTestDefraDB(t)
+	cfg := testConfig()
+	cfg.Indexer.ReceiptWorkers = 1
+
+	txs := make([]types.Transaction, 3)
+	for i := range 3 {
+		txs[i] = fakeTx(fmt.Sprintf("0x%064x", i+1))
+	}
+	block := fakeBlockWithTxs(0xddd0, txs...)
+
+	firstReceiptCalled := make(chan struct{})
+	client := &fakeRPCClient{
+		block:    block,
+		batchErr: fmt.Errorf("not supported"),
+		txReceiptFn: func(_ context.Context, _ string) (*types.TransactionReceipt, error) {
+			select {
+			case firstReceiptCalled <- struct{}{}:
+			default:
+			}
+			time.Sleep(5 * time.Second)
+			return nil, fmt.Errorf("timeout")
+		},
+	}
+	a := newEVMAdapter(cfg, client)
+	t.Cleanup(func() { _ = a.Close() })
+	require.NoError(t, a.Init(context.Background(), td.Node))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- a.FetchAndStoreBlock(ctx, 0xddd0)
+	}()
+
+	select {
+	case <-firstReceiptCalled:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for first receipt call")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		t.Logf("FetchAndStoreBlock error: %v", err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for FetchAndStoreBlock to complete")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Context cancellation during batch creation
+// ---------------------------------------------------------------------------
+
+func TestEVMAdapter_FetchAndStoreBlock_ContextCancelDuringBatch(t *testing.T) {
+	t.Parallel()
+	td := testutils.SetupTestDefraDB(t)
+	cfg := testConfig()
+	client := &fakeRPCClient{
+		block:         fakeBlock(0xdead),
+		batchReceipts: []*types.TransactionReceipt{},
+	}
+	a := newEVMAdapter(cfg, client)
+	t.Cleanup(func() { _ = a.Close() })
+	require.NoError(t, a.Init(context.Background(), td.Node))
+
+	// First call: block persists.
+	require.NoError(t, a.FetchAndStoreBlock(context.Background(), 0xdead))
+
+	// Second call with pre-canceled ctx — either already-exists or ctx error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := a.FetchAndStoreBlock(ctx, 0xdead)
+	if err != nil {
+		assert.Error(t, err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/chain/helpers_test.go
+++ b/pkg/chain/helpers_test.go
@@ -1,0 +1,140 @@
+package chain
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"math/big"
+
+	"github.com/shinzonetwork/shinzo-generator-client/config"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/types"
+)
+
+func testConfig() *config.Config {
+	return &config.Config{
+		Chain: config.ChainConfig{
+			Name:    "Ethereum",
+			Network: "Mainnet",
+		},
+		Geth: config.GethConfig{},
+		Indexer: config.IndexerConfig{
+			MaxDocsPerTxn:      1000,
+			MaxTxDocsPerBatch:  100,
+			MaxLogDocsPerBatch: 100,
+			MaxALEDocsPerBatch: 100,
+			ReceiptWorkers:     8,
+		},
+	}
+}
+
+func fakeHash(seed string) string {
+	h := sha256.Sum256([]byte(seed))
+	return "0x" + hex.EncodeToString(h[:])
+}
+
+func fakeBlock(num int64) *types.Block {
+	return &types.Block{
+		Hash:             fakeHash("block-" + big.NewInt(num).String()),
+		Number:           "0x" + big.NewInt(num).Text(16),
+		Timestamp:        "1640995200",
+		ParentHash:       "0x0000000000000000000000000000000000000000000000000000000000000000",
+		Difficulty:       "1000000",
+		TotalDifficulty:  "1000000",
+		GasUsed:          "21000",
+		GasLimit:         "8000000",
+		Nonce:            "0x0",
+		Miner:            "0x0000000000000000000000000000000000000001",
+		Size:             "1024",
+		StateRoot:        "0x0000000000000000000000000000000000000000000000000000000000000001",
+		Sha3Uncles:       "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		TransactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+		ReceiptsRoot:     "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+		LogsBloom:        "0x00",
+		ExtraData:        "0x",
+		MixHash:          "0x0000000000000000000000000000000000000000000000000000000000000000",
+	}
+}
+
+func fakeTx(hash string) types.Transaction {
+	return types.Transaction{
+		Hash:      hash,
+		BlockHash: "0x0000000000000000000000000000000000000000000000000000000000000001",
+		From:      "0x0000000000000000000000000000000000000001",
+		To:        "0x0000000000000000000000000000000000000002",
+		Value:     "0x3e8",
+		Gas:       "0x5208",
+		GasPrice:  "0x3b9aca00",
+		Input:     "0x",
+		Nonce:     "0x0",
+		Type:      "0x0",
+		V:         "0x1b",
+		R:         "0x1111111111111111111111111111111111111111111111111111111111111111",
+		S:         "0x2222222222222222222222222222222222222222222222222222222222222222",
+	}
+}
+
+func fakeBlockWithTxs(num int64, txs ...types.Transaction) *types.Block {
+	b := fakeBlock(num)
+	b.Transactions = txs
+	return b
+}
+
+func fakeReceipt(txHash string, blockNum int64) *types.TransactionReceipt {
+	return &types.TransactionReceipt{
+		TransactionHash:   txHash,
+		TransactionIndex:  "0x0",
+		BlockHash:         "0x0000000000000000000000000000000000000000000000000000000000000001",
+		BlockNumber:       "0x" + big.NewInt(blockNum).Text(16),
+		From:              "0x0000000000000000000000000000000000000001",
+		To:                "0x0000000000000000000000000000000000000002",
+		CumulativeGasUsed: "0x5208",
+		GasUsed:           "0x5208",
+		Status:            "0x1",
+	}
+}
+
+type fakeRPCClient struct {
+	latestNum     *big.Int
+	latestErr     error
+	block         *types.Block
+	blockErr      error
+	batchReceipts []*types.TransactionReceipt
+	batchErr      error
+	txReceipt     *types.TransactionReceipt
+	txErr         error
+	closed        bool
+
+	blockFn     func(ctx context.Context, n *big.Int) (*types.Block, error)
+	batchFn     func(ctx context.Context, n *big.Int) ([]*types.TransactionReceipt, error)
+	txReceiptFn func(ctx context.Context, hash string) (*types.TransactionReceipt, error)
+}
+
+func (f *fakeRPCClient) GetLatestBlockNumber(_ context.Context) (*big.Int, error) {
+	return f.latestNum, f.latestErr
+}
+
+func (f *fakeRPCClient) GetBlockByNumber(ctx context.Context, n *big.Int) (*types.Block, error) {
+	if f.blockFn != nil {
+		return f.blockFn(ctx, n)
+	}
+	return f.block, f.blockErr
+}
+
+func (f *fakeRPCClient) GetBlockReceipts(ctx context.Context, n *big.Int) ([]*types.TransactionReceipt, error) {
+	if f.batchFn != nil {
+		return f.batchFn(ctx, n)
+	}
+	return f.batchReceipts, f.batchErr
+}
+
+func (f *fakeRPCClient) GetTransactionReceipt(ctx context.Context, hash string) (*types.TransactionReceipt, error) {
+	if f.txReceiptFn != nil {
+		return f.txReceiptFn(ctx, hash)
+	}
+	return f.txReceipt, f.txErr
+}
+
+func (f *fakeRPCClient) Close() error {
+	f.closed = true
+	return nil
+}

--- a/pkg/indexer/concurrent_processor.go
+++ b/pkg/indexer/concurrent_processor.go
@@ -3,15 +3,12 @@ package indexer
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"sync"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/defra"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/chain"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/errors"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/logger"
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/rpc"
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/types"
 )
 
 const (
@@ -23,12 +20,6 @@ const (
 
 	// MaxRPCRetries is the maximum number of retries for non-"not found" RPC errors.
 	MaxRPCRetries = 3
-
-	// TransactionConflictRetryBaseDelay is the base delay for retrying transaction conflicts.
-	TransactionConflictRetryBaseDelay = 50 * time.Millisecond
-
-	// SigningQueueSize is the buffer size for the background block signing channel.
-	SigningQueueSize = 64
 
 	// DispatchThrottleDelay is the delay when the processor is too far ahead of committed blocks.
 	DispatchThrottleDelay = 100 * time.Millisecond
@@ -42,46 +33,29 @@ type BlockResult struct {
 	Error    error
 }
 
-// signingJob holds the data needed to sign an existing block in the background.
-type signingJob struct {
-	blockNum     int64
-	blockHash    string
-	block        *types.Block
-	transactions []*types.Transaction
-	receipts     []*types.TransactionReceipt
-}
-
 // ConcurrentBlockProcessor processes multiple blocks concurrently.
 type ConcurrentBlockProcessor struct {
-	blockHandler    *defra.BlockHandler
-	ethClient       *rpc.EthereumClient
+	chain           chain.Chain
 	workers         int
-	receiptWorkers  int
 	blocksPerMinute int
 	resultChan      chan *BlockResult
 	pendingMu       sync.Mutex
 	pending         map[int64]*BlockResult
 	nextToCommit    int64
-	signingChan     chan signingJob
 }
 
 // NewConcurrentBlockProcessor creates a new concurrent processor.
 func NewConcurrentBlockProcessor(
-	blockHandler *defra.BlockHandler,
-	ethClient *rpc.EthereumClient,
+	chain chain.Chain,
 	workers int,
-	receiptWorkers int,
 	blocksPerMinute int,
 ) *ConcurrentBlockProcessor {
 	return &ConcurrentBlockProcessor{
-		blockHandler:    blockHandler,
-		ethClient:       ethClient,
+		chain:           chain,
 		workers:         workers,
-		receiptWorkers:  receiptWorkers,
 		blocksPerMinute: blocksPerMinute,
 		resultChan:      make(chan *BlockResult, workers*DefaultWorkersAhead),
 		pending:         make(map[int64]*BlockResult),
-		signingChan:     make(chan signingJob, SigningQueueSize),
 	}
 }
 
@@ -93,36 +67,20 @@ func (p *ConcurrentBlockProcessor) ProcessBlocks(
 ) error {
 	p.nextToCommit = startBlock
 
-	workChan, wg, collectWg, signingWg := p.startWorkers(ctx, onBlockProcessed)
+	workChan, wg, collectWg := p.startWorkers(ctx, onBlockProcessed)
 
 	shutdown := func() {
 		close(workChan)
 		wg.Wait()
 		close(p.resultChan)
 		collectWg.Wait()
-		close(p.signingChan)
-		signingWg.Wait()
 	}
 
 	return p.dispatchLoop(ctx, startBlock, workChan, shutdown)
 }
 
-// startWorkers launches signing, processing, and result-collection goroutines.
-func (p *ConcurrentBlockProcessor) startWorkers(ctx context.Context, onBlockProcessed func(blockNum int64)) (chan int64, *sync.WaitGroup, *sync.WaitGroup, *sync.WaitGroup) {
-	var signingWg sync.WaitGroup
-	signingWg.Go(func() {
-		for job := range p.signingChan {
-			if ctx.Err() != nil {
-				continue
-			}
-			if _, err := p.blockHandler.CreateBlockSignatureForExistingBlock(
-				ctx, job.blockNum, job.blockHash, job.block, job.transactions, job.receipts,
-			); err != nil {
-				logger.Sugar.Warnf("Block %d: failed to create block signature for existing block: %v", job.blockNum, err)
-			}
-		}
-	})
-
+// startWorkers launches processing and result-collection goroutines.
+func (p *ConcurrentBlockProcessor) startWorkers(ctx context.Context, onBlockProcessed func(blockNum int64)) (chan int64, *sync.WaitGroup, *sync.WaitGroup) {
 	workChan := make(chan int64, p.workers*DefaultWorkersAhead)
 
 	var wg sync.WaitGroup
@@ -144,7 +102,7 @@ func (p *ConcurrentBlockProcessor) startWorkers(ctx context.Context, onBlockProc
 		p.collectResults(onBlockProcessed)
 	})
 
-	return workChan, &wg, &collectWg, &signingWg
+	return workChan, &wg, &collectWg
 }
 
 // collectResults reads from resultChan and commits blocks in order.
@@ -161,10 +119,10 @@ func (p *ConcurrentBlockProcessor) collectResults(onBlockProcessed func(blockNum
 			delete(p.pending, p.nextToCommit)
 
 			if next.Success {
-				if next.BlockID != "existing" {
+				if next.BlockID != "" {
 					logger.Sugar.Infof("Committed block %d (ID: %s)", next.BlockNum, next.BlockID)
 				} else {
-					logger.Sugar.Infof("Block %d already existed, skipping", next.BlockNum)
+					logger.Sugar.Infof("Committed block %d", next.BlockNum)
 				}
 				if onBlockProcessed != nil {
 					onBlockProcessed(next.BlockNum)
@@ -227,39 +185,32 @@ func (p *ConcurrentBlockProcessor) dispatchLoop(ctx context.Context, startBlock 
 	}
 }
 
-// fetchAndProcessBlock fetches a block and processes it into DefraDB.
+// fetchAndProcessBlock calls chain.FetchAndStoreBlock with retry classification:
+//   - not-found: infinite retry with BlockNotFoundRetryDelay (block may not be mined yet)
+//   - other errors: up to MaxRPCRetries with linear backoff (RPCErrorRetryBaseDelay * attempt)
 func (p *ConcurrentBlockProcessor) fetchAndProcessBlock(ctx context.Context, blockNum int64) *BlockResult {
 	result := &BlockResult{BlockNum: blockNum}
 
-	block, err := p.fetchBlockWithRetry(ctx, blockNum)
-	if err != nil {
-		result.Error = err
-		return result
-	}
-
-	transactions, validReceipts := p.fetchTransactionsAndReceipts(ctx, block, blockNum)
-
-	return p.createBlockBatchWithRetry(ctx, block, blockNum, transactions, validReceipts, result)
-}
-
-// fetchBlockWithRetry fetches a block by number, retrying on not-found and RPC errors.
-func (p *ConcurrentBlockProcessor) fetchBlockWithRetry(ctx context.Context, blockNum int64) (*types.Block, error) {
 	otherErrors := 0
 	for {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			result.Error = ctx.Err()
+			return result
 		}
 
-		block, err := p.ethClient.GetBlockByNumber(ctx, big.NewInt(blockNum))
+		blockID, err := p.chain.FetchAndStoreBlock(ctx, blockNum)
 		if err == nil {
-			return block, nil
+			result.BlockID = blockID
+			result.Success = true
+			return result
 		}
 
 		if errors.IsErrNotFound(err) {
 			logger.Sugar.Infof("Block %d not available yet, waiting...", blockNum)
 			select {
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				result.Error = ctx.Err()
+				return result
 			case <-time.After(BlockNotFoundRetryDelay):
 			}
 			continue
@@ -267,114 +218,14 @@ func (p *ConcurrentBlockProcessor) fetchBlockWithRetry(ctx context.Context, bloc
 
 		otherErrors++
 		if otherErrors >= MaxRPCRetries {
-			return nil, fmt.Errorf("failed to fetch block: %w", err)
+			result.Error = fmt.Errorf("failed to fetch block %d: %w", blockNum, err)
+			return result
 		}
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			result.Error = ctx.Err()
+			return result
 		case <-time.After(time.Duration(otherErrors) * RPCErrorRetryBaseDelay):
 		}
 	}
-}
-
-// fetchTransactionsAndReceipts fetches receipts for a block, falling back to individual fetches.
-func (p *ConcurrentBlockProcessor) fetchTransactionsAndReceipts(ctx context.Context, block *types.Block, blockNum int64) ([]*types.Transaction, []*types.TransactionReceipt) {
-	transactions := make([]*types.Transaction, len(block.Transactions))
-	for i := range block.Transactions {
-		transactions[i] = &block.Transactions[i]
-	}
-
-	batchReceipts, batchErr := p.ethClient.GetBlockReceipts(ctx, big.NewInt(blockNum))
-	if batchErr == nil {
-		return transactions, batchReceipts
-	}
-
-	if ctx.Err() == nil {
-		logger.Sugar.Debugf("Block %d: eth_getBlockReceipts not available, falling back to individual fetches: %v", blockNum, batchErr)
-	}
-
-	receipts := make([]*types.TransactionReceipt, len(block.Transactions))
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, p.receiptWorkers)
-
-	for i, tx := range block.Transactions {
-		wg.Add(1)
-		go func(idx int, txHash string) {
-			defer wg.Done()
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-			case <-ctx.Done():
-				return
-			}
-			receipt, err := p.ethClient.GetTransactionReceipt(ctx, txHash)
-			if err != nil {
-				if ctx.Err() == nil {
-					logger.Sugar.Warnf("Failed to fetch receipt for tx %s: %v", txHash, err)
-				}
-				return
-			}
-			receipts[idx] = receipt
-		}(i, tx.Hash)
-	}
-	wg.Wait()
-
-	validReceipts := make([]*types.TransactionReceipt, 0, len(receipts))
-	for _, r := range receipts {
-		if r != nil {
-			validReceipts = append(validReceipts, r)
-		}
-	}
-
-	return transactions, validReceipts
-}
-
-// createBlockBatchWithRetry attempts to write the block batch to DefraDB with retries.
-func (p *ConcurrentBlockProcessor) createBlockBatchWithRetry(ctx context.Context, block *types.Block, blockNum int64, transactions []*types.Transaction, validReceipts []*types.TransactionReceipt, result *BlockResult) *BlockResult {
-	for attempt := range MaxRPCRetries {
-		if ctx.Err() != nil {
-			result.Error = ctx.Err()
-			return result
-		}
-
-		blockID, err := p.blockHandler.CreateBlockBatch(ctx, block, transactions, validReceipts)
-		if err == nil {
-			result.Success = true
-			result.BlockID = blockID
-			return result
-		}
-
-		if errors.IsErrAlreadyExists(err) {
-			select {
-			case p.signingChan <- signingJob{
-				blockNum:     blockNum,
-				blockHash:    block.Hash,
-				block:        block,
-				transactions: transactions,
-				receipts:     validReceipts,
-			}:
-			default:
-				logger.Sugar.Warnf("Block %d: signing queue full, skipping block signature", blockNum)
-			}
-			result.Success = true
-			result.BlockID = "existing"
-			return result
-		}
-
-		if errors.IsErrTransactionConflict(err) && attempt < MaxRPCRetries-1 {
-			logger.Sugar.Infof("Block %d transaction conflict, retrying (attempt %d/%d)", blockNum, attempt+1, MaxRPCRetries)
-			select {
-			case <-ctx.Done():
-				result.Error = ctx.Err()
-				return result
-			case <-time.After(time.Duration(attempt+1) * TransactionConflictRetryBaseDelay):
-			}
-			continue
-		}
-
-		result.Error = fmt.Errorf("failed to create block batch: %w", err)
-		return result
-	}
-
-	return result
 }

--- a/pkg/indexer/concurrent_processor.go
+++ b/pkg/indexer/concurrent_processor.go
@@ -15,12 +15,6 @@ const (
 	// BlockNotFoundRetryDelay is the delay before retrying when a block is not yet available on chain.
 	BlockNotFoundRetryDelay = 3 * time.Second
 
-	// RPCErrorRetryBaseDelay is the base delay for retrying RPC errors (multiplied by attempt number).
-	RPCErrorRetryBaseDelay = 500 * time.Millisecond
-
-	// MaxRPCRetries is the maximum number of retries for non-"not found" RPC errors.
-	MaxRPCRetries = 3
-
 	// DispatchThrottleDelay is the delay when the processor is too far ahead of committed blocks.
 	DispatchThrottleDelay = 100 * time.Millisecond
 )
@@ -185,13 +179,14 @@ func (p *ConcurrentBlockProcessor) dispatchLoop(ctx context.Context, startBlock 
 	}
 }
 
-// fetchAndProcessBlock calls chain.FetchAndStoreBlock with retry classification:
-//   - not-found: infinite retry with BlockNotFoundRetryDelay (block may not be mined yet)
-//   - other errors: up to MaxRPCRetries with linear backoff (RPCErrorRetryBaseDelay * attempt)
+// fetchAndProcessBlock calls chain.FetchAndStoreBlock. The adapter retries
+// non-not-found RPC errors internally (up to maxRPCRetries with linear
+// backoff); the processor only handles not-found with infinite retry
+// (block may not be mined yet). This avoids double-retry (previously
+// 3×3=9 attempts).
 func (p *ConcurrentBlockProcessor) fetchAndProcessBlock(ctx context.Context, blockNum int64) *BlockResult {
 	result := &BlockResult{BlockNum: blockNum}
 
-	otherErrors := 0
 	for {
 		if ctx.Err() != nil {
 			result.Error = ctx.Err()
@@ -216,16 +211,7 @@ func (p *ConcurrentBlockProcessor) fetchAndProcessBlock(ctx context.Context, blo
 			continue
 		}
 
-		otherErrors++
-		if otherErrors >= MaxRPCRetries {
-			result.Error = fmt.Errorf("failed to fetch block %d: %w", blockNum, err)
-			return result
-		}
-		select {
-		case <-ctx.Done():
-			result.Error = ctx.Err()
-			return result
-		case <-time.After(time.Duration(otherErrors) * RPCErrorRetryBaseDelay):
-		}
+		result.Error = fmt.Errorf("failed to fetch block %d: %w", blockNum, err)
+		return result
 	}
 }

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -65,7 +65,7 @@ const defaultListenAddress string = "/ip4/127.0.0.1/tcp/9171"
 type ChainIndexer struct {
 	cfg                       *config.Config
 	collections               *constants.CollectionNames
-	adapter                   chain.Adapter
+	adapter                   chain.Adapter // TODO: receive via adapterFactory field instead.
 	shouldIndex               bool
 	isStarted                 bool
 	hasIndexedAtLeastOneBlock bool
@@ -154,7 +154,11 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 
 	logger.Sugar.Infof("Indexing chain: %s (prefix: %s)", cfg.Chain.Name+"__"+cfg.Chain.Network, chainPrefixFromConfig(cfg))
 
-	adapter, err := chain.NewEVMAdapter(cfg)
+	// TODO: replace chain.NewAdapter(cfg) with i.adapterFactory(cfg)
+	// once the adapterFactory field is added (when a second chain package exists).
+	// The factory itself moves to per-chain packages (pkg/chain/evm, pkg/chain/cosmos);
+	// pkg/chain keeps only the Adapter interface. The binary determines the chain.
+	adapter, err := chain.NewAdapter(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create chain adapter: %w", err)
 	}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -61,11 +61,23 @@ const (
 // defaultListenAddress is the default P2P listen address for the embedded DefraDB node.
 const defaultListenAddress string = "/ip4/127.0.0.1/tcp/9171"
 
+// chainAdapter is the unexported seam over *chain.EVMAdapter. It exists so
+// tests can inject a recording wrapper that asserts StartIndexing's call order.
+// *chain.EVMAdapter satisfies it via structural typing.
+type chainAdapter interface {
+	chain.Chain
+	Init(ctx context.Context, node *node.Node) error
+	Close() error
+	SetDocIDTracker(tracker defra.DocIDTrackerInterface)
+}
+
+var _ chainAdapter = (*chain.EVMAdapter)(nil) // compile-time guard
+
 // ChainIndexer is the main indexer that processes blockchain blocks.
 type ChainIndexer struct {
 	cfg                       *config.Config
 	collections               *constants.CollectionNames
-	adapter                   *chain.EVMAdapter
+	adapter                   chainAdapter
 	shouldIndex               bool
 	isStarted                 bool
 	hasIndexedAtLeastOneBlock bool
@@ -306,7 +318,7 @@ func newSchemaAuthenticator(cfg *config.Config) (server.Authenticator, error) {
 }
 
 // initServices starts the health server, pruner, and snapshotter if configured.
-func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, adapter *chain.EVMAdapter) error {
+func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, adapter chainAdapter) error {
 	if cfg.Indexer.HealthServerPort > 0 {
 		if err := i.initHealthServer(cfg); err != nil {
 			return err

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -13,14 +13,13 @@ import (
 	"time"
 
 	"github.com/shinzonetwork/shinzo-generator-client/config"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/chain"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/defra"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/defradb"
 	indexerErrors "github.com/shinzonetwork/shinzo-generator-client/pkg/errors"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/pruner"
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/rpc"
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/schema"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/server"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/signer"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/snapshot"
@@ -66,6 +65,7 @@ const defaultListenAddress string = "/ip4/127.0.0.1/tcp/9171"
 type ChainIndexer struct {
 	cfg                       *config.Config
 	collections               *constants.CollectionNames
+	adapter                   *chain.EVMAdapter
 	shouldIndex               bool
 	isStarted                 bool
 	hasIndexedAtLeastOneBlock bool
@@ -154,18 +154,22 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 
 	logger.Sugar.Infof("Indexing chain: %s (prefix: %s)", cfg.Chain.Name+"__"+cfg.Chain.Network, chainPrefixFromConfig(cfg))
 
-	ctx, err := i.initDefra(ctx, cfg, defraStarted)
+	adapter, err := chain.NewEVMAdapter(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create chain adapter: %w", err)
+	}
+	i.adapter = adapter
+
+	ctx, err = i.initDefra(ctx, cfg, defraStarted)
 	if err != nil {
 		return err
 	}
 
-	blockHandler, ethClient, err := i.initClients(cfg)
-	if err != nil {
-		return err
+	if err := adapter.Init(ctx, i.defraNode); err != nil {
+		return fmt.Errorf("failed to initialize chain adapter: %w", err)
 	}
-	defer func() { _ = ethClient.Close() }()
 
-	nextBlockToProcess, err := i.resolveStartHeight(ctx, cfg, blockHandler, ethClient)
+	nextBlockToProcess, err := i.resolveStartHeight(ctx, cfg, adapter)
 	if err != nil {
 		return err
 	}
@@ -173,13 +177,13 @@ func (i *ChainIndexer) StartIndexing(defraStarted bool) error {
 	i.shouldIndex = true
 	logger.Sugar.Info("Starting indexer - will process latest blocks from Geth ", cfg.Geth.NodeURL)
 
-	if err := i.initServices(ctx, cfg, blockHandler); err != nil {
+	if err := i.initServices(ctx, cfg, adapter); err != nil {
 		return err
 	}
 
 	if cfg.Indexer.ConcurrentBlocks >= 1 && i.defraNode != nil {
 		logger.Sugar.Infof("Using concurrent block processing with %d workers", cfg.Indexer.ConcurrentBlocks)
-		return i.runConcurrentIndexing(ctx, ethClient, blockHandler, nextBlockToProcess, cfg)
+		return i.runConcurrentIndexing(ctx, adapter, nextBlockToProcess, cfg)
 	}
 	return nil
 }
@@ -197,7 +201,7 @@ func (i *ChainIndexer) initDefra(ctx context.Context, cfg *config.Config, defraS
 		}
 
 		defraNode, networkHandler, err := defradb.StartDefraInstance(cfg,
-			defradb.NewSchemaApplierFromDir(chainPrefixFromConfig(cfg)), nil, replicationFilter, i.collections.AllCollections()...)
+			defradb.NewSchemaApplierFromDir(chainPrefixFromConfig(cfg)), nil, replicationFilter, i.adapter.GetCollections()...)
 		if err != nil {
 			return ctx, fmt.Errorf("failed to start DefraDB instance: %w", err)
 		}
@@ -232,27 +236,8 @@ func (i *ChainIndexer) initDefra(ctx context.Context, cfg *config.Config, defraS
 	return ctx, nil
 }
 
-// initClients creates the block handler and Ethereum client.
-func (i *ChainIndexer) initClients(cfg *config.Config) (*defra.BlockHandler, *rpc.EthereumClient, error) {
-	blockHandler, err := defra.NewBlockHandler(i.defraNode, cfg.Indexer.MaxDocsPerTxn, i.collections)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create block handler: %w", err)
-	}
-	blockHandler.SetBatchSizes(cfg.Indexer.MaxTxDocsPerBatch, cfg.Indexer.MaxLogDocsPerBatch, cfg.Indexer.MaxALEDocsPerBatch)
-	logger.Sugar.Infof("Using direct DB access for embedded DefraDB (maxDocsPerTxn=%d, txBatch=%d, logBatch=%d, aleBatch=%d)",
-		cfg.Indexer.MaxDocsPerTxn, cfg.Indexer.MaxTxDocsPerBatch, cfg.Indexer.MaxLogDocsPerBatch, cfg.Indexer.MaxALEDocsPerBatch)
-
-	ethClient, err := rpc.NewEthereumClient(cfg.Geth.NodeURL, cfg.Geth.WsURL, cfg.Geth.APIKey, cfg.Geth.APIKeyType)
-	if err != nil {
-		logCtx := indexerErrors.LogContext(err)
-		logger.Sugar.With("context", logCtx).Fatalf("Failed to connect to Ethereum client: %v", err)
-	}
-
-	return blockHandler, ethClient, nil
-}
-
 // resolveStartHeight determines the block number to start indexing from.
-func (i *ChainIndexer) resolveStartHeight(ctx context.Context, cfg *config.Config, blockHandler *defra.BlockHandler, ethClient *rpc.EthereumClient) (int64, error) {
+func (i *ChainIndexer) resolveStartHeight(ctx context.Context, cfg *config.Config, chain chain.Chain) (int64, error) {
 	configuredHeight := int64(cfg.Indexer.StartHeight)
 	var highestExisting int64
 	var pruneQueue *pruner.IndexerQueue
@@ -270,7 +255,7 @@ func (i *ChainIndexer) resolveStartHeight(ctx context.Context, cfg *config.Confi
 	}
 
 	if highestExisting == 0 {
-		nBlock, err := blockHandler.GetHighestBlockNumber(ctx)
+		nBlock, err := chain.GetHighestStoredBlockNumber(ctx)
 		if err != nil {
 			logger.Sugar.Debugf("No existing blocks found in DB: %v", err)
 		} else {
@@ -278,11 +263,11 @@ func (i *ChainIndexer) resolveStartHeight(ctx context.Context, cfg *config.Confi
 		}
 	}
 
-	latestBlock, err := ethClient.GetLatestBlockNumber(ctx)
+	latestBlock, err := chain.FetchHighestBlockNumber(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get latest block number from RPC: %w", err)
 	}
-	chainTip := latestBlock.Int64()
+	chainTip := latestBlock
 	startBuffer := int64(cfg.Indexer.StartBuffer)
 
 	switch {
@@ -321,7 +306,7 @@ func newSchemaAuthenticator(cfg *config.Config) (server.Authenticator, error) {
 }
 
 // initServices starts the health server, pruner, and snapshotter if configured.
-func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, blockHandler *defra.BlockHandler) error {
+func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, adapter *chain.EVMAdapter) error {
 	if cfg.Indexer.HealthServerPort > 0 {
 		if err := i.initHealthServer(cfg); err != nil {
 			return err
@@ -341,7 +326,7 @@ func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, blo
 			logger.Sugar.Infof("Restored %d entries from prune queue file", restored)
 		}
 		i.pruner.SetQueue(pruneQueue)
-		blockHandler.SetDocIDTracker(&indexerQueueTracker{
+		adapter.SetDocIDTracker(&indexerQueueTracker{
 			queue:       pruneQueue,
 			collections: i.collections,
 		})
@@ -385,7 +370,7 @@ func (i *ChainIndexer) initHealthServer(cfg *config.Config) error {
 		return err
 	}
 	prefix := chainPrefixFromConfig(cfg)
-	sdl, err := schema.GetSchemaForChain(prefix)
+	sdl, err := i.adapter.GetSchema()
 	if err != nil {
 		return fmt.Errorf("load schema for chain %s: %w", prefix, err)
 	}
@@ -410,8 +395,7 @@ func (i *ChainIndexer) initHealthServer(cfg *config.Config) error {
 // runConcurrentIndexing runs the indexer with concurrent block processing.
 func (i *ChainIndexer) runConcurrentIndexing(
 	ctx context.Context,
-	ethClient *rpc.EthereumClient,
-	blockHandler *defra.BlockHandler,
+	chain chain.Chain,
 	startBlock int64,
 	cfg *config.Config,
 ) error {
@@ -419,10 +403,8 @@ func (i *ChainIndexer) runConcurrentIndexing(
 	i.isStarted = true
 
 	processor := NewConcurrentBlockProcessor(
-		blockHandler,
-		ethClient,
+		chain,
 		cfg.Indexer.ConcurrentBlocks,
-		cfg.Indexer.ReceiptWorkers,
 		cfg.Indexer.BlocksPerMinute,
 	)
 
@@ -454,6 +436,12 @@ func (i *ChainIndexer) StopIndexing() {
 		ctx, cancel := context.WithTimeout(context.Background(), DefaultRetryDelay)
 		defer cancel()
 		_ = i.healthServer.Stop(ctx)
+	}
+
+	// Close chain adapter (cancels internal context, drains signing goroutine, closes RPC client)
+	if i.adapter != nil {
+		_ = i.adapter.Close()
+		i.adapter = nil
 	}
 
 	// Stop P2P network handler before closing the node

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -61,23 +61,11 @@ const (
 // defaultListenAddress is the default P2P listen address for the embedded DefraDB node.
 const defaultListenAddress string = "/ip4/127.0.0.1/tcp/9171"
 
-// chainAdapter is the unexported seam over *chain.EVMAdapter. It exists so
-// tests can inject a recording wrapper that asserts StartIndexing's call order.
-// *chain.EVMAdapter satisfies it via structural typing.
-type chainAdapter interface {
-	chain.Chain
-	Init(ctx context.Context, node *node.Node) error
-	Close() error
-	SetDocIDTracker(tracker defra.DocIDTrackerInterface)
-}
-
-var _ chainAdapter = (*chain.EVMAdapter)(nil) // compile-time guard
-
 // ChainIndexer is the main indexer that processes blockchain blocks.
 type ChainIndexer struct {
 	cfg                       *config.Config
 	collections               *constants.CollectionNames
-	adapter                   chainAdapter
+	adapter                   chain.Adapter
 	shouldIndex               bool
 	isStarted                 bool
 	hasIndexedAtLeastOneBlock bool
@@ -318,7 +306,7 @@ func newSchemaAuthenticator(cfg *config.Config) (server.Authenticator, error) {
 }
 
 // initServices starts the health server, pruner, and snapshotter if configured.
-func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, adapter chainAdapter) error {
+func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, adapter chain.Adapter) error {
 	if cfg.Indexer.HealthServerPort > 0 {
 		if err := i.initHealthServer(cfg); err != nil {
 			return err

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -20,13 +20,13 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/shinzonetwork/shinzo-generator-client/config"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/chain"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/defra"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/defradb"
 	indexerErrors "github.com/shinzonetwork/shinzo-generator-client/pkg/errors"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/pruner"
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/rpc"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/server"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/snapshot"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/testutils"
@@ -778,19 +778,17 @@ func TestGetCurrentBlockAndLastProcessedTime_Consistency(t *testing.T) {
 
 func TestNewConcurrentBlockProcessor(t *testing.T) {
 	t.Parallel()
-	p := NewConcurrentBlockProcessor(nil, nil, 4, 8, 60)
+	p := NewConcurrentBlockProcessor(nil, 4, 60)
 	require.NotNil(t, p)
 	assert.Equal(t, 4, p.workers)
-	assert.Equal(t, 8, p.receiptWorkers)
 	assert.Equal(t, 60, p.blocksPerMinute)
 	assert.NotNil(t, p.resultChan)
 	assert.NotNil(t, p.pending)
-	assert.NotNil(t, p.signingChan)
 }
 
 func TestNewConcurrentBlockProcessor_DefaultValues(t *testing.T) {
 	t.Parallel()
-	p := NewConcurrentBlockProcessor(nil, nil, 1, 1, 0)
+	p := NewConcurrentBlockProcessor(nil, 1, 0)
 	require.NotNil(t, p)
 	assert.Equal(t, 1, p.workers)
 	assert.Equal(t, 0, p.blocksPerMinute)
@@ -953,12 +951,10 @@ func TestBlockResult_Fields(t *testing.T) {
 	t.Parallel()
 	r := &BlockResult{
 		BlockNum: 42,
-		BlockID:  "bae-123",
 		Success:  true,
 		Error:    nil,
 	}
 	assert.Equal(t, int64(42), r.BlockNum)
-	assert.Equal(t, "bae-123", r.BlockID)
 	assert.True(t, r.Success)
 	assert.Nil(t, r.Error)
 }
@@ -1018,6 +1014,34 @@ func newMockRPCServer(handler func(method string, params json.RawMessage) (any, 
 	}))
 }
 
+// newTestEVMAdapter creates an EVMAdapter wired to the given mock RPC server
+// and test DefraDB node. The adapter's Close is registered for test cleanup.
+func newTestEVMAdapter(t *testing.T, td *testutils.TestDefraDB, rpcServerURL string, receiptWorkers int) *chain.EVMAdapter {
+	t.Helper()
+	cfg := &config.Config{
+		Chain: config.ChainConfig{
+			Name:    "Ethereum",
+			Network: "Mainnet",
+		},
+		Geth: config.GethConfig{
+			NodeURL:    rpcServerURL,
+			APIKeyType: "X-Api-Key",
+		},
+		Indexer: config.IndexerConfig{
+			MaxDocsPerTxn:      100,
+			ReceiptWorkers:     receiptWorkers,
+			MaxTxDocsPerBatch:  100,
+			MaxLogDocsPerBatch: 100,
+			MaxALEDocsPerBatch: 100,
+		},
+	}
+	adapter, err := chain.NewEVMAdapter(cfg)
+	require.NoError(t, err)
+	require.NoError(t, adapter.Init(context.Background(), td.Node))
+	t.Cleanup(func() { _ = adapter.Close() })
+	return adapter
+}
+
 func fullBlockResponse(number string, txs []any) map[string]any {
 	emptyTrieRoot := testTransactionsRoot
 	block := map[string]any{
@@ -1045,52 +1069,6 @@ func fullBlockResponse(number string, txs []any) map[string]any {
 		block["transactions"] = txs
 	} else {
 		block["transactions"] = []any{}
-	}
-	return block
-}
-
-// fullBlockResponseWithTx returns a block response with a single legacy transaction.
-// The transactionsRoot is set to a non-empty value so go-ethereum accepts it.
-func fullBlockResponseWithTx(number string) map[string]any {
-	tx := map[string]any{
-		"hash":                      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		"nonce":                     "0x0",
-		constants.BlockHashKeyValue: "0x0000000000000000000000000000000000000000000000000000000000000001",
-		"blockNumber":               number,
-		"transactionIndex":          "0x0",
-		"from":                      "0x0000000000000000000000000000000000000001",
-		"to":                        "0x0000000000000000000000000000000000000002",
-		"value":                     "0x3e8",
-		"gas":                       "0x5208",
-		"gasPrice":                  "0x3b9aca00",
-		"input":                     "0x",
-		"v":                         "0x1b",
-		"r":                         "0x1111111111111111111111111111111111111111111111111111111111111111",
-		"s":                         "0x2222222222222222222222222222222222222222222222222222222222222222",
-		"type":                      "0x0",
-	}
-
-	block := map[string]any{
-		constants.NumberFieldValue: number,
-		"hash":                     "0x0000000000000000000000000000000000000000000000000000000000000001",
-		"parentHash":               "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"nonce":                    "0x0000000000000000",
-		"sha3Uncles":               testSha3Uncles,
-		"logsBloom":                "0x" + fmt.Sprintf("%0512x", 0),
-		"transactionsRoot":         "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", // non-empty → indicates txns present.
-		"stateRoot":                "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"receiptsRoot":             "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"miner":                    "0x0000000000000000000000000000000000000000",
-		"difficulty":               "0x0",
-		"totalDifficulty":          "0x0",
-		"extraData":                "0x",
-		"size":                     "0x100",
-		"gasLimit":                 "0x1000000",
-		"gasUsed":                  "0x5208",
-		"timestamp":                "0x60000000",
-		"mixHash":                  "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"uncles":                   []any{},
-		"transactions":             []any{tx},
 	}
 	return block
 }
@@ -1279,40 +1257,6 @@ func NewHealthServerForTest(t *testing.T) *server.HealthServer {
 // fetchAndProcessBlock tests.
 // ---------------------------------------------------------------------------.
 
-func TestFetchAndProcessBlock_Success_NoTx(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-
-	td := testutils.SetupTestDefraDB(t)
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			return fullBlockResponse("0x1f4", nil), nil // block 500.
-		case ethGetBlockReceipts:
-			return []any{}, nil
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
-
-	result := p.fetchAndProcessBlock(context.Background(), 500)
-	require.NotNil(t, result)
-	assert.True(t, result.Success, "fetchAndProcessBlock should succeed: %v", result.Error)
-	assert.NotEmpty(t, result.BlockID)
-	assert.Equal(t, int64(500), result.BlockNum)
-}
-
 func TestFetchAndProcessBlock_RPCError(t *testing.T) {
 	t.Parallel()
 	logger.InitConsoleOnly(true)
@@ -1329,14 +1273,9 @@ func TestFetchAndProcessBlock_RPCError(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	result := p.fetchAndProcessBlock(context.Background(), 500)
 	require.NotNil(t, result)
@@ -1356,14 +1295,9 @@ func TestFetchAndProcessBlock_ContextCancelled(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately.
@@ -1374,46 +1308,7 @@ func TestFetchAndProcessBlock_ContextCancelled(t *testing.T) {
 	assert.Error(t, result.Error)
 }
 
-func TestFetchAndProcessBlock_DuplicateBlock(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-
-	td := testutils.SetupTestDefraDB(t)
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			return fullBlockResponse("0x2bc", nil), nil // block 700
-		case ethGetBlockReceipts:
-			return []any{}, nil
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
-
-	// First call should succeed.
-	result1 := p.fetchAndProcessBlock(context.Background(), 700)
-	require.NotNil(t, result1)
-	assert.True(t, result1.Success)
-
-	// Second call should detect duplicate and return "existing".
-	result2 := p.fetchAndProcessBlock(context.Background(), 700)
-	require.NotNil(t, result2)
-	assert.True(t, result2.Success)
-	assert.Equal(t, "existing", result2.BlockID)
-}
-
-// ---------------------------------------------------------------------------.
+// ----------------------------------------------------------------------------.
 // ProcessBlocks tests (with context cancellation).
 // ---------------------------------------------------------------------------.
 
@@ -1438,14 +1333,9 @@ func TestProcessBlocks_ContextCancel(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -1458,7 +1348,7 @@ func TestProcessBlocks_ContextCancel(t *testing.T) {
 		cancel()
 	}()
 
-	err = p.ProcessBlocks(ctx, 1001, func(blockNum int64) {
+	err := p.ProcessBlocks(ctx, 1001, func(blockNum int64) {
 		mu.Lock()
 		processed = append(processed, blockNum)
 		mu.Unlock()
@@ -1492,17 +1382,10 @@ func TestProcessBlocks_WithRateLimit_ContextCancel(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() {
-		_ = ethClient.Close()
-	}()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	// Rate limit to 600 blocks/min = 10/sec.
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 600)
+	p := NewConcurrentBlockProcessor(adapter, 1, 600)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -1511,7 +1394,7 @@ func TestProcessBlocks_WithRateLimit_ContextCancel(t *testing.T) {
 		cancel()
 	}()
 
-	err = p.ProcessBlocks(ctx, 2001, nil)
+	err := p.ProcessBlocks(ctx, 2001, nil)
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -1795,14 +1678,7 @@ func TestRunConcurrentIndexing_DirectCall(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() {
-		_ = ethClient.Close()
-	}()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	indexer := &ChainIndexer{
 		cfg: &config.Config{
@@ -1822,7 +1698,7 @@ func TestRunConcurrentIndexing_DirectCall(t *testing.T) {
 		cancel()
 	}()
 
-	err = indexer.runConcurrentIndexing(ctx, ethClient, blockHandler, 5001, indexer.cfg)
+	err := indexer.runConcurrentIndexing(ctx, adapter, 5001, indexer.cfg)
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.True(t, indexer.isStarted)
 	assert.True(t, indexer.shouldIndex)
@@ -1898,16 +1774,9 @@ func TestFetchAndProcessBlock_NotFoundThenSuccess(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() {
-		_ = ethClient.Close()
-	}()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	// Use a context with timeout so the not-found retry doesn't block forever.
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -1943,14 +1812,9 @@ func TestFetchAndProcessBlock_OtherRPCErrorRetry(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	result := p.fetchAndProcessBlock(context.Background(), 30000)
 	require.NotNil(t, result)
@@ -1977,14 +1841,9 @@ func TestFetchAndProcessBlock_TransactionConflict(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	// Insert block first
 	result1 := p.fetchAndProcessBlock(context.Background(), 40000)
@@ -1994,7 +1853,6 @@ func TestFetchAndProcessBlock_TransactionConflict(t *testing.T) {
 	result2 := p.fetchAndProcessBlock(context.Background(), 40000)
 	require.NotNil(t, result2)
 	assert.True(t, result2.Success)
-	assert.Equal(t, "existing", result2.BlockID)
 }
 
 // TestFetchAndProcessBlock_ContextCancelledDuringNotFound tests cancellation.
@@ -2015,14 +1873,9 @@ func TestFetchAndProcessBlock_ContextCancelledDuringNotFound(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
@@ -2051,14 +1904,9 @@ func TestFetchAndProcessBlock_ContextCancelledDuringOtherRetry(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -2219,15 +2067,10 @@ func TestProcessBlocks_TooFarAhead(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	// Use only 1 worker so the tooFarAhead check (workers*2=2) triggers quickly.
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -2236,7 +2079,7 @@ func TestProcessBlocks_TooFarAhead(t *testing.T) {
 		cancel()
 	}()
 
-	err = p.ProcessBlocks(ctx, 3001, nil)
+	err := p.ProcessBlocks(ctx, 3001, nil)
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -2261,14 +2104,9 @@ func TestProcessBlocks_WithNilCallback(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -2276,7 +2114,7 @@ func TestProcessBlocks_WithNilCallback(t *testing.T) {
 		cancel()
 	}()
 
-	err = p.ProcessBlocks(ctx, 4001, nil)
+	err := p.ProcessBlocks(ctx, 4001, nil)
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -2306,14 +2144,9 @@ func TestProcessBlocks_FailedBlockInSequence(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var mu sync.Mutex
@@ -2323,7 +2156,7 @@ func TestProcessBlocks_FailedBlockInSequence(t *testing.T) {
 		cancel()
 	}()
 
-	err = p.ProcessBlocks(ctx, 6001, func(blockNum int64) {
+	err := p.ProcessBlocks(ctx, 6001, func(blockNum int64) {
 		mu.Lock()
 		processed = append(processed, blockNum)
 		mu.Unlock()
@@ -2496,15 +2329,10 @@ func TestProcessBlocks_CancelDuringRateLimit(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	// Very low rate limit (1 block/min) so cancellation hits during wait.
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 1)
+	p := NewConcurrentBlockProcessor(adapter, 1, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -2512,7 +2340,7 @@ func TestProcessBlocks_CancelDuringRateLimit(t *testing.T) {
 		cancel()
 	}()
 
-	err = p.ProcessBlocks(ctx, 7001, nil)
+	err := p.ProcessBlocks(ctx, 7001, nil)
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -2540,19 +2368,14 @@ func TestProcessBlocks_CancelDuringTooFarAhead(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	err = p.ProcessBlocks(ctx, 9001, nil)
+	err := p.ProcessBlocks(ctx, 9001, nil)
 	// Should be context.DeadlineExceeded or context.Canceled.
 	assert.Error(t, err)
 }
@@ -2586,50 +2409,7 @@ func TestGetPeerInfo_DeduplicationBranch(t *testing.T) {
 // fetchAndProcessBlock — context cancel during CreateBlockBatch retry
 // ---------------------------------------------------------------------------
 
-func TestFetchAndProcessBlock_ContextCancelDuringBatch(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-
-	td := testutils.SetupTestDefraDB(t)
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			return fullBlockResponse("0xdead", nil), nil
-		case ethGetBlockReceipts:
-			return []any{}, nil
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
-
-	// Insert block first to cause "already exists" on second attempt.
-	result1 := p.fetchAndProcessBlock(context.Background(), 0xdead)
-	require.True(t, result1.Success)
-
-	// Second attempt with canceled context — tests ctx.Err() check in retry loop.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // immediately canceled
-
-	result2 := p.fetchAndProcessBlock(ctx, 0xdead)
-	require.NotNil(t, result2)
-	// Either already-exists (fast path) or context error.
-	if !result2.Success {
-		assert.Error(t, result2.Error)
-	}
-}
-
-// ---------------------------------------------------------------------------.
+// ----------------------------------------------------------------------------.
 // openBrowser — test the "default" (linux) case on non-darwin platforms.
 // The function switches on runtime.GOOS. On macOS, only darwin branch runs.
 // We test that the function completes without panicking.
@@ -2727,34 +2507,18 @@ func TestFetchAndProcessBlock_SigningQueueFull(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	// First: insert block.
 	result1 := p.fetchAndProcessBlock(context.Background(), 0xbeef)
 	require.True(t, result1.Success)
 
-	// Fill the signing channel to capacity.
-	for i := 0; i < cap(p.signingChan); i++ {
-		p.signingChan <- signingJob{blockNum: int64(i)}
-	}
-
-	// Second: duplicate block with full signing queue → "signing queue full" warning.
+	// Second: duplicate block — adapter enqueues signing internally and returns success.
 	result2 := p.fetchAndProcessBlock(context.Background(), 0xbeef)
 	require.NotNil(t, result2)
 	assert.True(t, result2.Success)
-	assert.Equal(t, "existing", result2.BlockID)
-
-	// Drain signing channel.
-	for len(p.signingChan) > 0 {
-		<-p.signingChan
-	}
 }
 
 // ---------------------------------------------------------------------------.
@@ -3109,217 +2873,6 @@ func TestStartIndexing_ResumeFromHighBlock(t *testing.T) {
 	indexer.StopIndexing()
 }
 
-// ---------------------------------------------------------------------------
-// fetchAndProcessBlock — receipt fallback to individual fetch
-// ---------------------------------------------------------------------------
-
-func TestFetchAndProcessBlock_ReceiptFallbackIndividual(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-
-	td := testutils.SetupTestDefraDB(t)
-
-	var getBlockCalls atomic.Int64
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			getBlockCalls.Add(1)
-			// Return a block with 0 txns (so receipt fallback path runs but has no txns to iterate).
-			return fullBlockResponse("0x186a0", nil), nil
-		case ethGetBlockReceipts:
-			// Fail batch receipts → triggers fallback to individual fetches.
-			return nil, fmt.Errorf("eth_getBlockReceipts not supported")
-		case ethGetTransactionReceipt:
-			return map[string]any{
-				"status": "0x1",
-				"logs":   []any{},
-			}, nil
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	processor := NewConcurrentBlockProcessor(
-		blockHandler,
-		ethClient,
-		2, // workers.
-		2, // receiptWorkers.
-		0, // blocksPerMinute.
-	)
-
-	ctx := context.Background()
-	result := processor.fetchAndProcessBlock(ctx, 100000)
-
-	assert.True(t, result.Success, "block should be processed successfully")
-	assert.NoError(t, result.Error)
-	assert.NotEmpty(t, result.BlockID)
-}
-
-// ---------------------------------------------------------------------------.
-// fetchAndProcessBlock — receipt fallback with actual transactions.
-// ---------------------------------------------------------------------------.
-
-func TestFetchAndProcessBlock_ReceiptFallbackWithTxns(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-
-	td := testutils.SetupTestDefraDB(t)
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			// Return a block WITH a transaction.
-			return fullBlockResponseWithTx("0x186a0"), nil
-		case ethGetBlockReceipts:
-			// Fail batch receipts → triggers individual fallback.
-			return nil, fmt.Errorf("eth_getBlockReceipts not supported")
-		case ethGetTransactionReceipt:
-			// Return a valid receipt with all required go-ethereum fields.
-			return map[string]any{
-				"transactionHash":           "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				constants.BlockHashKeyValue: "0x0000000000000000000000000000000000000000000000000000000000000001",
-				"blockNumber":               "0x186a0",
-				"transactionIndex":          "0x0",
-				"from":                      "0x0000000000000000000000000000000000000001",
-				"to":                        "0x0000000000000000000000000000000000000002",
-				"gasUsed":                   "0x5208",
-				"cumulativeGasUsed":         "0x5208",
-				"contractAddress":           nil,
-				"status":                    "0x1",
-				"type":                      "0x0",
-				"logsBloom":                 "0x" + fmt.Sprintf("%0512x", 0),
-				"logs":                      []any{},
-			}, nil
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	processor := NewConcurrentBlockProcessor(
-		blockHandler,
-		ethClient,
-		1, // workers.
-		2, // receiptWorkers.
-		0, // blocksPerMinute.
-	)
-
-	ctx := context.Background()
-	result := processor.fetchAndProcessBlock(ctx, 100000)
-
-	assert.True(t, result.Success, "block with receipt fallback should succeed: %v", result.Error)
-	assert.NoError(t, result.Error)
-	assert.NotEmpty(t, result.BlockID)
-}
-
-// TestFetchAndProcessBlock_ReceiptFallbackWithTxnsFail tests the fallback.
-// when individual receipt fetch also fails.
-func TestFetchAndProcessBlock_ReceiptFallbackWithTxnsFail(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-
-	td := testutils.SetupTestDefraDB(t)
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			return fullBlockResponseWithTx("0x186a1"), nil
-		case ethGetBlockReceipts:
-			return nil, fmt.Errorf("eth_getBlockReceipts not supported")
-		case ethGetTransactionReceipt:
-			// Individual receipt fetch also fails.
-			return nil, fmt.Errorf("receipt not available")
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	processor := NewConcurrentBlockProcessor(
-		blockHandler,
-		ethClient,
-		1, // workers.
-		2, // receiptWorkers.
-		0, // blocksPerMinute.
-	)
-
-	ctx := context.Background()
-	result := processor.fetchAndProcessBlock(ctx, 100001)
-
-	// Block should still be created (just without receipts).
-	assert.True(t, result.Success, "block should still succeed even with receipt failures: %v", result.Error)
-}
-
-// TestFetchAndProcessBlock_ReceiptFallbackContextCancel tests receipt fallback.
-// when context is canceled during individual fetch.
-func TestFetchAndProcessBlock_ReceiptFallbackContextCancel(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-
-	td := testutils.SetupTestDefraDB(t)
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			return fullBlockResponseWithTx("0x186a2"), nil
-		case ethGetBlockReceipts:
-			return nil, fmt.Errorf("eth_getBlockReceipts not supported")
-		case ethGetTransactionReceipt:
-			// Slow response to trigger context cancel during receipt fetch.
-			time.Sleep(2 * time.Second)
-			return nil, fmt.Errorf("timeout")
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	processor := NewConcurrentBlockProcessor(
-		blockHandler,
-		ethClient,
-		1, // workers.
-		2, // receiptWorkers.
-		0, // blocksPerMinute.
-	)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
-
-	result := processor.fetchAndProcessBlock(ctx, 100002)
-	// May succeed (block created without receipts) or fail (ctx canceled during batch create).
-	// The important thing is it doesn't hang.
-	t.Logf("result: success=%v, error=%v", result.Success, result.Error)
-}
-
 // ---------------------------------------------------------------------------.
 // ProcessBlocks — already-existing block triggers signing queue ("existing" path).
 // ---------------------------------------------------------------------------.
@@ -3345,26 +2898,19 @@ func TestProcessBlocks_ExistingBlockPath(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	processor := NewConcurrentBlockProcessor(
-		blockHandler,
-		ethClient,
-		1, // workers.
-		2, // receiptWorkers.
-		0, // blocksPerMinute.
+		adapter, // chain.
+		1,       // workers.
+		0,       // blocksPerMinute.
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	var processedBlocks atomic.Int64
-	err = processor.ProcessBlocks(ctx, 100000, func(_ int64) {
+	err := processor.ProcessBlocks(ctx, 100000, func(_ int64) {
 		processedBlocks.Add(1)
 	})
 
@@ -3599,25 +3145,18 @@ func TestProcessBlocks_BlockFetchExhaustion(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	processor := NewConcurrentBlockProcessor(
-		blockHandler,
-		ethClient,
-		1, // workers.
-		2, // receiptWorkers.
-		0, // blocksPerMinute.
+		adapter, // chain.
+		1,       // workers.
+		0,       // blocksPerMinute.
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err = processor.ProcessBlocks(ctx, 100000, nil)
+	err := processor.ProcessBlocks(ctx, 100000, nil)
 	// Should exit due to context timeout (blocks keep failing).
 	assert.Error(t, err)
 }
@@ -3644,26 +3183,19 @@ func TestFetchAndProcessBlock_ContextCancelMainLoop(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	processor := NewConcurrentBlockProcessor(
-		blockHandler,
-		ethClient,
-		2,  // workers.
-		2,  // receiptWorkers.
-		60, // blocksPerMinute - rate limited to exercise more paths.
+		adapter, // chain.
+		2,       // workers.
+		60,      // blocksPerMinute - rate limited to exercise more paths.
 	)
 
 	// Cancel immediately to exercise the main dispatch loop's ctx.Done().
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	err = processor.ProcessBlocks(ctx, 100000, nil)
+	err := processor.ProcessBlocks(ctx, 100000, nil)
 	assert.Error(t, err)
 }
 
@@ -3947,55 +3479,6 @@ func TestStartIndexing_WithOpenBrowser(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------.
-// fetchAndProcessBlock — context cancel during receipt fetch (covers line 272-273).
-// ---------------------------------------------------------------------------.
-
-func TestFetchAndProcessBlock_ContextCancelDuringReceiptFetch(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-	td := testutils.SetupTestDefraDB(t)
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			return fullBlockResponseWithTx("0x3e8"), nil // block 1000 with tx.
-		case ethGetBlockReceipts:
-			return nil, fmt.Errorf("not supported")
-		case ethGetTransactionReceipt:
-			// Slow response to give time for cancellation.
-			time.Sleep(500 * time.Millisecond)
-			return map[string]any{
-				"transactionHash":           "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				"blockNumber":               "0x3e8",
-				constants.BlockHashKeyValue: "0x0000000000000000000000000000000000000000000000000000000000000001",
-				"gasUsed":                   "0x5208",
-				"status":                    "0x1",
-				"logs":                      []any{},
-			}, nil
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	result := p.fetchAndProcessBlock(ctx, 1000)
-	require.NotNil(t, result)
-	// May succeed or fail depending on timing, but shouldn't panic.
-}
-
-// ---------------------------------------------------------------------------.
 // GetPeerInfo — embedded node without P2P (covers lines 596+).
 // ---------------------------------------------------------------------------.
 
@@ -4182,16 +3665,11 @@ func TestFetchAndProcessBlock_TransactionConflictRetry(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	// Create two processors that share the same blockHandler.
-	p1 := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
-	p2 := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	// Create two processors that share the same adapter.
+	p1 := NewConcurrentBlockProcessor(adapter, 1, 0)
+	p2 := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	// Run both concurrently to try to trigger a transaction conflict.
 	var wg sync.WaitGroup
@@ -4217,8 +3695,8 @@ func TestFetchAndProcessBlock_TransactionConflictRetry(t *testing.T) {
 		}
 	}
 	assert.GreaterOrEqual(t, successCount, 1, "at least one concurrent block creation should succeed")
-	t.Logf("Result 1: success=%v, blockID=%s, err=%v", results[0].Success, results[0].BlockID, results[0].Error)
-	t.Logf("Result 2: success=%v, blockID=%s, err=%v", results[1].Success, results[1].BlockID, results[1].Error)
+	t.Logf("Result 1: success=%v, err=%v", results[0].Success, results[0].Error)
+	t.Logf("Result 2: success=%v, err=%v", results[1].Success, results[1].Error)
 }
 
 // ---------------------------------------------------------------------------.
@@ -4322,8 +3800,8 @@ func createClosedTestDefraNode(t *testing.T) *node.Node {
 // ---------------------------------------------------------------------------.
 
 // ---------------------------------------------------------------------------.
-// StartIndexing — GetHighestBlockNumber returns error (line 229),
-// This happens when blockHandler.GetHighestBlockNumber fails.
+// StartIndexing — GetHighestStoredBlockNumber returns error (line 229),
+// This happens when chain.GetHighestStoredBlockNumber fails.
 // In a fresh DB with no blocks, this returns an error naturally.
 // Let's ensure the "sets 0" path is covered.
 // ---------------------------------------------------------------------------.
@@ -4628,15 +4106,10 @@ func TestFetchAndProcessBlock_ContextCancelDuringConflictRetry(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	// First, insert the block to make subsequent inserts trigger "already exists".
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 	result1 := p.fetchAndProcessBlock(context.Background(), 0xdead1)
 	require.True(t, result1.Success)
 
@@ -4662,20 +4135,15 @@ func TestProcessBlocks_ImmediateCancel(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+	p := NewConcurrentBlockProcessor(adapter, 1, 0)
 
 	// Cancel immediately — should hit ctx.Done() in the dispatch loop.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err = p.ProcessBlocks(ctx, 100000, nil)
+	err := p.ProcessBlocks(ctx, 100000, nil)
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -4694,20 +4162,15 @@ func TestProcessBlocks_ImmediateCancelWithRateLimit(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	// Rate limited processor
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 30)
+	p := NewConcurrentBlockProcessor(adapter, 1, 30)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediate cancel
 
-	err = p.ProcessBlocks(ctx, 100000, nil)
+	err := p.ProcessBlocks(ctx, 100000, nil)
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -4770,53 +4233,6 @@ func TestGetPeerPublicKey_WithEmbeddedNode(t *testing.T) {
 // fetchAndProcessBlock — receipt fetch with batch receipts success,
 // (covers the batch receipt path in concurrent processor, not the fallback).
 // ---------------------------------------------------------------------------..
-func TestFetchAndProcessBlock_WithTxAndBatchReceipts(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-	td := testutils.SetupTestDefraDB(t)
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			return fullBlockResponseWithTx("0xbbb0"), nil
-		case ethGetBlockReceipts:
-			return []any{
-				map[string]any{
-					"transactionHash":           "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-					"transactionIndex":          "0x0",
-					constants.BlockHashKeyValue: "0x0000000000000000000000000000000000000000000000000000000000000001",
-					"blockNumber":               "0xbbb0",
-					"from":                      "0x0000000000000000000000000000000000000001",
-					"to":                        "0x0000000000000000000000000000000000000002",
-					"cumulativeGasUsed":         "0x5208",
-					"gasUsed":                   "0x5208",
-					"contractAddress":           nil,
-					"logs":                      []any{},
-					"logsBloom":                 "0x" + fmt.Sprintf("%0512x", 0),
-					"status":                    "0x1",
-					"effectiveGasPrice":         "0x4a817c800",
-					"type":                      "0x0",
-				},
-			}, nil
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
-
-	result := p.fetchAndProcessBlock(context.Background(), 0xbbb0)
-	require.NotNil(t, result)
-	assert.True(t, result.Success, "block with batch receipts should succeed: %v", result.Error)
-}
 
 // ---------------------------------------------------------------------------.
 // fetchAndProcessBlock — individual receipt success in fallback path,
@@ -4913,107 +4329,6 @@ func TestGetPeerInfo_P2PEnabled_NoNetworkHandler(t *testing.T) {
 	if info.Self != nil {
 		assert.NotEmpty(t, info.Self.ID)
 	}
-}
-
-func TestFetchAndProcessBlock_IndividualReceiptSuccess(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-	td := testutils.SetupTestDefraDB(t)
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			return fullBlockResponseWithTx("0xccc0"), nil
-		case ethGetBlockReceipts:
-			return nil, fmt.Errorf("not supported") // Force fallback.
-		case ethGetTransactionReceipt:
-			return map[string]any{
-				"transactionHash":           "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				"transactionIndex":          "0x0",
-				constants.BlockHashKeyValue: "0x0000000000000000000000000000000000000000000000000000000000000001",
-				"blockNumber":               "0xccc0",
-				"from":                      "0x0000000000000000000000000000000000000001",
-				"to":                        "0x0000000000000000000000000000000000000002",
-				"cumulativeGasUsed":         "0x5208",
-				"gasUsed":                   "0x5208",
-				"contractAddress":           nil,
-				"logs":                      []any{},
-				"logsBloom":                 "0x" + fmt.Sprintf("%0512x", 0),
-				"status":                    "0x1",
-				"effectiveGasPrice":         "0x4a817c800",
-				"type":                      "0x0",
-			}, nil
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
-
-	result := p.fetchAndProcessBlock(context.Background(), 0xccc0)
-	require.NotNil(t, result)
-	assert.True(t, result.Success, "block with individual receipt fallback should succeed: %v", result.Error)
-}
-
-// ---------------------------------------------------------------------------.
-// Helper: create a block response with multiple transactions for testing,
-// concurrent receipt fetching.
-// ---------------------------------------------------------------------------.
-
-func fullBlockResponseWithMultipleTxs(number string, count int) map[string]any {
-	txs := make([]any, count)
-	for i := range count {
-		txHash := fmt.Sprintf("0x%064x", i+1) // unique tx hashes
-		txs[i] = map[string]any{
-			"hash":                      txHash,
-			"nonce":                     fmt.Sprintf("0x%x", i),
-			constants.BlockHashKeyValue: "0x0000000000000000000000000000000000000000000000000000000000000001",
-			"blockNumber":               number,
-			"transactionIndex":          fmt.Sprintf("0x%x", i),
-			"from":                      "0x0000000000000000000000000000000000000001",
-			"to":                        "0x0000000000000000000000000000000000000002",
-			"value":                     "0x3e8",
-			"gas":                       "0x5208",
-			"gasPrice":                  "0x3b9aca00",
-			"input":                     "0x",
-			"v":                         "0x1b",
-			"r":                         "0x1111111111111111111111111111111111111111111111111111111111111111",
-			"s":                         "0x2222222222222222222222222222222222222222222222222222222222222222",
-			"type":                      "0x0",
-		}
-	}
-
-	block := map[string]any{
-		constants.NumberFieldValue: number,
-		"hash":                     "0x0000000000000000000000000000000000000000000000000000000000000001",
-		"parentHash":               "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"nonce":                    "0x0000000000000000",
-		"sha3Uncles":               "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-		"logsBloom":                "0x" + fmt.Sprintf("%0512x", 0),
-		"transactionsRoot":         "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-		"stateRoot":                "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"receiptsRoot":             "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"miner":                    "0x0000000000000000000000000000000000000000",
-		"difficulty":               "0x0",
-		"totalDifficulty":          "0x0",
-		"extraData":                "0x",
-		"size":                     "0x100",
-		"gasLimit":                 "0x1000000",
-		"gasUsed":                  "0x5208",
-		"timestamp":                "0x60000000",
-		"mixHash":                  "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"uncles":                   []any{},
-		"transactions":             txs,
-	}
-	return block
 }
 
 // ---------------------------------------------------------------------------.
@@ -5206,83 +4521,6 @@ func TestOpenBrowser_DarwinHappyPath(t *testing.T) {
 	defer func() { execCommand = original }()
 
 	openBrowser("about:blank")
-}
-
-// ---------------------------------------------------------------------------.
-// fetchAndProcessBlock — ctx cancel during individual receipt semaphore wait,
-// (covers concurrent_processor.go lines 272-273).
-// Uses receiptWorkers=1 with multiple transactions. The first tx's receipt,
-// fetch holds the semaphore while ctx is canceled, so the second tx hits,
-// the ctx.Done() branch at line 272.
-// ---------------------------------------------------------------------------.
-
-func TestFetchAndProcessBlock_CtxCancelDuringSemaphoreWait(t *testing.T) {
-	t.Parallel()
-	logger.InitConsoleOnly(true)
-	td := testutils.SetupTestDefraDB(t)
-
-	firstReceiptCalled := make(chan struct{})
-
-	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
-		switch method {
-		case ethGetBlockByNumber:
-			// Block with 3 transactions.
-			return fullBlockResponseWithMultipleTxs("0xddd0", 3), nil
-		case ethGetBlockReceipts:
-			// Force fallback to individual receipts.
-			return nil, fmt.Errorf("not supported")
-		case ethGetTransactionReceipt:
-			// Signal that the first receipt call is in progress, then block.
-			select {
-			case firstReceiptCalled <- struct{}{}:
-			default:
-			}
-			// Block for a long time to hold the semaphore.
-			time.Sleep(5 * time.Second)
-			return nil, fmt.Errorf("timeout")
-		default:
-			return "0x1", nil
-		}
-	})
-	defer rpcServer.Close()
-
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
-
-	// receiptWorkers=1 means only one goroutine can acquire the semaphore at a time.
-	p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 1, 0)
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	resultCh := make(chan *BlockResult, 1)
-	go func() {
-		resultCh <- p.fetchAndProcessBlock(ctx, 0xddd0)
-	}()
-
-	// Wait for the first receipt call to start (semaphore acquired).
-	select {
-	case <-firstReceiptCalled:
-		t.Log("First receipt call started, canceling context")
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for first receipt call")
-	}
-
-	// Give a tiny bit of time for the other goroutines to reach the semaphore select.
-	time.Sleep(100 * time.Millisecond)
-
-	// Cancel context — this should trigger ctx.Done() in the semaphore select for waiting goroutines.
-	cancel()
-
-	select {
-	case result := <-resultCh:
-		t.Logf("fetchAndProcessBlock result: success=%v, err=%v", result.Success, result.Error)
-	case <-time.After(15 * time.Second):
-		t.Fatal("timed out waiting for fetchAndProcessBlock to complete")
-	}
 }
 
 // ---------------------------------------------------------------------------.
@@ -5519,12 +4757,7 @@ func TestFetchAndProcessBlock_ConflictRetryCtxCancel(t *testing.T) {
 	})
 	defer rpcServer.Close()
 
-	ethClient, err := rpc.NewEthereumClient(rpcServer.URL, "", "", "X-Api-Key")
-	require.NoError(t, err)
-	defer func() { _ = ethClient.Close() }()
-
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	// Run many concurrent processors on the same block to maximize,
 	// the chance of hitting a transaction conflict (not already-exists).
@@ -5538,7 +4771,7 @@ func TestFetchAndProcessBlock_ConflictRetryCtxCancel(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			p := NewConcurrentBlockProcessor(blockHandler, ethClient, 1, 2, 0)
+			p := NewConcurrentBlockProcessor(adapter, 1, 0)
 			results[idx] = p.fetchAndProcessBlock(ctx, 0xeee0)
 		}(i)
 	}
@@ -5805,12 +5038,16 @@ func TestInitServices_MTLSMode_ReturnsError(t *testing.T) {
 		cfg:       cfg,
 	}
 
-	blockHandler, err := defra.NewBlockHandler(td.Node, 100, nil)
-	require.NoError(t, err)
+	rpcServer := newMockRPCServer(func(_ string, _ json.RawMessage) (any, error) {
+		return "0x1", nil
+	})
+	defer rpcServer.Close()
+
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	err = indexer.initServices(ctx, cfg, blockHandler)
+	err := indexer.initServices(ctx, cfg, adapter)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "schema auth configuration")
 	assert.ErrorIs(t, err, ErrMTLSNotImplemented)

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -2400,6 +2400,88 @@ func TestProcessBlocks_CancelDuringTooFarAhead(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ProcessBlocks — out-of-order completion is committed in nonce order.
+// ---------------------------------------------------------------------------
+
+// TestProcessBlocks_OutOfOrderCompletion verifies that collectResults commits
+// blocks strictly in ascending nonce order even when worker results arrive
+// out of order. Block 1002 is artificially slowed so that 1003–1005 complete
+// first; the hold-back loop must stash them in p.pending until 1002 arrives,
+// then commit 1002→1005 in a single pass. Blocks ≥1006 are parked on
+// ctx.Done() so collectResults sees exactly five results.
+//
+// This is a pure unit test: only testutils.MockChain is used (no DefraDB, no
+// RPC server). State is snapshotted BEFORE cancel() to avoid races with
+// parked workers waking up after cancellation.
+func TestProcessBlocks_OutOfOrderCompletion(t *testing.T) {
+	t.Parallel()
+	logger.InitConsoleOnly(true)
+
+	mc := &testutils.MockChain{
+		FetchAndStoreBlockFn: func(ctx context.Context, height int64) (string, error) {
+			switch {
+			case height == 1002:
+				// Slow 1002 so that workers 3/4/5 finish first, producing
+				// out-of-order arrival at resultChan.
+				time.Sleep(250 * time.Millisecond)
+				return fmt.Sprintf("0x%x", height), nil
+			case height >= 1006:
+				// Park extra blocks so collectResults sees no result beyond 1005.
+				<-ctx.Done()
+				return "", ctx.Err()
+			default:
+				return fmt.Sprintf("0x%x", height), nil
+			}
+		},
+	}
+
+	p := NewConcurrentBlockProcessor(mc, 4, 0)
+
+	var (
+		mu        sync.Mutex
+		committed []int64
+		done      = make(chan struct{})
+	)
+	callback := func(blockNum int64) {
+		mu.Lock()
+		committed = append(committed, blockNum)
+		if len(committed) == 5 {
+			close(done)
+		}
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- p.ProcessBlocks(ctx, 1001, callback)
+	}()
+
+	// Wait for all 5 callbacks to fire (settled state).
+	<-done
+
+	// Race-free snapshot: capture processor state BEFORE cancel() so parked
+	// workers (≥1006) waking up after cancel can't mutate pending/nextToCommit.
+	p.pendingMu.Lock()
+	snapNextToCommit := p.nextToCommit
+	snapPendingLen := len(p.pending)
+	p.pendingMu.Unlock()
+
+	mu.Lock()
+	snapCommitted := append([]int64(nil), committed...)
+	mu.Unlock()
+
+	cancel()
+	err := <-errCh
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int64(1006), snapNextToCommit, "nextToCommit should have advanced past all 5 blocks")
+	assert.Empty(t, snapPendingLen, "pending map should be drained after ordered commit")
+	assert.Equal(t, []int64{1001, 1002, 1003, 1004, 1005}, snapCommitted,
+		"committed blocks should be in strict nonce order despite out-of-order arrival")
+}
+
+// ---------------------------------------------------------------------------
 // GetPeerInfo — test peer deduplication with mock addresses
 // ---------------------------------------------------------------------------
 
@@ -3525,7 +3607,7 @@ func TestGetPeerInfo_WithEmbeddedNode_NoP2P(t *testing.T) {
 // ===========================================================================
 
 // ---------------------------------------------------------------------------
-// GetPeerInfo — full coverage with P2P enabled via app-sdk StartDefraInstance
+// GetPeerInfo — full coverage with P2P enabled via StartDefraInstance
 // This exercises: selfInfo construction (lines 601-612), peer dedup (624-638),
 // PeerInfo error path (596-598).
 // ---------------------------------------------------------------------------.

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -1995,6 +1995,21 @@ func TestStopIndexing_WithAllComponents(t *testing.T) {
 
 	td := testutils.SetupTestDefraDB(t)
 
+	// Create chain adapter (EVMAdapter) wired to a mock RPC server.
+	rpcServer := newMockRPCServer(func(method string, _ json.RawMessage) (any, error) {
+		switch method {
+		case ethGetBlockByNumber:
+			return fullBlockResponse("0x1", nil), nil
+		case ethGetBlockReceipts:
+			return []any{}, nil
+		default:
+			return "0x1", nil
+		}
+	})
+	defer rpcServer.Close()
+	adapter := newTestEVMAdapter(t, td, rpcServer.URL, 2)
+	require.NotNil(t, adapter)
+
 	// Create pruner.
 	p := pruner.NewPruner(&pruner.Config{
 		Enabled:   true,
@@ -2021,6 +2036,7 @@ func TestStopIndexing_WithAllComponents(t *testing.T) {
 	indexer := &ChainIndexer{
 		shouldIndex:    true,
 		isStarted:      true,
+		adapter:        adapter,
 		defraNode:      td.Node,
 		pruner:         p,
 		snapshotter:    s,
@@ -2029,10 +2045,13 @@ func TestStopIndexing_WithAllComponents(t *testing.T) {
 		cfg:            &config.Config{},
 	}
 
+	require.NotNil(t, indexer.adapter, "adapter should be set before StopIndexing")
+
 	indexer.StopIndexing()
 
 	assert.False(t, indexer.shouldIndex)
 	assert.False(t, indexer.isStarted)
+	assert.Nil(t, indexer.adapter, "StopIndexing should close and nil the adapter")
 	assert.Nil(t, indexer.defraNode)
 	assert.Nil(t, indexer.pruner)
 	assert.Nil(t, indexer.snapshotter)

--- a/pkg/testutils/mock_chain.go
+++ b/pkg/testutils/mock_chain.go
@@ -25,7 +25,7 @@ type MockChain struct {
 	mu sync.Mutex
 
 	// Optional overrides. When nil the method returns its zero value.
-	FetchAndStoreBlockFn          func(ctx context.Context, height int64) error
+	FetchAndStoreBlockFn          func(ctx context.Context, height int64) (string, error)
 	FetchHighestBlockNumberFn     func(ctx context.Context) (int64, error)
 	GetHighestStoredBlockNumberFn func(ctx context.Context) (int64, error)
 	GetLowestStoredBlockNumberFn  func(ctx context.Context) (int64, error)
@@ -44,14 +44,14 @@ type MockChain struct {
 }
 
 // FetchAndStoreBlock records the height and delegates to FetchAndStoreBlockFn.
-func (m *MockChain) FetchAndStoreBlock(ctx context.Context, height int64) error {
+func (m *MockChain) FetchAndStoreBlock(ctx context.Context, height int64) (string, error) {
 	m.mu.Lock()
 	m.FetchAndStoreBlockCalls = append(m.FetchAndStoreBlockCalls, height)
 	m.mu.Unlock()
 	if m.FetchAndStoreBlockFn != nil {
 		return m.FetchAndStoreBlockFn(ctx, height)
 	}
-	return nil
+	return "", nil
 }
 
 // FetchHighestBlockNumber records the call and delegates to FetchHighestBlockNumberFn.


### PR DESCRIPTION
# Pull Request

## Description
<!-- Briefly describe what this PR does and why -->

## Changes
- Updated `Chain` interface to return ID on `FetchAndStoreBlock` to match existing block commit flow.
- Replaced existing Ethereum-coupled flow in 'pkg/indexer/indexer.go`  and `pkg/indexer/concurrent_processor.go` with the chain-agnostic implementation of the `Chain` interface.
- Refactored  `pkg/indexer` 's tests to work with the chain-agnostic indexing flow and moved relevant tests to `pkg/chain`.

## Related Issue
#132 

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Verify core functionality works as expected (e.g., main page loads, API responds)

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
- Indexer tests are still dependent on `GethConfig`. This will be updated once Cosmos support is introduced in future PRs.
