### PR TITLE
refactor: chain-agnostic BlockHandler

### DIFF
--- a/pkg/chains/chains.go
+++ b/pkg/chains/chains.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/shinzonetwork/shinzo-generator-client/config"
-	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/node"
 )
 
@@ -199,12 +198,11 @@ type Fetcher interface {
 // call, keeping the Converter stateless and testable without a live DefraDB.
 type Converter interface {
 	// Convert transforms a raw block (returned by Fetcher.FetchBlock) into
-	// a set of DocumentGroups plus the name of the block-signature collection.
+	// a ConversionResult containing DocumentGroups, the block-signature
+	// collection name, and a LinkStamper for cross-document link resolution.
 	// The rawBlock parameter is typed as any to keep pkg/chains free of
 	// chain SDK imports; the concrete Converter type-asserts internally.
-	// The vp parameter supplies collection versions for in-memory docID
-	// computation used to set cross-document link fields (_blockID, etc.).
-	Convert(ctx context.Context, rawBlock any, vp CollectionVersionProvider) (groups []DocumentGroup, signatureCollection string, err error)
+	Convert(ctx context.Context, rawBlock any) (ConversionResult, error)
 
 	// GetSchema returns the GraphQL SDL for the configured chain, with
 	// collection names adapted to the chain's prefix.
@@ -237,19 +235,29 @@ type Converter interface {
 type DocumentGroup struct {
 	Collection string
 	Docs       []map[string]any
-	// ParentRef is a parallel array (one entry per Doc) carrying a parent reference
-	// key (e.g. a transaction hash) used by Store to resolve cross-document link
-	// fields (_transactionID) after AddDocument assigns persistent docIDs. It is
-	// never persisted to DefraDB — it exists solely for link resolution in Store
-	// when the target collection's schema has no natural join field (e.g. ALEs
-	// which have no transactionHash column). When the docs themselves carry a
-	// joinable field (e.g. logs have transactionHash), ParentRef may be left nil.
-	ParentRef []string
+	// BatchSize is the max documents per write transaction for this group.
+	// When 0, the BlockHandler uses its default maxDocsPerTxn.
+	BatchSize int
+	// BlockNumField is the field name in each doc that holds the block number
+	// (e.g. "number" for block docs, "blockNumber" for tx/log/ale docs).
+	// Used by BlockHandler.SignExisting to query stored docIDs by block number.
+	BlockNumField string
 }
 
-// CollectionVersionProvider resolves a collection name to its
-// client.CollectionVersion, used by Converters for in-memory DocID computation.
-// BlockHandler implements this so Converters never need a direct *node.Node.
-type CollectionVersionProvider interface {
-	CollectionVersion(ctx context.Context, name string) (client.CollectionVersion, error)
+// LinkStamper resolves cross-document link fields (_blockID, _transactionID)
+// after AddDocument assigns persistent docIDs. It mutates the groups' doc
+// maps in-place. Called by BlockHandler.Store in group order (block → tx →
+// log → ALE) so the stamper can build internal lookup maps as each group
+// is written.
+type LinkStamper interface {
+	StampLinks(groups []DocumentGroup, writtenCollection string, writtenDocs []map[string]any, writtenDocIDs []string)
+}
+
+// ConversionResult is the output of Converter.Convert — it bundles the
+// document groups, the signature collection name, and the chain-specific
+// LinkStamper needed for link resolution during Store.
+type ConversionResult struct {
+	Groups              []DocumentGroup
+	SignatureCollection string
+	LinkStamper         LinkStamper
 }

--- a/pkg/chains/chains.go
+++ b/pkg/chains/chains.go
@@ -237,6 +237,14 @@ type Converter interface {
 type DocumentGroup struct {
 	Collection string
 	Docs       []map[string]any
+	// ParentRef is a parallel array (one entry per Doc) carrying a parent reference
+	// key (e.g. a transaction hash) used by Store to resolve cross-document link
+	// fields (_transactionID) after AddDocument assigns persistent docIDs. It is
+	// never persisted to DefraDB — it exists solely for link resolution in Store
+	// when the target collection's schema has no natural join field (e.g. ALEs
+	// which have no transactionHash column). When the docs themselves carry a
+	// joinable field (e.g. logs have transactionHash), ParentRef may be left nil.
+	ParentRef []string
 }
 
 // CollectionVersionProvider resolves a collection name to its

--- a/pkg/chains/evm/adapter.go
+++ b/pkg/chains/evm/adapter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shinzonetwork/shinzo-generator-client/config"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/chains"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/defra"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/errors"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/logger"
@@ -37,8 +38,7 @@ const (
 type signingJob struct {
 	blockNum  int64
 	blockHash string
-	groups    []chains.DocumentGroup
-	sigCol    string
+	result    chains.ConversionResult
 }
 
 // Adapter is a Chain implementation backed by an EVM JSON-RPC endpoint and a
@@ -132,15 +132,10 @@ func (a *Adapter) Init(ctx context.Context, defraNode *node.Node) error {
 	if a.cfg == nil {
 		return errors.NewConfigurationError("chain", "Init", "config is nil", "", nil)
 	}
-	blockHandler, err := defra.NewBlockHandler(defraNode, a.cfg.Indexer.MaxDocsPerTxn, a.collections)
+	blockHandler, err := defra.NewBlockHandler(defraNode, a.cfg.Indexer.MaxDocsPerTxn)
 	if err != nil {
 		return fmt.Errorf("create block handler: %w", err)
 	}
-	blockHandler.SetBatchSizes(
-		a.cfg.Indexer.MaxTxDocsPerBatch,
-		a.cfg.Indexer.MaxLogDocsPerBatch,
-		a.cfg.Indexer.MaxALEDocsPerBatch,
-	)
 
 	a.blockHandler = blockHandler
 	a.node = defraNode
@@ -160,7 +155,7 @@ func (a *Adapter) signBlocks(ctx context.Context) {
 			continue
 		}
 		if _, err := a.blockHandler.SignExisting(
-			ctx, job.groups, job.sigCol, job.blockHash, job.blockNum, a.blockHandler,
+			ctx, job.result, job.blockHash, job.blockNum,
 		); err != nil {
 			logger.Sugar.Warnf("Block %d: failed to create block signature for existing block: %v", job.blockNum, err)
 		}
@@ -190,24 +185,24 @@ func (a *Adapter) FetchAndStoreBlock(ctx context.Context, height int64) (string,
 	if err != nil {
 		return "", err
 	}
-	groups, sigCol, err := a.converter.Convert(ctx, raw, a.blockHandler)
+	result, err := a.converter.Convert(ctx, raw)
 	if err != nil {
 		return "", fmt.Errorf("convert block: %w", err)
 	}
-	blockHash := extractBlockHashFromGroups(groups, a.collections)
-	return a.storeBlockWithRetry(ctx, groups, sigCol, blockHash, height)
+	blockHash := extractBlockHashFromGroups(result.Groups, a.collections)
+	return a.storeBlockWithRetry(ctx, result, blockHash, height)
 }
 
 // storeBlockWithRetry persists document groups via BlockHandler.Store. When
 // the block already exists a signing job is enqueued and nil is returned.
 // Transaction conflicts are retried up to maxRPCRetries times.
-func (a *Adapter) storeBlockWithRetry(ctx context.Context, groups []chains.DocumentGroup, sigCol, blockHash string, blockNum int64) (string, error) {
+func (a *Adapter) storeBlockWithRetry(ctx context.Context, result chains.ConversionResult, blockHash string, blockNum int64) (string, error) {
 	for attempt := range maxRPCRetries {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
 
-		res, err := a.blockHandler.Store(ctx, groups, sigCol, a.blockHandler)
+		res, err := a.blockHandler.Store(ctx, result)
 		if err == nil {
 			return res.BlockID, nil
 		}
@@ -217,8 +212,7 @@ func (a *Adapter) storeBlockWithRetry(ctx context.Context, groups []chains.Docum
 			case a.signingChan <- signingJob{
 				blockNum:  blockNum,
 				blockHash: blockHash,
-				groups:    groups,
-				sigCol:    sigCol,
+				result:    result,
 			}:
 			default:
 				logger.Sugar.Warnf("Block %d: signing queue full, skipping block signature", blockNum)
@@ -245,7 +239,7 @@ func (a *Adapter) storeBlockWithRetry(ctx context.Context, groups []chains.Docum
 func extractBlockHashFromGroups(groups []chains.DocumentGroup, cols *CollectionNames) string {
 	for _, g := range groups {
 		if g.Collection == cols.Block && len(g.Docs) > 0 {
-			if hash, ok := g.Docs[0]["hash"].(string); ok {
+			if hash, ok := g.Docs[0][constants.HashKeyValue].(string); ok {
 				return hash
 			}
 		}

--- a/pkg/chains/evm/adapter.go
+++ b/pkg/chains/evm/adapter.go
@@ -12,7 +12,6 @@ import (
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/errors"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/rpc"
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/types"
 	"github.com/sourcenetwork/defradb/node"
 )
 
@@ -36,11 +35,10 @@ const (
 
 // signingJob holds the data needed to sign an existing block in the background.
 type signingJob struct {
-	blockNum     int64
-	blockHash    string
-	block        *types.Block
-	transactions []*types.Transaction
-	receipts     []*types.TransactionReceipt
+	blockNum  int64
+	blockHash string
+	groups    []chains.DocumentGroup
+	sigCol    string
 }
 
 // Adapter is a Chain implementation backed by an EVM JSON-RPC endpoint and a
@@ -161,8 +159,8 @@ func (a *Adapter) signBlocks(ctx context.Context) {
 		if ctx.Err() != nil {
 			continue
 		}
-		if _, err := a.blockHandler.CreateBlockSignatureForExistingBlock(
-			ctx, job.blockNum, job.blockHash, job.block, job.transactions, job.receipts,
+		if _, err := a.blockHandler.SignExisting(
+			ctx, job.groups, job.sigCol, job.blockHash, job.blockNum, a.blockHandler,
 		); err != nil {
 			logger.Sugar.Warnf("Block %d: failed to create block signature for existing block: %v", job.blockNum, err)
 		}
@@ -192,35 +190,35 @@ func (a *Adapter) FetchAndStoreBlock(ctx context.Context, height int64) (string,
 	if err != nil {
 		return "", err
 	}
-	bundle, ok := raw.(*BlockBundle)
-	if !ok {
-		return "", fmt.Errorf("unexpected fetch result type %T", raw)
+	groups, sigCol, err := a.converter.Convert(ctx, raw, a.blockHandler)
+	if err != nil {
+		return "", fmt.Errorf("convert block: %w", err)
 	}
-	return a.createBlockBatchWithRetry(ctx, bundle.Block, height, bundle.Transactions, bundle.Receipts)
+	blockHash := extractBlockHashFromGroups(groups, a.collections)
+	return a.storeBlockWithRetry(ctx, groups, sigCol, blockHash, height)
 }
 
-// createBlockBatchWithRetry persists the block batch via the BlockHandler. When
+// storeBlockWithRetry persists document groups via BlockHandler.Store. When
 // the block already exists a signing job is enqueued and nil is returned.
 // Transaction conflicts are retried up to maxRPCRetries times.
-func (a *Adapter) createBlockBatchWithRetry(ctx context.Context, block *types.Block, blockNum int64, transactions []*types.Transaction, receipts []*types.TransactionReceipt) (string, error) {
+func (a *Adapter) storeBlockWithRetry(ctx context.Context, groups []chains.DocumentGroup, sigCol, blockHash string, blockNum int64) (string, error) {
 	for attempt := range maxRPCRetries {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
 
-		blockID, err := a.blockHandler.CreateBlockBatch(ctx, block, transactions, receipts)
+		res, err := a.blockHandler.Store(ctx, groups, sigCol, a.blockHandler)
 		if err == nil {
-			return blockID, nil
+			return res.BlockID, nil
 		}
 
 		if errors.IsErrAlreadyExists(err) {
 			select {
 			case a.signingChan <- signingJob{
-				blockNum:     blockNum,
-				blockHash:    block.Hash,
-				block:        block,
-				transactions: transactions,
-				receipts:     receipts,
+				blockNum:  blockNum,
+				blockHash: blockHash,
+				groups:    groups,
+				sigCol:    sigCol,
 			}:
 			default:
 				logger.Sugar.Warnf("Block %d: signing queue full, skipping block signature", blockNum)
@@ -238,9 +236,21 @@ func (a *Adapter) createBlockBatchWithRetry(ctx context.Context, block *types.Bl
 			continue
 		}
 
-		return "", fmt.Errorf("failed to create block batch: %w", err)
+		return "", fmt.Errorf("failed to store block: %w", err)
 	}
 	return "", nil
+}
+
+// extractBlockHashFromGroups finds the block group and returns its "hash" value.
+func extractBlockHashFromGroups(groups []chains.DocumentGroup, cols *CollectionNames) string {
+	for _, g := range groups {
+		if g.Collection == cols.Block && len(g.Docs) > 0 {
+			if hash, ok := g.Docs[0]["hash"].(string); ok {
+				return hash
+			}
+		}
+	}
+	return ""
 }
 
 // GetHighestStoredBlockNumber implements Chain.

--- a/pkg/chains/evm/converter.go
+++ b/pkg/chains/evm/converter.go
@@ -56,29 +56,28 @@ func NewConverter(cfg *config.Config) *Converter {
 // and builds DocumentGroups for block, transactions, logs, and access list
 // entries. The data maps contain only field values — cross-document link fields
 // (_blockID, _transactionID) are NOT set here; they are resolved by
-// BlockHandler.Store (Phase D) after AddDocument assigns persistent docIDs.
+// BlockHandler.Store via the returned LinkStamper after AddDocument assigns
+// persistent docIDs.
 //
-// The vp (CollectionVersionProvider) parameter is retained in the interface
-// signature for future use but is not needed by the current implementation.
-//
-// The signature collection name is returned as the second value; the signature
-// document itself is built later by BlockHandler during signing (Phase D).
+// Each group is tagged with BatchSize (from config) and BlockNumField (the
+// field name holding the block number in each doc map). The signature
+// collection name is returned inside the ConversionResult; the signature
+// document itself is built later by BlockHandler during signing.
 func (c *Converter) Convert(
 	_ context.Context,
 	rawBlock any,
-	_ chains.CollectionVersionProvider,
-) ([]chains.DocumentGroup, string, error) {
+) (chains.ConversionResult, error) {
 	bundle, ok := rawBlock.(*BlockBundle)
 	if !ok {
-		return nil, "", fmt.Errorf("converter: expected *BlockBundle, got %T", rawBlock)
+		return chains.ConversionResult{}, fmt.Errorf("converter: expected *BlockBundle, got %T", rawBlock)
 	}
 	if bundle == nil || bundle.Block == nil {
-		return nil, "", fmt.Errorf("converter: nil block in bundle")
+		return chains.ConversionResult{}, fmt.Errorf("converter: nil block in bundle")
 	}
 
 	blockInt, err := utils.HexToInt(bundle.Block.Number)
 	if err != nil {
-		return nil, "", fmt.Errorf("converter: parse block number: %w", err)
+		return chains.ConversionResult{}, fmt.Errorf("converter: parse block number: %w", err)
 	}
 
 	blockData := c.buildBlockData(bundle.Block, blockInt)
@@ -87,24 +86,77 @@ func (c *Converter) Convert(
 	logDocs := c.buildLogDocs(bundle.Transactions, receiptMap)
 	aleDocs, aleParentRefs := c.buildALEDocs(bundle.Transactions, blockInt)
 
+	defaultBatch := c.maxDocsPerTxn()
+
 	groups := []chains.DocumentGroup{
-		{Collection: c.collections.Block, Docs: []map[string]any{blockData}},
+		{
+			Collection:    c.collections.Block,
+			Docs:          []map[string]any{blockData},
+			BatchSize:     defaultBatch,
+			BlockNumField: constants.NumberFieldValue,
+		},
 	}
 	if len(txDocs) > 0 {
-		groups = append(groups, chains.DocumentGroup{Collection: c.collections.Transaction, Docs: txDocs})
+		groups = append(groups, chains.DocumentGroup{
+			Collection:    c.collections.Transaction,
+			Docs:          txDocs,
+			BatchSize:     c.txBatchSize(defaultBatch),
+			BlockNumField: constants.BlockNumberKeyValue,
+		})
 	}
 	if len(logDocs) > 0 {
-		groups = append(groups, chains.DocumentGroup{Collection: c.collections.Log, Docs: logDocs})
+		groups = append(groups, chains.DocumentGroup{
+			Collection:    c.collections.Log,
+			Docs:          logDocs,
+			BatchSize:     c.logBatchSize(defaultBatch),
+			BlockNumField: constants.BlockNumberKeyValue,
+		})
 	}
 	if len(aleDocs) > 0 {
 		groups = append(groups, chains.DocumentGroup{
-			Collection: c.collections.AccessListEntry,
-			Docs:       aleDocs,
-			ParentRef:  aleParentRefs,
+			Collection:    c.collections.AccessListEntry,
+			Docs:          aleDocs,
+			BatchSize:     c.aleBatchSize(defaultBatch),
+			BlockNumField: constants.BlockNumberKeyValue,
 		})
 	}
 
-	return groups, c.collections.BlockSignature, nil
+	stamper := newEvmLinkStamper(c.collections, aleParentRefs)
+
+	return chains.ConversionResult{
+		Groups:              groups,
+		SignatureCollection: c.collections.BlockSignature,
+		LinkStamper:         stamper,
+	}, nil
+}
+
+// maxDocsPerTxn returns the configured default batch size for BlockHandler.
+func (c *Converter) maxDocsPerTxn() int {
+	if c.cfg != nil && c.cfg.Indexer.MaxDocsPerTxn > 0 {
+		return c.cfg.Indexer.MaxDocsPerTxn
+	}
+	return 1000 //nolint:mnd
+}
+
+func (c *Converter) txBatchSize(defaultBatch int) int {
+	if c.cfg != nil && c.cfg.Indexer.MaxTxDocsPerBatch > 0 {
+		return c.cfg.Indexer.MaxTxDocsPerBatch
+	}
+	return defaultBatch
+}
+
+func (c *Converter) logBatchSize(defaultBatch int) int {
+	if c.cfg != nil && c.cfg.Indexer.MaxLogDocsPerBatch > 0 {
+		return c.cfg.Indexer.MaxLogDocsPerBatch
+	}
+	return defaultBatch
+}
+
+func (c *Converter) aleBatchSize(defaultBatch int) int {
+	if c.cfg != nil && c.cfg.Indexer.MaxALEDocsPerBatch > 0 {
+		return c.cfg.Indexer.MaxALEDocsPerBatch
+	}
+	return defaultBatch
 }
 
 // buildTransactionDocs builds data maps for all non-nil transactions in the bundle.
@@ -150,7 +202,7 @@ func (c *Converter) buildLogDocs(txs []*types.Transaction, receiptMap map[string
 
 // buildALEDocs builds data maps for all access list entries across transactions.
 // It also returns a parallel slice of parent transaction hashes (one per doc)
-// so BlockHandler.Store can resolve _transactionID links without requiring a
+// used by the LinkStamper to resolve _transactionID links without requiring a
 // transactionHash field on the ALE schema.
 func (c *Converter) buildALEDocs(txs []*types.Transaction, blockInt int64) ([]map[string]any, []string) {
 	var docs []map[string]any
@@ -226,7 +278,7 @@ func (c *Converter) GetDocIDsByBlockRange(ctx context.Context, n *node.Node, fro
 // buildBlockData builds the data map for a block document.
 func (c *Converter) buildBlockData(block *types.Block, blockInt int64) map[string]any {
 	return map[string]any{
-		"hash":                     block.Hash,
+		constants.HashKeyValue:     block.Hash,
 		constants.NumberFieldValue: blockInt,
 		"timestamp":                block.Timestamp,
 		"parentHash":               block.ParentHash,
@@ -255,7 +307,7 @@ func (c *Converter) buildBlockData(block *types.Block, blockInt int64) map[strin
 func (c *Converter) buildTransactionData(tx *types.Transaction) map[string]any {
 	txBlockNum, _ := strconv.ParseInt(tx.BlockNumber, 10, 64)
 	return map[string]any{
-		"hash":                        tx.Hash,
+		constants.HashKeyValue:        tx.Hash,
 		constants.BlockNumberKeyValue: txBlockNum,
 		constants.BlockHashKeyValue:   tx.BlockHash,
 		"transactionIndex":            tx.TransactionIndex,
@@ -285,25 +337,25 @@ func (c *Converter) buildTransactionData(tx *types.Transaction) map[string]any {
 func (c *Converter) buildLogData(logEntry *types.Log) map[string]any {
 	logBlockNum, _ := utils.HexToInt(logEntry.BlockNumber)
 	return map[string]any{
-		"address":                     logEntry.Address,
-		"topics":                      logEntry.Topics,
-		"data":                        logEntry.Data,
-		constants.BlockNumberKeyValue: logBlockNum,
-		"transactionHash":             logEntry.TransactionHash,
-		"transactionIndex":            logEntry.TransactionIndex,
-		constants.BlockHashKeyValue:   logEntry.BlockHash,
-		"logIndex":                    logEntry.LogIndex,
-		"removed":                     fmt.Sprintf("%v", logEntry.Removed),
+		constants.AddressKeyValue:         logEntry.Address,
+		"topics":                          logEntry.Topics,
+		"data":                            logEntry.Data,
+		constants.BlockNumberKeyValue:     logBlockNum,
+		constants.TransactionHashKeyValue: logEntry.TransactionHash,
+		"transactionIndex":                logEntry.TransactionIndex,
+		constants.BlockHashKeyValue:       logEntry.BlockHash,
+		"logIndex":                        logEntry.LogIndex,
+		"removed":                         fmt.Sprintf("%v", logEntry.Removed),
 	}
 }
 
 // buildALEData builds the data map for an access list entry document.
-// Link fields (_transactionID) are NOT set here; BlockHandler.Store resolves
-// them after AddDocument assigns the tx docID, using the ParentRef parallel
-// array on the DocumentGroup.
+// Link fields (_transactionID) are NOT set here; the LinkStamper resolves
+// them after AddDocument assigns the tx docID, using the parent refs
+// parallel array passed to newEvmLinkStamper.
 func (c *Converter) buildALEData(ale *types.AccessListEntry, blockNumber int64) map[string]any {
 	return map[string]any{
-		"address":                     ale.Address,
+		constants.AddressKeyValue:     ale.Address,
 		constants.BlockNumberKeyValue: blockNumber,
 		"storageKeys":                 ale.StorageKeys,
 	}

--- a/pkg/chains/evm/converter.go
+++ b/pkg/chains/evm/converter.go
@@ -85,7 +85,7 @@ func (c *Converter) Convert(
 	txDocs := c.buildTransactionDocs(bundle)
 	receiptMap := c.buildReceiptMap(bundle.Receipts)
 	logDocs := c.buildLogDocs(bundle.Transactions, receiptMap)
-	aleDocs := c.buildALEDocs(bundle.Transactions, blockInt)
+	aleDocs, aleParentRefs := c.buildALEDocs(bundle.Transactions, blockInt)
 
 	groups := []chains.DocumentGroup{
 		{Collection: c.collections.Block, Docs: []map[string]any{blockData}},
@@ -97,7 +97,11 @@ func (c *Converter) Convert(
 		groups = append(groups, chains.DocumentGroup{Collection: c.collections.Log, Docs: logDocs})
 	}
 	if len(aleDocs) > 0 {
-		groups = append(groups, chains.DocumentGroup{Collection: c.collections.AccessListEntry, Docs: aleDocs})
+		groups = append(groups, chains.DocumentGroup{
+			Collection: c.collections.AccessListEntry,
+			Docs:       aleDocs,
+			ParentRef:  aleParentRefs,
+		})
 	}
 
 	return groups, c.collections.BlockSignature, nil
@@ -145,17 +149,22 @@ func (c *Converter) buildLogDocs(txs []*types.Transaction, receiptMap map[string
 }
 
 // buildALEDocs builds data maps for all access list entries across transactions.
-func (c *Converter) buildALEDocs(txs []*types.Transaction, blockInt int64) []map[string]any {
+// It also returns a parallel slice of parent transaction hashes (one per doc)
+// so BlockHandler.Store can resolve _transactionID links without requiring a
+// transactionHash field on the ALE schema.
+func (c *Converter) buildALEDocs(txs []*types.Transaction, blockInt int64) ([]map[string]any, []string) {
 	var docs []map[string]any
+	var parentRefs []string
 	for _, tx := range txs {
 		if tx == nil {
 			continue
 		}
 		for i := range tx.AccessList {
 			docs = append(docs, c.buildALEData(&tx.AccessList[i], blockInt))
+			parentRefs = append(parentRefs, tx.Hash)
 		}
 	}
-	return docs
+	return docs, parentRefs
 }
 
 // GetSchema implements chains.Converter. It delegates to the schema loader,
@@ -290,7 +299,8 @@ func (c *Converter) buildLogData(logEntry *types.Log) map[string]any {
 
 // buildALEData builds the data map for an access list entry document.
 // Link fields (_transactionID) are NOT set here; BlockHandler.Store resolves
-// them after AddDocument assigns the tx docID.
+// them after AddDocument assigns the tx docID, using the ParentRef parallel
+// array on the DocumentGroup.
 func (c *Converter) buildALEData(ale *types.AccessListEntry, blockNumber int64) map[string]any {
 	return map[string]any{
 		"address":                     ale.Address,

--- a/pkg/chains/evm/converter.go
+++ b/pkg/chains/evm/converter.go
@@ -29,10 +29,10 @@ var errBlockNumberCorrupt = fmt.Errorf("block exists but has invalid or unparsea
 // Converter never stores a *node.Node — it receives one explicitly on each
 // progress-query call, keeping it stateless and testable without a live DB.
 //
-// Coexistence (Phase C): the original build helpers remain in
-// pkg/defra/block_handler.go for the old CreateBlockBatch path. This
-// converter's helpers are the new path that BlockHandler.Store (Phase D)
-// will consume. Phase G removes the duplicates.
+// Coexistence (Phase C): the original build helpers were moved here from
+// pkg/defra/block_handler.go. BlockHandler.Store (Phase D) consumes the
+// DocumentGroups produced by this converter. Phase G removes any
+// remaining duplicates.
 type Converter struct {
 	collections *CollectionNames
 	cfg         *config.Config

--- a/pkg/chains/evm/converter_test.go
+++ b/pkg/chains/evm/converter_test.go
@@ -103,10 +103,10 @@ func TestConvert_TypeMismatch(t *testing.T) {
 	cfg := testConfig()
 	c := NewConverter(cfg)
 
-	groups, sigCol, err := c.Convert(context.Background(), "not a bundle", nil)
+	result, err := c.Convert(context.Background(), "not a bundle")
 	assert.Error(t, err)
-	assert.Nil(t, groups)
-	assert.Empty(t, sigCol)
+	assert.Nil(t, result.Groups)
+	assert.Empty(t, result.SignatureCollection)
 }
 
 func TestConvert_NilVP(t *testing.T) {
@@ -117,10 +117,10 @@ func TestConvert_NilVP(t *testing.T) {
 	// Convert no longer uses vp (link-ID pre-computation removed); nil vp
 	// should succeed for a block-only bundle.
 	bundle := &BlockBundle{Block: fakeBlock(1)}
-	groups, sigCol, err := c.Convert(context.Background(), bundle, nil)
+	result, err := c.Convert(context.Background(), bundle)
 	require.NoError(t, err)
-	require.Len(t, groups, 1)
-	assert.Equal(t, c.collections.BlockSignature, sigCol)
+	require.Len(t, result.Groups, 1)
+	assert.Equal(t, c.collections.BlockSignature, result.SignatureCollection)
 }
 
 func TestConvert_NilBlockInBundle(t *testing.T) {
@@ -128,9 +128,9 @@ func TestConvert_NilBlockInBundle(t *testing.T) {
 	cfg := testConfig()
 	c := NewConverter(cfg)
 
-	groups, _, err := c.Convert(context.Background(), &BlockBundle{}, nil)
+	result, err := c.Convert(context.Background(), &BlockBundle{})
 	assert.Error(t, err)
-	assert.Nil(t, groups)
+	assert.Nil(t, result.Groups)
 }
 
 func TestConvert_EmptyBlock(t *testing.T) {
@@ -141,13 +141,13 @@ func TestConvert_EmptyBlock(t *testing.T) {
 	block := fakeBlock(42)
 	bundle := &BlockBundle{Block: block, Transactions: nil, Receipts: nil}
 
-	groups, sigCol, err := c.Convert(context.Background(), bundle, nil)
+	result, err := c.Convert(context.Background(), bundle)
 	require.NoError(t, err)
-	require.Len(t, groups, 1) // only block group
-	assert.Equal(t, c.collections.Block, groups[0].Collection)
-	require.Len(t, groups[0].Docs, 1)
-	assert.Equal(t, int64(42), groups[0].Docs[0][constants.NumberFieldValue])
-	assert.Equal(t, c.collections.BlockSignature, sigCol)
+	require.Len(t, result.Groups, 1) // only block group
+	assert.Equal(t, c.collections.Block, result.Groups[0].Collection)
+	require.Len(t, result.Groups[0].Docs, 1)
+	assert.Equal(t, int64(42), result.Groups[0].Docs[0][constants.NumberFieldValue])
+	assert.Equal(t, c.collections.BlockSignature, result.SignatureCollection)
 }
 
 func TestConvert_BlockBundleToDocumentGroups(t *testing.T) {
@@ -176,21 +176,21 @@ func TestConvert_BlockBundleToDocumentGroups(t *testing.T) {
 		Receipts:     []*types.TransactionReceipt{receipt},
 	}
 
-	groups, sigCol, err := c.Convert(context.Background(), bundle, nil)
+	result, err := c.Convert(context.Background(), bundle)
 	require.NoError(t, err)
-	assert.Equal(t, c.collections.BlockSignature, sigCol)
+	assert.Equal(t, c.collections.BlockSignature, result.SignatureCollection)
 
 	// Block group
-	require.GreaterOrEqual(t, len(groups), 2)
-	assert.Equal(t, c.collections.Block, groups[0].Collection)
-	require.Len(t, groups[0].Docs, 1)
-	assert.Equal(t, block.Hash, groups[0].Docs[0]["hash"])
+	require.GreaterOrEqual(t, len(result.Groups), 2)
+	assert.Equal(t, c.collections.Block, result.Groups[0].Collection)
+	require.Len(t, result.Groups[0].Docs, 1)
+	assert.Equal(t, block.Hash, result.Groups[0].Docs[0][constants.HashKeyValue])
 
 	// Transaction group
-	assert.Equal(t, c.collections.Transaction, groups[1].Collection)
-	require.Len(t, groups[1].Docs, 1)
-	txData := groups[1].Docs[0]
-	assert.Equal(t, txHash, txData["hash"])
+	assert.Equal(t, c.collections.Transaction, result.Groups[1].Collection)
+	require.Len(t, result.Groups[1].Docs, 1)
+	txData := result.Groups[1].Docs[0]
+	assert.Equal(t, txHash, txData[constants.HashKeyValue])
 
 	// _blockID and _transactionID are NOT set by Convert; they are resolved
 	// by BlockHandler.Store (Phase D) after AddDocument assigns persistent docIDs.
@@ -198,10 +198,10 @@ func TestConvert_BlockBundleToDocumentGroups(t *testing.T) {
 	assert.False(t, hasBlockID, "_blockID should not be set by Convert")
 
 	// Log group (if present)
-	if len(groups) >= 3 {
-		assert.Equal(t, c.collections.Log, groups[2].Collection)
-		require.Len(t, groups[2].Docs, 1)
-		logData := groups[2].Docs[0]
+	if len(result.Groups) >= 3 {
+		assert.Equal(t, c.collections.Log, result.Groups[2].Collection)
+		require.Len(t, result.Groups[2].Docs, 1)
+		logData := result.Groups[2].Docs[0]
 		_, hasLogBlockID := logData["_blockID"]
 		assert.False(t, hasLogBlockID, "_blockID should not be set by Convert")
 		_, hasTxID := logData["_transactionID"]
@@ -218,9 +218,9 @@ func TestConvert_SignatureCollectionName(t *testing.T) {
 	block := fakeBlock(1)
 	bundle := &BlockBundle{Block: block}
 
-	_, sigCol, err := c.Convert(context.Background(), bundle, nil)
+	result, err := c.Convert(context.Background(), bundle)
 	require.NoError(t, err)
-	assert.Equal(t, "Optimism__Mainnet__BlockSignature", sigCol)
+	assert.Equal(t, "Optimism__Mainnet__BlockSignature", result.SignatureCollection)
 }
 
 func TestConvert_WithAccessListEntries(t *testing.T) {
@@ -242,19 +242,19 @@ func TestConvert_WithAccessListEntries(t *testing.T) {
 		Receipts:     []*types.TransactionReceipt{fakeReceipt(txHash, 16)},
 	}
 
-	groups, _, err := c.Convert(context.Background(), bundle, nil)
+	result, err := c.Convert(context.Background(), bundle)
 	require.NoError(t, err)
 
 	var aleGroup *chains.DocumentGroup
-	for i := range groups {
-		if groups[i].Collection == c.collections.AccessListEntry {
-			aleGroup = &groups[i]
+	for i := range result.Groups {
+		if result.Groups[i].Collection == c.collections.AccessListEntry {
+			aleGroup = &result.Groups[i]
 			break
 		}
 	}
 	require.NotNil(t, aleGroup, "should have an ALE group")
 	assert.Len(t, aleGroup.Docs, 2)
-	assert.Equal(t, "0x0000000000000000000000000000000000000001", aleGroup.Docs[0]["address"])
+	assert.Equal(t, "0x0000000000000000000000000000000000000001", aleGroup.Docs[0][constants.AddressKeyValue])
 }
 
 // ---------------------------------------------------------------------------
@@ -311,7 +311,7 @@ func TestMockConverter_SatisfiesInterface(t *testing.T) {
 func TestMockConverter_ConvertNotSet(t *testing.T) {
 	t.Parallel()
 	m := &testutils.MockConverter{}
-	_, _, err := m.Convert(context.Background(), nil, nil)
+	_, err := m.Convert(context.Background(), nil)
 	assert.ErrorIs(t, err, testutils.ErrMockConvertFnNotSet)
 	assert.Len(t, m.ConvertCalls, 1)
 }
@@ -321,13 +321,16 @@ func TestMockConverter_ConvertFn(t *testing.T) {
 	m := &testutils.MockConverter{}
 	expectedGroups := []chains.DocumentGroup{{Collection: "test", Docs: []map[string]any{{"foo": "bar"}}}}
 	expectedSigCol := "sigCol"
-	m.ConvertFn = func(_ context.Context, _ any, _ chains.CollectionVersionProvider) ([]chains.DocumentGroup, string, error) {
-		return expectedGroups, expectedSigCol, nil
+	m.ConvertFn = func(_ context.Context, _ any) (chains.ConversionResult, error) {
+		return chains.ConversionResult{
+			Groups:              expectedGroups,
+			SignatureCollection: expectedSigCol,
+		}, nil
 	}
-	groups, sigCol, err := m.Convert(context.Background(), &BlockBundle{}, nil)
+	result, err := m.Convert(context.Background(), &BlockBundle{})
 	require.NoError(t, err)
-	assert.Equal(t, expectedGroups, groups)
-	assert.Equal(t, expectedSigCol, sigCol)
+	assert.Equal(t, expectedGroups, result.Groups)
+	assert.Equal(t, expectedSigCol, result.SignatureCollection)
 	assert.Len(t, m.ConvertCalls, 1)
 }
 

--- a/pkg/chains/evm/link_stamper.go
+++ b/pkg/chains/evm/link_stamper.go
@@ -1,0 +1,73 @@
+package evm
+
+import (
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/chains"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/constants"
+)
+
+// evmLinkStamper implements chains.LinkStamper for EVM chains. It resolves
+// cross-document link fields (_blockID, _transactionID) after AddDocument
+// assigns persistent docIDs.
+//
+// Mutable state: txHashToID and blockID are populated as StampLinks is called
+// in group order (block → tx → log → ALE). This order is naturally enforced by
+// the group slice returned by Convert.
+type evmLinkStamper struct {
+	aleParentRefs []string
+	cols          *CollectionNames
+	txHashToID    map[string]string
+	blockID       string
+}
+
+// newEvmLinkStamper creates an evmLinkStamper with the given collection names
+// and ALE parent references (one per ALE doc, holding the parent tx hash).
+func newEvmLinkStamper(cols *CollectionNames, aleParentRefs []string) *evmLinkStamper {
+	return &evmLinkStamper{
+		aleParentRefs: aleParentRefs,
+		cols:          cols,
+		txHashToID:    make(map[string]string),
+	}
+}
+
+// StampLinks implements chains.LinkStamper. It dispatches by writtenCollection
+// and mutates the groups' doc maps in-place.
+func (s *evmLinkStamper) StampLinks(
+	_ []chains.DocumentGroup,
+	writtenCollection string,
+	writtenDocs []map[string]any,
+	writtenDocIDs []string,
+) {
+	switch writtenCollection {
+	case s.cols.Block:
+		if len(writtenDocIDs) > 0 {
+			s.blockID = writtenDocIDs[0]
+		}
+
+	case s.cols.Transaction:
+		for j := range writtenDocs {
+			writtenDocs[j]["_blockID"] = s.blockID
+			txHash, _ := writtenDocs[j][constants.HashKeyValue].(string)
+			if j < len(writtenDocIDs) {
+				s.txHashToID[txHash] = writtenDocIDs[j]
+			}
+		}
+
+	case s.cols.Log:
+		for j := range writtenDocs {
+			writtenDocs[j]["_blockID"] = s.blockID
+			txHash, _ := writtenDocs[j][constants.TransactionHashKeyValue].(string)
+			if txID, ok := s.txHashToID[txHash]; ok {
+				writtenDocs[j]["_transactionID"] = txID
+			}
+		}
+
+	case s.cols.AccessListEntry:
+		for j := range writtenDocs {
+			if j < len(s.aleParentRefs) {
+				if txID, ok := s.txHashToID[s.aleParentRefs[j]]; ok {
+					writtenDocs[j]["_transactionID"] = txID
+				}
+			}
+		}
+	}
+}

--- a/pkg/chains/evm/link_stamper_test.go
+++ b/pkg/chains/evm/link_stamper_test.go
@@ -1,0 +1,181 @@
+package evm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/chains"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/constants"
+)
+
+func TestStampLinks_Block(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, nil)
+
+	blockDocs := []map[string]any{{constants.HashKeyValue: "0xabc"}}
+	blockIDs := []string{"block-doc-id-1"}
+
+	s.StampLinks(nil, cols.Block, blockDocs, blockIDs)
+
+	assert.Equal(t, "block-doc-id-1", s.blockID)
+}
+
+func TestStampLinks_Transaction(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, nil)
+	s.blockID = "block-doc-id-1"
+
+	txDocs := []map[string]any{
+		{constants.HashKeyValue: "0xtx1"},
+		{constants.HashKeyValue: "0xtx2"},
+	}
+	txIDs := []string{"tx-doc-id-1", "tx-doc-id-2"}
+
+	s.StampLinks(nil, cols.Transaction, txDocs, txIDs)
+
+	assert.Equal(t, "block-doc-id-1", txDocs[0]["_blockID"])
+	assert.Equal(t, "block-doc-id-1", txDocs[1]["_blockID"])
+	assert.Equal(t, "tx-doc-id-1", s.txHashToID["0xtx1"])
+	assert.Equal(t, "tx-doc-id-2", s.txHashToID["0xtx2"])
+}
+
+func TestStampLinks_Log(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, nil)
+	s.blockID = "block-doc-id-1"
+	s.txHashToID["0xtx1"] = "tx-doc-id-1"
+
+	logDocs := []map[string]any{
+		{constants.TransactionHashKeyValue: "0xtx1"},
+	}
+	logIDs := []string{"log-doc-id-1"}
+
+	s.StampLinks(nil, cols.Log, logDocs, logIDs)
+
+	assert.Equal(t, "block-doc-id-1", logDocs[0]["_blockID"])
+	assert.Equal(t, "tx-doc-id-1", logDocs[0]["_transactionID"])
+}
+
+func TestStampLinks_Log_TxNotYetStamped(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, nil)
+	s.blockID = "block-doc-id-1"
+
+	logDocs := []map[string]any{
+		{constants.TransactionHashKeyValue: "0xunknown"},
+	}
+
+	s.StampLinks(nil, cols.Log, logDocs, []string{"log-doc-id-1"})
+
+	assert.Equal(t, "block-doc-id-1", logDocs[0]["_blockID"])
+	_, hasTxID := logDocs[0]["_transactionID"]
+	assert.False(t, hasTxID, "_transactionID should not be set when tx hash is unknown")
+}
+
+func TestStampLinks_AccessListEntry(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, []string{"0xtx1", "0xtx2"})
+	s.txHashToID["0xtx1"] = "tx-doc-id-1"
+	s.txHashToID["0xtx2"] = "tx-doc-id-2"
+
+	aleDocs := []map[string]any{
+		{constants.AddressKeyValue: "0x01"},
+		{constants.AddressKeyValue: "0x02"},
+	}
+
+	s.StampLinks(nil, cols.AccessListEntry, aleDocs, []string{"ale-1", "ale-2"})
+
+	assert.Equal(t, "tx-doc-id-1", aleDocs[0]["_transactionID"])
+	assert.Equal(t, "tx-doc-id-2", aleDocs[1]["_transactionID"])
+}
+
+func TestStampLinks_AccessListEntry_FewerParentRefs(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, []string{"0xtx1"})
+	s.txHashToID["0xtx1"] = "tx-doc-id-1"
+
+	aleDocs := []map[string]any{
+		{constants.AddressKeyValue: "0x01"},
+		{constants.AddressKeyValue: "0x02"},
+	}
+
+	s.StampLinks(nil, cols.AccessListEntry, aleDocs, []string{"ale-1", "ale-2"})
+
+	assert.Equal(t, "tx-doc-id-1", aleDocs[0]["_transactionID"])
+	_, hasTxID := aleDocs[1]["_transactionID"]
+	assert.False(t, hasTxID, "second ALE should not get _transactionID when parentRefs is shorter")
+}
+
+func TestStampLinks_UnknownCollection(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, nil)
+
+	docs := []map[string]any{{"foo": "bar"}}
+	s.StampLinks(nil, "UnknownCollection", docs, []string{"id-1"})
+
+	assert.Equal(t, "bar", docs[0]["foo"])
+	_, hasBlockID := docs[0]["_blockID"]
+	assert.False(t, hasBlockID)
+}
+
+func TestStampLinks_BlockNoDocIDs(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, nil)
+
+	s.StampLinks(nil, cols.Block, []map[string]any{{constants.HashKeyValue: "0xabc"}}, nil)
+
+	assert.Empty(t, s.blockID)
+}
+
+func TestStampLinks_TransactionBuildsTxHashToID(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, nil)
+
+	txDocs := []map[string]any{
+		{constants.HashKeyValue: "0xtxA"},
+		{constants.HashKeyValue: "0xtxB"},
+	}
+	txIDs := []string{"docA", "docB"}
+
+	s.StampLinks(nil, cols.Transaction, txDocs, txIDs)
+
+	require.Len(t, s.txHashToID, 2)
+	assert.Equal(t, "docA", s.txHashToID["0xtxA"])
+	assert.Equal(t, "docB", s.txHashToID["0xtxB"])
+}
+
+func TestStampLinks_FullBlockSequence(t *testing.T) {
+	t.Parallel()
+	cols := NewCollectionNames("Ethereum__Mainnet")
+	s := newEvmLinkStamper(cols, []string{"0xtx1"})
+
+	groups := []chains.DocumentGroup{
+		{Collection: cols.Block, Docs: []map[string]any{{constants.HashKeyValue: "0xblock"}}},
+		{Collection: cols.Transaction, Docs: []map[string]any{{constants.HashKeyValue: "0xtx1"}}},
+		{Collection: cols.Log, Docs: []map[string]any{{constants.TransactionHashKeyValue: "0xtx1"}}},
+		{Collection: cols.AccessListEntry, Docs: []map[string]any{{constants.AddressKeyValue: "0x01"}}},
+	}
+
+	s.StampLinks(groups, cols.Block, groups[0].Docs, []string{"block-id-1"})
+	s.StampLinks(groups, cols.Transaction, groups[1].Docs, []string{"tx-id-1"})
+	s.StampLinks(groups, cols.Log, groups[2].Docs, []string{"log-id-1"})
+	s.StampLinks(groups, cols.AccessListEntry, groups[3].Docs, []string{"ale-id-1"})
+
+	assert.Equal(t, "block-id-1", s.blockID)
+	assert.Equal(t, "block-id-1", groups[1].Docs[0]["_blockID"])
+	assert.Equal(t, "tx-id-1", s.txHashToID["0xtx1"])
+	assert.Equal(t, "block-id-1", groups[2].Docs[0]["_blockID"])
+	assert.Equal(t, "tx-id-1", groups[2].Docs[0]["_transactionID"])
+	assert.Equal(t, "tx-id-1", groups[3].Docs[0]["_transactionID"])
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -38,3 +38,12 @@ const ContentTypeJSON = "application/json"
 
 // CacheControlSchema is the Cache-Control directive for schema responses.
 const CacheControlSchema = "no-cache"
+
+// HashKeyValue is the string value "hash" assigned to a key field.
+const HashKeyValue = "hash"
+
+// AddressKeyValue is the string value "address" assigned to a key field.
+const AddressKeyValue = "address"
+
+// TransactionHashKeyValue is the string value "transactionHash" assigned to a key field.
+const TransactionHashKeyValue = "transactionHash"

--- a/pkg/defra/block_handler.go
+++ b/pkg/defra/block_handler.go
@@ -5,10 +5,8 @@ import (
 	"encoding/hex"
 	stderrors "errors"
 	"fmt"
-	"maps"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	cid "github.com/ipfs/go-cid"
@@ -64,36 +62,24 @@ type DocIDTrackerInterface interface {
 	TrackBlock(ctx context.Context, blockNumber int64, result *BlockCreationResult) error
 }
 
-// Compile-time guarantee that BlockHandler implements chains.CollectionVersionProvider.
-var _ chains.CollectionVersionProvider = (*BlockHandler)(nil)
-
 // BlockHandler manages the creation and storage of blocks, transactions, and logs in DefraDB.
 type BlockHandler struct {
-	db              blockDB               // DB interface (from defraNode.DB).
-	maxDocsPerTxn   int                   // Threshold for single-txn vs batched block creation.
-	maxTxBatchSize  int                   // Per-collection batch size for transactions (0 = use maxDocsPerTxn).
-	maxLogBatchSize int                   // Per-collection batch size for logs (0 = use maxDocsPerTxn).
-	maxALEBatchSize int                   // Per-collection batch size for ALEs (0 = use maxDocsPerTxn).
-	docIDTracker    DocIDTrackerInterface // Optional tracker for docIDs.
-	collections     chains.Collections    // Chain-specific collection names.
-	nodeIdentity    identity.Identity     // Node identity for signing.
-
-	// colVersionCache caches collection versions (immutable per schema version)
-	// so CollectionVersion avoids opening a read txn on every call.
-	colVersionCache map[string]client.CollectionVersion
-	colVerMu        sync.Mutex
+	db            blockDB               // DB interface (from defraNode.DB).
+	maxDocsPerTxn int                   // Default per-group batch size when group BatchSize is 0.
+	docIDTracker  DocIDTrackerInterface // Optional tracker for docIDs.
+	nodeIdentity  identity.Identity     // Node identity for signing.
 
 	// Injectable functions for testability (set to defaults in NewBlockHandler).
 	signBatchFn      func(ctx context.Context, collector *node.BatchCIDCollector) (*node.BatchSignature, error)
 	verifyBatchSigFn func(sig *node.BatchSignature, cids []cid.Cid) (bool, error)
-	collectDocCIDsFn func(ctx context.Context, docIDs []string) ([]cid.Cid, error)
+	collectDocCIDsFn func(ctx context.Context, docIDs []string, collectionNames []string) ([]cid.Cid, error)
 	maxCIDRetries    int
 	retryBackoffFn   func(int) time.Duration
 }
 
 // NewBlockHandler creates a BlockHandler that uses direct DB calls.
 // maxDocsPerTxn is the default per-group batch size.
-func NewBlockHandler(defraNode *node.Node, maxDocsPerTxn int, collections chains.Collections) (*BlockHandler, error) {
+func NewBlockHandler(defraNode *node.Node, maxDocsPerTxn int) (*BlockHandler, error) {
 	if defraNode == nil {
 		return nil, errors.NewConfigurationError("defra", "NewBlockHandler",
 			"defraNode is nil", "", nil)
@@ -101,89 +87,16 @@ func NewBlockHandler(defraNode *node.Node, maxDocsPerTxn int, collections chains
 	if maxDocsPerTxn <= 0 {
 		maxDocsPerTxn = 1000 //nolint:mnd
 	}
-	if collections == nil {
-		return nil, errors.NewConfigurationError("defra", "NewBlockHandler",
-			"collections is nil", "", nil)
-	}
 	h := &BlockHandler{
-		db:              defraNode.DB,
-		maxDocsPerTxn:   maxDocsPerTxn,
-		collections:     collections,
-		maxCIDRetries:   15, //nolint:mnd
-		retryBackoffFn:  retryBackoff,
-		colVersionCache: make(map[string]client.CollectionVersion),
+		db:             defraNode.DB,
+		maxDocsPerTxn:  maxDocsPerTxn,
+		maxCIDRetries:  15, //nolint:mnd
+		retryBackoffFn: retryBackoff,
 	}
 	h.signBatchFn = h.defaultSignBatch
 	h.verifyBatchSigFn = node.VerifyBatchSignature
 	h.collectDocCIDsFn = h.defaultCollectDocCIDs
 	return h, nil
-}
-
-// CollectionVersion implements chains.CollectionVersionProvider. It opens a
-// read-only txn, looks up the collection by name, and returns its version.
-// The result is cached for the handler's lifetime (versions are immutable per
-// schema version).
-func (h *BlockHandler) CollectionVersion(ctx context.Context, name string) (client.CollectionVersion, error) {
-	h.colVerMu.Lock()
-	if v, ok := h.colVersionCache[name]; ok {
-		h.colVerMu.Unlock()
-		return v, nil
-	}
-	h.colVerMu.Unlock()
-
-	txn, err := h.db.NewTxn(true)
-	if err != nil {
-		return client.CollectionVersion{}, fmt.Errorf("create read txn for CollectionVersion: %w", err) //nolint:err113
-	}
-	defer txn.Discard()
-
-	col, err := txn.GetCollectionByName(ctx, name)
-	if err != nil {
-		return client.CollectionVersion{}, fmt.Errorf("get collection %s: %w", name, err) //nolint:err113
-	}
-
-	v := col.Version()
-	h.colVerMu.Lock()
-	h.colVersionCache[name] = v
-	h.colVerMu.Unlock()
-	return v, nil
-}
-
-func extractCollection(collections chains.Collections, role string) string {
-	name, err := collections.GetCollection(role)
-	if err != nil {
-		panic(fmt.Sprintf("programmer error: %v", err))
-	}
-	return name
-}
-
-// SetBatchSizes sets per-collection batch sizes for transactions, logs, and ALEs.
-// A value of 0 means "use maxDocsPerTxn" for that collection.
-func (h *BlockHandler) SetBatchSizes(txDocs, logDocs, aleDocs int) {
-	h.maxTxBatchSize = txDocs
-	h.maxLogBatchSize = logDocs
-	h.maxALEBatchSize = aleDocs
-}
-
-func (h *BlockHandler) txBatchSize() int {
-	if h.maxTxBatchSize > 0 {
-		return h.maxTxBatchSize
-	}
-	return h.maxDocsPerTxn
-}
-
-func (h *BlockHandler) logBatchSize() int {
-	if h.maxLogBatchSize > 0 {
-		return h.maxLogBatchSize
-	}
-	return h.maxDocsPerTxn
-}
-
-func (h *BlockHandler) aleBatchSize() int {
-	if h.maxALEBatchSize > 0 {
-		return h.maxALEBatchSize
-	}
-	return h.maxDocsPerTxn
 }
 
 // SetNodeIdentity sets the node identity used for block signing.
@@ -297,21 +210,15 @@ func (h *BlockHandler) extractCIDsFromCollection(ctx context.Context, colName, i
 }
 
 // defaultCollectDocCIDs queries each collection via GQL to retrieve CIDs for the given docIDs.
-func (h *BlockHandler) defaultCollectDocCIDs(ctx context.Context, docIDs []string) ([]cid.Cid, error) {
+func (h *BlockHandler) defaultCollectDocCIDs(ctx context.Context, docIDs []string, collectionNames []string) ([]cid.Cid, error) {
 	if len(docIDs) == 0 {
 		return nil, nil
 	}
 
 	idsJSON := buildDocIDJSONArray(docIDs)
 
-	sigCol, _ := h.collections.GetCollection(chains.TypeBlockSignature)
-	snapCol, _ := h.collections.GetCollection(chains.TypeSnapshotSignature)
-
 	var allCIDs []cid.Cid
-	for _, colName := range h.collections.AllCollections() {
-		if colName == sigCol || colName == snapCol {
-			continue
-		}
+	for _, colName := range collectionNames {
 		allCIDs = append(allCIDs, h.extractCIDsFromCollection(ctx, colName, idsJSON)...)
 	}
 	return allCIDs, nil
@@ -347,161 +254,99 @@ func toInt64(v any) (int64, error) {
 }
 
 // Store persists a block and all its constituent documents (transactions, logs,
-// access-list entries, etc.) from the given DocumentGroups. It writes the
-// block document first, then writes the remaining groups in role order
-// (transactions → logs → access-list entries → other), resolving
-// cross-document link fields (_blockID, _transactionID) after AddDocument
-// assigns persistent docIDs. The block signature is created over the collected
-// CIDs when signing identity is available.
-//
-// The signatureCollection parameter names the collection where the block
-// signature document will be stored. The vp parameter is retained in the
-// interface signature for future use but is not needed by the current
-// implementation.
+// access-list entries, etc.) from the ConversionResult. It writes the block
+// document first, then writes the remaining groups in order, resolving
+// cross-document link fields (_blockID, _transactionID) via the
+// chain-provided LinkStamper. The block signature is created over the
+// collected CIDs when signing identity is available.
 func (h *BlockHandler) Store(
 	ctx context.Context,
-	groups []chains.DocumentGroup,
-	signatureCollection string,
-	_ chains.CollectionVersionProvider,
+	result chains.ConversionResult,
 ) (*BlockCreationResult, error) {
 	if h.db == nil {
 		return nil, errors.NewConfigurationError("defra", "Store",
 			"store requires embedded DefraDB node", "", nil)
 	}
-	if len(groups) == 0 {
+	if len(result.Groups) == 0 {
 		return nil, fmt.Errorf("no document groups to store") //nolint:err113
 	}
 
-	cols := h.roleCollectionNames()
-	blockInt, blockHash, blockData, err := h.findBlockGroup(groups, cols.block)
-	if err != nil {
-		return nil, err
+	blockGroup := result.Groups[0]
+	if len(blockGroup.Docs) == 0 {
+		return nil, fmt.Errorf("no block document in groups") //nolint:err113
 	}
+	blockData := blockGroup.Docs[0]
+	blockInt, err := toInt64(blockData[blockGroup.BlockNumField])
+	if err != nil {
+		return nil, fmt.Errorf("invalid block number: %w", err) //nolint:err113
+	}
+	blockHash, _ := blockData[constants.HashKeyValue].(string)
 
 	collector := node.NewBatchCIDCollector()
 	ctx = node.ContextWithBatchSigning(ctx, collector)
 
-	blockID, err := h.storeBlockDoc(ctx, blockData, cols.block)
+	blockID, err := h.storeBlockDoc(ctx, blockData, blockGroup.Collection)
 	if err != nil {
 		return nil, err
 	}
 
-	allDocIDs, otherDocIDs, batchErrors := h.storeGroups(ctx, groups, cols, blockInt, blockID)
+	if result.LinkStamper != nil {
+		result.LinkStamper.StampLinks(result.Groups, blockGroup.Collection, blockGroup.Docs, []string{blockID})
+	}
 
-	blockSigDocID := h.signStoredBlock(ctx, blockInt, blockHash, allDocIDs, batchErrors, signatureCollection, collector)
+	allDocIDs := []string{blockID}
+	otherDocIDs := map[string][]string{}
+	var batchErrors []error
 
-	result := &BlockCreationResult{
+	for _, g := range result.Groups[1:] {
+		if result.LinkStamper != nil {
+			result.LinkStamper.StampLinks(result.Groups, g.Collection, g.Docs, nil)
+		}
+
+		ids, err := h.writeGroup(ctx, blockInt, g)
+		if err != nil {
+			batchErrors = append(batchErrors, err)
+		}
+
+		if result.LinkStamper != nil {
+			result.LinkStamper.StampLinks(result.Groups, g.Collection, g.Docs, ids)
+		}
+
+		otherDocIDs[g.Collection] = append(otherDocIDs[g.Collection], ids...)
+		allDocIDs = append(allDocIDs, ids...)
+	}
+
+	blockSigDocID := h.signStoredBlock(ctx, blockInt, blockHash, allDocIDs, batchErrors, result.SignatureCollection, collector)
+
+	creationResult := &BlockCreationResult{
 		BlockNumber:              blockInt,
 		BlockID:                  blockID,
 		BlockSignatureID:         blockSigDocID,
-		BlockSignatureCollection: signatureCollection,
+		BlockSignatureCollection: result.SignatureCollection,
 		OtherDocIDs:              otherDocIDs,
 	}
 
 	if h.docIDTracker != nil {
-		if err := h.docIDTracker.TrackBlock(ctx, blockInt, result); err != nil {
+		if err := h.docIDTracker.TrackBlock(ctx, blockInt, creationResult); err != nil {
 			logger.Sugar.Warnf("Failed to track docIDs for block %d: %v", blockInt, err)
 		}
 	}
 
 	if len(batchErrors) > 0 {
-		return result, fmt.Errorf("block %d partially indexed with %d batch errors (first: %w)", //nolint:err113
+		return creationResult, fmt.Errorf("block %d partially indexed with %d batch errors (first: %w)", //nolint:err113
 			blockInt, len(batchErrors), batchErrors[0])
 	}
 
-	return result, nil
+	return creationResult, nil
 }
 
-type roleCollectionNames struct {
-	block string
-	tx    string
-	log   string
-	ale   string
-}
-
-func (h *BlockHandler) roleCollectionNames() roleCollectionNames {
-	return roleCollectionNames{
-		block: extractCollection(h.collections, chains.TypeBlock),
-		tx:    extractCollection(h.collections, chains.TypeTransaction),
-		log:   extractCollection(h.collections, chains.TypeLog),
-		ale:   extractCollection(h.collections, chains.TypeAccessListEntry),
+// writeGroup writes a DocumentGroup's docs in batches, returning all docIDs.
+func (h *BlockHandler) writeGroup(ctx context.Context, blockInt int64, g chains.DocumentGroup) ([]string, error) {
+	batchSize := g.BatchSize
+	if batchSize <= 0 {
+		batchSize = h.maxDocsPerTxn
 	}
-}
-
-func (h *BlockHandler) findBlockGroup(groups []chains.DocumentGroup, blockColName string) (int64, string, map[string]any, error) {
-	var blockGroup *chains.DocumentGroup
-	for i := range groups {
-		if groups[i].Collection == blockColName {
-			blockGroup = &groups[i]
-			break
-		}
-	}
-	if blockGroup == nil || len(blockGroup.Docs) == 0 {
-		return 0, "", nil, fmt.Errorf("no block document in groups") //nolint:err113
-	}
-	blockData := blockGroup.Docs[0]
-	blockInt, err := toInt64(blockData[constants.NumberFieldValue])
-	if err != nil {
-		return 0, "", nil, fmt.Errorf("invalid block number: %w", err)
-	}
-	blockHash, _ := blockData["hash"].(string)
-	return blockInt, blockHash, blockData, nil
-}
-
-func (h *BlockHandler) storeGroups(
-	ctx context.Context,
-	groups []chains.DocumentGroup,
-	cols roleCollectionNames,
-	blockInt int64,
-	blockID string,
-) ([]string, map[string][]string, []error) {
-	allDocIDs := []string{blockID}
-	otherDocIDs := map[string][]string{}
-	var batchErrors []error
-	txHashToID := make(map[string]string)
-
-	for _, g := range groups {
-		if g.Collection != cols.tx {
-			continue
-		}
-		ids, hashToID, err := h.storeTxGroup(ctx, blockInt, g, blockID)
-		if err != nil {
-			batchErrors = append(batchErrors, err)
-		}
-		maps.Copy(txHashToID, hashToID)
-		otherDocIDs[g.Collection] = append(otherDocIDs[g.Collection], ids...)
-		allDocIDs = append(allDocIDs, ids...)
-	}
-
-	for _, g := range groups {
-		switch g.Collection {
-		case cols.block, cols.tx:
-			continue
-		case cols.log:
-			ids, err := h.storeLogGroup(ctx, blockInt, g, blockID, txHashToID)
-			if err != nil {
-				batchErrors = append(batchErrors, err)
-			}
-			otherDocIDs[g.Collection] = append(otherDocIDs[g.Collection], ids...)
-			allDocIDs = append(allDocIDs, ids...)
-		case cols.ale:
-			ids, err := h.storeALEGroup(ctx, blockInt, g, txHashToID)
-			if err != nil {
-				batchErrors = append(batchErrors, err)
-			}
-			otherDocIDs[g.Collection] = append(otherDocIDs[g.Collection], ids...)
-			allDocIDs = append(allDocIDs, ids...)
-		default:
-			ids, err := h.createDocBatch(ctx, blockInt, g.Collection, g.Docs, h.maxDocsPerTxn)
-			if err != nil {
-				batchErrors = append(batchErrors, err)
-			}
-			otherDocIDs[g.Collection] = append(otherDocIDs[g.Collection], ids...)
-			allDocIDs = append(allDocIDs, ids...)
-		}
-	}
-
-	return allDocIDs, otherDocIDs, batchErrors
+	return h.createDocBatch(ctx, blockInt, g.Collection, g.Docs, batchSize)
 }
 
 func (h *BlockHandler) signStoredBlock(
@@ -572,81 +417,6 @@ func (h *BlockHandler) storeBlockDoc(ctx context.Context, blockData map[string]a
 	}
 
 	return blockID, nil
-}
-
-// storeTxGroup writes transaction documents in batches, setting _blockID on each
-// and recording the hash→docID mapping for downstream link resolution.
-func (h *BlockHandler) storeTxGroup(
-	ctx context.Context,
-	blockInt int64,
-	group chains.DocumentGroup,
-	blockID string,
-) (ids []string, hashToID map[string]string, err error) {
-	hashToID = make(map[string]string)
-	batchSize := h.txBatchSize()
-
-	for i := 0; i < len(group.Docs); i += batchSize {
-		end := min(i+batchSize, len(group.Docs))
-		batch := group.Docs[i:end]
-		if len(batch) == 0 {
-			continue
-		}
-		for j := range batch {
-			batch[j]["_blockID"] = blockID
-		}
-		var batchIDs []string
-		batchErr := h.writeBatchWithRetry(ctx, blockInt, "transaction", func() error {
-			var e error
-			batchIDs, e = h.createDocsInTxn(ctx, group.Collection, batch)
-			return e
-		})
-		if batchErr != nil {
-			return ids, hashToID, batchErr
-		}
-		for j, id := range batchIDs {
-			txHash, _ := batch[j]["hash"].(string)
-			hashToID[txHash] = id
-		}
-		ids = append(ids, batchIDs...)
-	}
-	return ids, hashToID, nil
-}
-
-// storeLogGroup writes log documents in batches, setting _blockID and
-// _transactionID (resolved by matching transactionHash↔hash).
-func (h *BlockHandler) storeLogGroup(
-	ctx context.Context,
-	blockInt int64,
-	group chains.DocumentGroup,
-	blockID string,
-	txHashToID map[string]string,
-) ([]string, error) {
-	for i := range group.Docs {
-		group.Docs[i]["_blockID"] = blockID
-		txHash, _ := group.Docs[i]["transactionHash"].(string)
-		if txID, ok := txHashToID[txHash]; ok {
-			group.Docs[i]["_transactionID"] = txID
-		}
-	}
-	return h.createDocBatch(ctx, blockInt, group.Collection, group.Docs, h.logBatchSize())
-}
-
-// storeALEGroup writes access-list entry documents in batches, setting
-// _transactionID resolved from the group's ParentRef parallel array.
-func (h *BlockHandler) storeALEGroup(
-	ctx context.Context,
-	blockInt int64,
-	group chains.DocumentGroup,
-	txHashToID map[string]string,
-) ([]string, error) {
-	for i := range group.Docs {
-		if i < len(group.ParentRef) {
-			if txID, ok := txHashToID[group.ParentRef[i]]; ok {
-				group.Docs[i]["_transactionID"] = txID
-			}
-		}
-	}
-	return h.createDocBatch(ctx, blockInt, group.Collection, group.Docs, h.aleBatchSize())
 }
 
 // createDocBatch writes documents in batches of batchSize, returning all docIDs.
@@ -733,44 +503,41 @@ func (h *BlockHandler) createDocsInTxn(
 // stored. It collects the stored docIDs by querying each group's collection
 // for the given block number, waits for CIDs, then signs over them.
 //
-// The groups parameter identifies which collections to query (typically the
-// same groups produced by Convert, minus the signature group). The
-// signatureCollection parameter names the collection where the block signature
-// document will be stored. The vp parameter is retained in the interface
-// signature for future use but is not needed by the current implementation.
+// The result.Groups identify which collections to query (typically the same
+// groups produced by Convert, minus the signature group).
+// result.SignatureCollection names the collection where the block signature
+// document will be stored.
 func (h *BlockHandler) SignExisting(
 	ctx context.Context,
-	groups []chains.DocumentGroup,
-	signatureCollection string,
+	result chains.ConversionResult,
 	blockHash string,
 	blockNumber int64,
-	_ chains.CollectionVersionProvider,
 ) (string, error) {
 	if h.db == nil {
 		return "", fmt.Errorf("defraNode is nil") //nolint:err113
 	}
 
-	blockColName := extractCollection(h.collections, chains.TypeBlock)
-
 	var allDocIDs []string
-	for _, g := range groups {
-		field := constants.BlockNumberKeyValue
-		if g.Collection == blockColName {
-			field = constants.NumberFieldValue
+	var collectionNames []string
+	for _, g := range result.Groups {
+		field := g.BlockNumField
+		if field == "" {
+			field = constants.BlockNumberKeyValue
 		}
 		docIDs, err := h.queryCollectionDocIDs(ctx, g.Collection, field, blockNumber, blockNumber)
 		if err != nil {
 			return "", fmt.Errorf("query docIDs for %s: %w", g.Collection, err) //nolint:err113
 		}
 		allDocIDs = append(allDocIDs, docIDs...)
+		collectionNames = append(collectionNames, g.Collection)
 	}
 
-	cids, err := h.waitForCIDs(ctx, blockNumber, allDocIDs)
+	cids, err := h.waitForCIDs(ctx, blockNumber, allDocIDs, collectionNames)
 	if err != nil {
 		return "", err
 	}
 
-	return h.signBlockOverCIDs(ctx, blockNumber, blockHash, len(allDocIDs), cids, signatureCollection)
+	return h.signBlockOverCIDs(ctx, blockNumber, blockHash, len(allDocIDs), cids, result.SignatureCollection)
 }
 
 // buildBlockSignatureDocument creates a client.Document for a block signature.
@@ -792,13 +559,13 @@ func (h *BlockHandler) buildBlockSignatureDocument(ctx context.Context, blockSig
 // waitForCIDs collects the CIDs for allDocIDs, retrying while they are still arriving (P2P data
 // can lag). It returns the CIDs only once every document has one; partial coverage is an error so
 // a signature is never made over a subset of the block.
-func (h *BlockHandler) waitForCIDs(ctx context.Context, blockNumber int64, allDocIDs []string) ([]cid.Cid, error) {
+func (h *BlockHandler) waitForCIDs(ctx context.Context, blockNumber int64, allDocIDs []string, collectionNames []string) ([]cid.Cid, error) {
 	maxRetries := h.maxCIDRetries
 	var lastCIDCount int
 	var lastErr error
 
 	for attempt := range maxRetries {
-		cids, err := h.collectDocCIDsFn(ctx, allDocIDs)
+		cids, err := h.collectDocCIDsFn(ctx, allDocIDs, collectionNames)
 		if err != nil {
 			lastErr = err
 			logger.Sugar.Warnf("Block %d: CID query failed (attempt %d/%d): %v", blockNumber, attempt+1, maxRetries, err)

--- a/pkg/defra/block_handler.go
+++ b/pkg/defra/block_handler.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"maps"
 	"sort"
-	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cid "github.com/ipfs/go-cid"
@@ -17,8 +17,6 @@ import (
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/defracontext"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/errors"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/logger"
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/types"
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/utils"
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
@@ -66,6 +64,9 @@ type DocIDTrackerInterface interface {
 	TrackBlock(ctx context.Context, blockNumber int64, result *BlockCreationResult) error
 }
 
+// Compile-time guarantee that BlockHandler implements chains.CollectionVersionProvider.
+var _ chains.CollectionVersionProvider = (*BlockHandler)(nil)
+
 // BlockHandler manages the creation and storage of blocks, transactions, and logs in DefraDB.
 type BlockHandler struct {
 	db              blockDB               // DB interface (from defraNode.DB).
@@ -77,30 +78,21 @@ type BlockHandler struct {
 	collections     chains.Collections    // Chain-specific collection names.
 	nodeIdentity    identity.Identity     // Node identity for signing.
 
+	// colVersionCache caches collection versions (immutable per schema version)
+	// so CollectionVersion avoids opening a read txn on every call.
+	colVersionCache map[string]client.CollectionVersion
+	colVerMu        sync.Mutex
+
 	// Injectable functions for testability (set to defaults in NewBlockHandler).
 	signBatchFn      func(ctx context.Context, collector *node.BatchCIDCollector) (*node.BatchSignature, error)
 	verifyBatchSigFn func(sig *node.BatchSignature, cids []cid.Cid) (bool, error)
 	collectDocCIDsFn func(ctx context.Context, docIDs []string) ([]cid.Cid, error)
-	blockExistsFn    func(ctx context.Context, blockNumber int64) (bool, error)
 	maxCIDRetries    int
 	retryBackoffFn   func(int) time.Duration
 }
 
-// logEntry holds a log and its associated transaction ID for batched processing.
-type logEntry struct {
-	log  *types.Log
-	txID string
-}
-
-// aleEntry holds an access list entry and its associated transaction ID for batched processing.
-type aleEntry struct {
-	ale         *types.AccessListEntry
-	txID        string
-	blockNumber int64
-}
-
 // NewBlockHandler creates a BlockHandler that uses direct DB calls.
-// maxDocsPerTxn is the threshold for single-txn vs batched block creation.
+// maxDocsPerTxn is the default per-group batch size.
 func NewBlockHandler(defraNode *node.Node, maxDocsPerTxn int, collections chains.Collections) (*BlockHandler, error) {
 	if defraNode == nil {
 		return nil, errors.NewConfigurationError("defra", "NewBlockHandler",
@@ -114,17 +106,47 @@ func NewBlockHandler(defraNode *node.Node, maxDocsPerTxn int, collections chains
 			"collections is nil", "", nil)
 	}
 	h := &BlockHandler{
-		db:             defraNode.DB,
-		maxDocsPerTxn:  maxDocsPerTxn,
-		collections:    collections,
-		maxCIDRetries:  15, //nolint:mnd
-		retryBackoffFn: retryBackoff,
+		db:              defraNode.DB,
+		maxDocsPerTxn:   maxDocsPerTxn,
+		collections:     collections,
+		maxCIDRetries:   15, //nolint:mnd
+		retryBackoffFn:  retryBackoff,
+		colVersionCache: make(map[string]client.CollectionVersion),
 	}
 	h.signBatchFn = h.defaultSignBatch
 	h.verifyBatchSigFn = node.VerifyBatchSignature
 	h.collectDocCIDsFn = h.defaultCollectDocCIDs
-	h.blockExistsFn = h.defaultBlockExists
 	return h, nil
+}
+
+// CollectionVersion implements chains.CollectionVersionProvider. It opens a
+// read-only txn, looks up the collection by name, and returns its version.
+// The result is cached for the handler's lifetime (versions are immutable per
+// schema version).
+func (h *BlockHandler) CollectionVersion(ctx context.Context, name string) (client.CollectionVersion, error) {
+	h.colVerMu.Lock()
+	if v, ok := h.colVersionCache[name]; ok {
+		h.colVerMu.Unlock()
+		return v, nil
+	}
+	h.colVerMu.Unlock()
+
+	txn, err := h.db.NewTxn(true)
+	if err != nil {
+		return client.CollectionVersion{}, fmt.Errorf("create read txn for CollectionVersion: %w", err) //nolint:err113
+	}
+	defer txn.Discard()
+
+	col, err := txn.GetCollectionByName(ctx, name)
+	if err != nil {
+		return client.CollectionVersion{}, fmt.Errorf("get collection %s: %w", name, err) //nolint:err113
+	}
+
+	v := col.Version()
+	h.colVerMu.Lock()
+	h.colVersionCache[name] = v
+	h.colVerMu.Unlock()
+	return v, nil
 }
 
 func extractCollection(collections chains.Collections, role string) string {
@@ -162,26 +184,6 @@ func (h *BlockHandler) aleBatchSize() int {
 		return h.maxALEBatchSize
 	}
 	return h.maxDocsPerTxn
-}
-
-func (h *BlockHandler) defaultBlockExists(ctx context.Context, blockNumber int64) (bool, error) {
-	blockCol := extractCollection(h.collections, "block")
-	query := `query { ` + blockCol + `(filter: {number: {_eq: ` + strconv.FormatInt(blockNumber, 10) + `}}) { _docID } }`
-	result := h.db.ExecRequest(ctx, query)
-	if len(result.GQL.Errors) > 0 {
-		return false, fmt.Errorf("block exists check failed: %w", result.GQL.Errors[0])
-	}
-	data, ok := result.GQL.Data.(map[string]any)
-	if !ok {
-		return false, nil
-	}
-	switch results := data[blockCol].(type) {
-	case []any:
-		return len(results) > 0, nil
-	case []map[string]any:
-		return len(results) > 0, nil
-	}
-	return false, nil
 }
 
 // SetNodeIdentity sets the node identity used for block signing.
@@ -302,15 +304,14 @@ func (h *BlockHandler) defaultCollectDocCIDs(ctx context.Context, docIDs []strin
 
 	idsJSON := buildDocIDJSONArray(docIDs)
 
-	colNames := []string{
-		extractCollection(h.collections, "block"),
-		extractCollection(h.collections, "transaction"),
-		extractCollection(h.collections, "log"),
-		extractCollection(h.collections, "accessListEntry"),
-	}
+	sigCol, _ := h.collections.GetCollection(chains.TypeBlockSignature)
+	snapCol, _ := h.collections.GetCollection(chains.TypeSnapshotSignature)
 
 	var allCIDs []cid.Cid
-	for _, colName := range colNames {
+	for _, colName := range h.collections.AllCollections() {
+		if colName == sigCol || colName == snapCol {
+			continue
+		}
 		allCIDs = append(allCIDs, h.extractCIDsFromCollection(ctx, colName, idsJSON)...)
 	}
 	return allCIDs, nil
@@ -331,431 +332,445 @@ func (h *BlockHandler) SetDocIDTracker(tracker DocIDTrackerInterface) {
 	h.docIDTracker = tracker
 }
 
-// CreateBlockBatch creates a block with all its transactions, logs, and access list entries.
-func (h *BlockHandler) CreateBlockBatch(ctx context.Context, block *types.Block, transactions []*types.Transaction, receipts []*types.TransactionReceipt) (string, error) {
-	if h.db == nil {
-		return "", errors.NewConfigurationError("defra", "CreateBlockBatch",
-			"batch creation requires embedded DefraDB node", "", nil)
+// toInt64 extracts an int64 from a map value that may be int64, int, or float64.
+func toInt64(v any) (int64, error) {
+	switch n := v.(type) {
+	case int64:
+		return n, nil
+	case int:
+		return int64(n), nil
+	case float64:
+		return int64(n), nil
+	default:
+		return 0, fmt.Errorf("expected numeric type, got %T", v) //nolint:err113
 	}
-
-	if block == nil {
-		return "", errors.NewInvalidBlockFormat("defra", "CreateBlockBatch", "nil", nil)
-	}
-
-	blockInt, err := utils.HexToInt(block.Number)
-	if err != nil {
-		return "", err
-	}
-
-	exists, err := h.blockExistsFn(ctx, blockInt)
-	if err != nil {
-		return "", errors.NewQueryFailed("defra", "CreateBlockBatch", "block exists check failed", err)
-	}
-	if exists {
-		return "", fmt.Errorf("block already exists") //nolint: err113
-	}
-
-	receiptMap := make(map[string]*types.TransactionReceipt)
-	for _, receipt := range receipts {
-		if receipt != nil {
-			receiptMap[receipt.TransactionHash] = receipt
-		}
-	}
-
-	totalLogs := 0
-	totalALEs := 0
-	missingReceipts := 0
-	for _, tx := range transactions {
-		if tx == nil {
-			continue
-		}
-		if receipt, ok := receiptMap[tx.Hash]; ok && receipt != nil {
-			totalLogs += len(receipt.Logs)
-		} else {
-			missingReceipts++
-		}
-		totalALEs += len(tx.AccessList)
-	}
-	if missingReceipts > 0 {
-		logger.Sugar.Warnf("Block %d: %d transactions have no receipt; their logs will not be indexed", blockInt, missingReceipts)
-	}
-	totalDocs := 1 + len(transactions) + totalLogs + totalALEs
-
-	if totalDocs <= h.maxDocsPerTxn {
-		return h.createBlockSingleTransaction(ctx, block, blockInt, transactions, receiptMap)
-	}
-
-	return h.createBlockBatched(ctx, block, blockInt, transactions, receiptMap)
 }
 
-// createBlockSingleTransaction creates the entire block in a single DB transaction.
-// Block and BlockSignature are created as separate documents in the same transaction.
-// This ensures all documents arrive via P2P together, and the host can listen for.
-// BlockSignature events to create attestations.
-func (h *BlockHandler) createBlockSingleTransaction(ctx context.Context, block *types.Block, blockInt int64, transactions []*types.Transaction, receiptMap map[string]*types.TransactionReceipt) (string, error) {
-	txn, err := h.db.NewTxn(false)
+// Store persists a block and all its constituent documents (transactions, logs,
+// access-list entries, etc.) from the given DocumentGroups. It writes the
+// block document first, then writes the remaining groups in role order
+// (transactions → logs → access-list entries → other), resolving
+// cross-document link fields (_blockID, _transactionID) after AddDocument
+// assigns persistent docIDs. The block signature is created over the collected
+// CIDs when signing identity is available.
+//
+// The signatureCollection parameter names the collection where the block
+// signature document will be stored. The vp parameter is retained in the
+// interface signature for future use but is not needed by the current
+// implementation.
+func (h *BlockHandler) Store(
+	ctx context.Context,
+	groups []chains.DocumentGroup,
+	signatureCollection string,
+	_ chains.CollectionVersionProvider,
+) (*BlockCreationResult, error) {
+	if h.db == nil {
+		return nil, errors.NewConfigurationError("defra", "Store",
+			"store requires embedded DefraDB node", "", nil)
+	}
+	if len(groups) == 0 {
+		return nil, fmt.Errorf("no document groups to store") //nolint:err113
+	}
+
+	cols := h.roleCollectionNames()
+	blockInt, blockHash, blockData, err := h.findBlockGroup(groups, cols.block)
 	if err != nil {
-		return "", errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to create transaction", err)
+		return nil, err
 	}
 
 	collector := node.NewBatchCIDCollector()
 	ctx = node.ContextWithBatchSigning(ctx, collector)
 
-	cols, err := h.getSingleTxnCollections(ctx, txn)
+	blockID, err := h.storeBlockDoc(ctx, blockData, cols.block)
 	if err != nil {
-		txn.Discard()
-		return "", err
+		return nil, err
 	}
 
-	blockID, txHashToID, logDocs, aleDocs, err := h.buildAndCreateSingleTxnDocs(ctx, txn, block, blockInt, transactions, receiptMap, cols)
-	if err != nil {
-		txn.Discard()
-		return "", err
-	}
+	allDocIDs, otherDocIDs, batchErrors := h.storeGroups(ctx, groups, cols, blockInt, blockID)
 
-	// Capture the signed CID count before the signature document is written: writing it feeds the
-	// same collector, so a later read would be one too high.
-	signedCIDCount := len(collector.GetCIDs())
-	blockSigDocID := h.buildAndCreateSingleTxnSignature(ctx, block, blockInt, collector, cols.blockSig)
-
-	if err := txn.Commit(); err != nil {
-		return "", errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to commit", err)
-	}
-
-	if blockSigDocID != "" {
-		logger.Sugar.Infof("Block %d: signed (%d CIDs)", blockInt, signedCIDCount)
-	}
-
-	h.trackSingleTxnDocIDs(ctx, blockInt, blockID, blockSigDocID, txHashToID, logDocs, aleDocs)
-
-	return blockID, nil
-}
-
-// singleTxnCollections holds all collections needed for a single-transaction block write.
-type singleTxnCollections struct {
-	block    client.Collection
-	tx       client.Collection
-	log      client.Collection
-	ale      client.Collection
-	blockSig client.Collection
-}
-
-// getSingleTxnCollections fetches all required collections within a transaction.
-func (h *BlockHandler) getSingleTxnCollections(ctx context.Context, txn client.Txn) (*singleTxnCollections, error) {
-	colBlock, err := txn.GetCollectionByName(ctx, extractCollection(h.collections, "block"))
-	if err != nil {
-		return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get block collection", err)
-	}
-	colTx, err := txn.GetCollectionByName(ctx, extractCollection(h.collections, "transaction"))
-	if err != nil {
-		return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get tx collection", err)
-	}
-	colLog, err := txn.GetCollectionByName(ctx, extractCollection(h.collections, "log"))
-	if err != nil {
-		return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get log collection", err)
-	}
-	colALE, err := txn.GetCollectionByName(ctx, extractCollection(h.collections, "accessListEntry"))
-	if err != nil {
-		return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get ALE collection", err)
-	}
-	colBlockSig, err := txn.GetCollectionByName(ctx, extractCollection(h.collections, "blockSignature"))
-	if err != nil {
-		return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to get block signature collection", err)
-	}
-	return &singleTxnCollections{block: colBlock, tx: colTx, log: colLog, ale: colALE, blockSig: colBlockSig}, nil
-}
-
-// buildAndCreateSingleTxnDocs builds and creates all block documents within the transaction.
-func (h *BlockHandler) buildAndCreateSingleTxnDocs(ctx context.Context, txn client.Txn, block *types.Block, blockInt int64, transactions []*types.Transaction, receiptMap map[string]*types.TransactionReceipt, cols *singleTxnCollections) (string, map[string]string, []*client.Document, []*client.Document, error) {
-	blockDoc, err := h.buildBlockDocument(ctx, block, blockInt, cols.block)
-	if err != nil {
-		return "", nil, nil, nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to build block document", err)
-	}
-	if err := cols.block.AddDocument(ctx, blockDoc); err != nil {
-		if errors.IsErrAlreadyExists(err) {
-			return "", nil, nil, nil, fmt.Errorf("block already exists") //nolint: err113
-		}
-		return "", nil, nil, nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", err.Error(), err)
-	}
-
-	blockID := blockDoc.ID().String()
-
-	txHashToID, err := h.createSingleTxnTransactions(ctx, txn, transactions, blockID, cols.tx)
-	if err != nil {
-		return "", nil, nil, nil, err
-	}
-
-	logDocs, err := h.createSingleTxnLogs(ctx, transactions, receiptMap, txHashToID, blockID, cols.log)
-	if err != nil {
-		return "", nil, nil, nil, err
-	}
-
-	aleDocs, err := h.createSingleTxnALEs(ctx, transactions, txHashToID, blockInt, cols.ale)
-	if err != nil {
-		return "", nil, nil, nil, err
-	}
-
-	return blockID, txHashToID, logDocs, aleDocs, nil
-}
-
-// createSingleTxnTransactions builds and creates transaction documents.
-func (h *BlockHandler) createSingleTxnTransactions(ctx context.Context, _ client.Txn, transactions []*types.Transaction, blockID string, colTx client.Collection) (map[string]string, error) {
-	txHashToID := make(map[string]string)
-	if len(transactions) == 0 {
-		return txHashToID, nil
-	}
-
-	txDocs := make([]*client.Document, 0, len(transactions))
-	txHashes := make([]string, 0, len(transactions))
-	for _, tx := range transactions {
-		if tx == nil {
-			continue
-		}
-		txDoc, err := h.buildTransactionDocument(ctx, tx, blockID, colTx)
-		if err != nil {
-			return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to build tx document", err)
-		}
-		txDocs = append(txDocs, txDoc)
-		txHashes = append(txHashes, tx.Hash)
-	}
-
-	if len(txDocs) > 0 {
-		if err := colTx.AddManyDocuments(ctx, txDocs); err != nil {
-			return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to create transactions", err)
-		}
-		for i, doc := range txDocs {
-			txHashToID[txHashes[i]] = doc.ID().String()
-		}
-	}
-
-	return txHashToID, nil
-}
-
-// createSingleTxnLogs builds and creates log documents.
-func (h *BlockHandler) createSingleTxnLogs(ctx context.Context, transactions []*types.Transaction, receiptMap map[string]*types.TransactionReceipt, txHashToID map[string]string, blockID string, colLog client.Collection) ([]*client.Document, error) {
-	var logDocs []*client.Document
-	for _, tx := range transactions {
-		if tx == nil {
-			continue
-		}
-		receipt, ok := receiptMap[tx.Hash]
-		if !ok || receipt == nil {
-			continue
-		}
-		txID, ok := txHashToID[tx.Hash]
-		if !ok {
-			continue
-		}
-		for i := range receipt.Logs {
-			logDoc, err := h.buildLogDocument(ctx, &receipt.Logs[i], blockID, txID, colLog)
-			if err != nil {
-				return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to build log document", err)
-			}
-			logDocs = append(logDocs, logDoc)
-		}
-	}
-
-	if len(logDocs) > 0 {
-		if err := colLog.AddManyDocuments(ctx, logDocs); err != nil {
-			return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to create logs", err)
-		}
-	}
-
-	return logDocs, nil
-}
-
-// createSingleTxnALEs builds and creates access list entry documents.
-func (h *BlockHandler) createSingleTxnALEs(ctx context.Context, transactions []*types.Transaction, txHashToID map[string]string, blockInt int64, colALE client.Collection) ([]*client.Document, error) {
-	var aleDocs []*client.Document
-	for _, tx := range transactions {
-		if tx == nil {
-			continue
-		}
-		txID, ok := txHashToID[tx.Hash]
-		if !ok {
-			continue
-		}
-		for i := range tx.AccessList {
-			aleDoc, err := h.buildALEDocument(ctx, &tx.AccessList[i], txID, blockInt, colALE)
-			if err != nil {
-				return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to build ALE document", err)
-			}
-			aleDocs = append(aleDocs, aleDoc)
-		}
-	}
-
-	if len(aleDocs) > 0 {
-		if err := colALE.AddManyDocuments(ctx, aleDocs); err != nil {
-			return nil, errors.NewQueryFailed("defra", "createBlockSingleTransaction", "failed to create ALEs", err)
-		}
-	}
-
-	return aleDocs, nil
-}
-
-// buildAndCreateSingleTxnSignature signs the block over the CIDs written in this transaction and
-// adds the signature document. It returns the signature document id, or empty when the block is
-// not signed (the block and its documents are still committed by the caller). A signature that
-// fails self-verification is not stored.
-func (h *BlockHandler) buildAndCreateSingleTxnSignature(ctx context.Context, block *types.Block, blockInt int64, collector *node.BatchCIDCollector, colBlockSig client.Collection) string {
-	collectedCIDs := collector.GetCIDs()
-
-	blockSig, err := h.signBatchFn(ctx, collector)
-	if err != nil {
-		logger.Sugar.Warnf("Block %d: signing failed: %v", blockInt, err)
-		return ""
-	}
-	if blockSig == nil {
-		logger.Sugar.Warnf("Block %d: not signing, no identity available", blockInt)
-		return ""
-	}
-
-	// The signature must verify over the CIDs it attests. A failure means signing produced an
-	// inconsistent signature, so it is not stored.
-	if valid, verifyErr := h.verifyBatchSigFn(blockSig, collectedCIDs); verifyErr != nil {
-		logger.Sugar.Warnf("Block %d: not signing, verify error: %v", blockInt, verifyErr)
-		return ""
-	} else if !valid {
-		logger.Sugar.Warnf("Block %d: not signing, signature failed self-verification", blockInt)
-		return ""
-	}
-
-	sortedCIDs := sortedCIDStrings(collectedCIDs)
-	blockSigDoc, err := h.buildBlockSignatureDocument(ctx, blockSig, block.Hash, blockInt, colBlockSig, sortedCIDs)
-	if err != nil {
-		logger.Sugar.Warnf("Block %d: failed to build block signature document: %v", blockInt, err)
-		return ""
-	}
-
-	if err := colBlockSig.AddDocument(ctx, blockSigDoc); err != nil {
-		logger.Sugar.Warnf("Block %d: failed to create block signature document: %v", blockInt, err)
-		return ""
-	}
-
-	return blockSigDoc.ID().String()
-}
-
-// trackSingleTxnDocIDs records all document IDs for pruning.
-func (h *BlockHandler) trackSingleTxnDocIDs(ctx context.Context, blockInt int64, blockID, blockSigDocID string, txHashToID map[string]string, logDocs, aleDocs []*client.Document) {
-	if h.docIDTracker == nil {
-		return
-	}
-
-	txIDs := make([]string, 0, len(txHashToID))
-	for _, id := range txHashToID {
-		txIDs = append(txIDs, id)
-	}
-	logIDs := make([]string, 0, len(logDocs))
-	for _, doc := range logDocs {
-		logIDs = append(logIDs, doc.ID().String())
-	}
-	aleIDs := make([]string, 0, len(aleDocs))
-	for _, doc := range aleDocs {
-		aleIDs = append(aleIDs, doc.ID().String())
-	}
+	blockSigDocID := h.signStoredBlock(ctx, blockInt, blockHash, allDocIDs, batchErrors, signatureCollection, collector)
 
 	result := &BlockCreationResult{
 		BlockNumber:              blockInt,
 		BlockID:                  blockID,
 		BlockSignatureID:         blockSigDocID,
-		BlockSignatureCollection: extractCollection(h.collections, "blockSignature"),
-		OtherDocIDs: map[string][]string{
-			extractCollection(h.collections, "transaction"):     txIDs,
-			extractCollection(h.collections, "log"):             logIDs,
-			extractCollection(h.collections, "accessListEntry"): aleIDs,
-		},
+		BlockSignatureCollection: signatureCollection,
+		OtherDocIDs:              otherDocIDs,
 	}
 
-	if err := h.docIDTracker.TrackBlock(ctx, blockInt, result); err != nil {
-		logger.Sugar.Warnf("Failed to track docIDs for block %d: %v", blockInt, err)
+	if h.docIDTracker != nil {
+		if err := h.docIDTracker.TrackBlock(ctx, blockInt, result); err != nil {
+			logger.Sugar.Warnf("Failed to track docIDs for block %d: %v", blockInt, err)
+		}
+	}
+
+	if len(batchErrors) > 0 {
+		return result, fmt.Errorf("block %d partially indexed with %d batch errors (first: %w)", //nolint:err113
+			blockInt, len(batchErrors), batchErrors[0])
+	}
+
+	return result, nil
+}
+
+type roleCollectionNames struct {
+	block string
+	tx    string
+	log   string
+	ale   string
+}
+
+func (h *BlockHandler) roleCollectionNames() roleCollectionNames {
+	return roleCollectionNames{
+		block: extractCollection(h.collections, chains.TypeBlock),
+		tx:    extractCollection(h.collections, chains.TypeTransaction),
+		log:   extractCollection(h.collections, chains.TypeLog),
+		ale:   extractCollection(h.collections, chains.TypeAccessListEntry),
 	}
 }
 
-// buildBlockDocument creates a client.Document for a block.
-func (h *BlockHandler) buildBlockDocument(ctx context.Context, block *types.Block, blockInt int64, col client.Collection) (*client.Document, error) {
-	data := map[string]any{
-		"hash":                     block.Hash,
-		constants.NumberFieldValue: blockInt,
-		"timestamp":                block.Timestamp,
-		"parentHash":               block.ParentHash,
-		"difficulty":               block.Difficulty,
-		"totalDifficulty":          block.TotalDifficulty,
-		"gasUsed":                  block.GasUsed,
-		"gasLimit":                 block.GasLimit,
-		"baseFeePerGas":            block.BaseFeePerGas,
-		"nonce":                    block.Nonce,
-		"miner":                    block.Miner,
-		"size":                     block.Size,
-		"stateRoot":                block.StateRoot,
-		"sha3Uncles":               block.Sha3Uncles,
-		"transactionsRoot":         block.TransactionsRoot,
-		"receiptsRoot":             block.ReceiptsRoot,
-		"logsBloom":                block.LogsBloom,
-		"extraData":                block.ExtraData,
-		"mixHash":                  block.MixHash,
-		"uncles":                   block.Uncles,
+func (h *BlockHandler) findBlockGroup(groups []chains.DocumentGroup, blockColName string) (int64, string, map[string]any, error) {
+	var blockGroup *chains.DocumentGroup
+	for i := range groups {
+		if groups[i].Collection == blockColName {
+			blockGroup = &groups[i]
+			break
+		}
 	}
-	return client.NewDocFromMap(ctx, data, col.Version())
+	if blockGroup == nil || len(blockGroup.Docs) == 0 {
+		return 0, "", nil, fmt.Errorf("no block document in groups") //nolint:err113
+	}
+	blockData := blockGroup.Docs[0]
+	blockInt, err := toInt64(blockData[constants.NumberFieldValue])
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("invalid block number: %w", err)
+	}
+	blockHash, _ := blockData["hash"].(string)
+	return blockInt, blockHash, blockData, nil
 }
 
-// buildTransactionDocument creates a client.Document for a transaction.
-func (h *BlockHandler) buildTransactionDocument(ctx context.Context, tx *types.Transaction, blockID string, col client.Collection) (*client.Document, error) {
-	txBlockNum, _ := strconv.ParseInt(tx.BlockNumber, 10, 64)
-	data := map[string]any{
-		"hash":                        tx.Hash,
-		constants.BlockNumberKeyValue: txBlockNum,
-		constants.BlockHashKeyValue:   tx.BlockHash,
-		"transactionIndex":            tx.TransactionIndex,
-		"from":                        tx.From,
-		"to":                          tx.To,
-		"value":                       tx.Value,
-		"gas":                         tx.Gas,
-		"gasPrice":                    tx.GasPrice,
-		"maxFeePerGas":                tx.MaxFeePerGas,
-		"maxPriorityFeePerGas":        tx.MaxPriorityFeePerGas,
-		"input":                       tx.Input,
-		"nonce":                       tx.Nonce,
-		"type":                        tx.Type,
-		"chainId":                     tx.ChainID,
-		"v":                           tx.V,
-		"r":                           tx.R,
-		"s":                           tx.S,
-		"cumulativeGasUsed":           tx.CumulativeGasUsed,
-		"effectiveGasPrice":           tx.EffectiveGasPrice,
-		"status":                      tx.Status,
-		"_blockID":                    blockID,
+func (h *BlockHandler) storeGroups(
+	ctx context.Context,
+	groups []chains.DocumentGroup,
+	cols roleCollectionNames,
+	blockInt int64,
+	blockID string,
+) ([]string, map[string][]string, []error) {
+	allDocIDs := []string{blockID}
+	otherDocIDs := map[string][]string{}
+	var batchErrors []error
+	txHashToID := make(map[string]string)
+
+	for _, g := range groups {
+		if g.Collection != cols.tx {
+			continue
+		}
+		ids, hashToID, err := h.storeTxGroup(ctx, blockInt, g, blockID)
+		if err != nil {
+			batchErrors = append(batchErrors, err)
+		}
+		maps.Copy(txHashToID, hashToID)
+		otherDocIDs[g.Collection] = append(otherDocIDs[g.Collection], ids...)
+		allDocIDs = append(allDocIDs, ids...)
 	}
-	return client.NewDocFromMap(ctx, data, col.Version())
+
+	for _, g := range groups {
+		switch g.Collection {
+		case cols.block, cols.tx:
+			continue
+		case cols.log:
+			ids, err := h.storeLogGroup(ctx, blockInt, g, blockID, txHashToID)
+			if err != nil {
+				batchErrors = append(batchErrors, err)
+			}
+			otherDocIDs[g.Collection] = append(otherDocIDs[g.Collection], ids...)
+			allDocIDs = append(allDocIDs, ids...)
+		case cols.ale:
+			ids, err := h.storeALEGroup(ctx, blockInt, g, txHashToID)
+			if err != nil {
+				batchErrors = append(batchErrors, err)
+			}
+			otherDocIDs[g.Collection] = append(otherDocIDs[g.Collection], ids...)
+			allDocIDs = append(allDocIDs, ids...)
+		default:
+			ids, err := h.createDocBatch(ctx, blockInt, g.Collection, g.Docs, h.maxDocsPerTxn)
+			if err != nil {
+				batchErrors = append(batchErrors, err)
+			}
+			otherDocIDs[g.Collection] = append(otherDocIDs[g.Collection], ids...)
+			allDocIDs = append(allDocIDs, ids...)
+		}
+	}
+
+	return allDocIDs, otherDocIDs, batchErrors
 }
 
-// buildLogDocument creates a client.Document for a log.
-func (h *BlockHandler) buildLogDocument(ctx context.Context, log *types.Log, blockID, txID string, col client.Collection) (*client.Document, error) {
-	logBlockNum, _ := utils.HexToInt(log.BlockNumber)
-	data := map[string]any{
-		"address":                     log.Address,
-		"topics":                      log.Topics,
-		"data":                        log.Data,
-		constants.BlockNumberKeyValue: logBlockNum,
-		"transactionHash":             log.TransactionHash,
-		"transactionIndex":            log.TransactionIndex,
-		constants.BlockHashKeyValue:   log.BlockHash,
-		"logIndex":                    log.LogIndex,
-		"removed":                     fmt.Sprintf("%v", log.Removed),
-		"_transactionID":              txID,
-		"_blockID":                    blockID,
+func (h *BlockHandler) signStoredBlock(
+	ctx context.Context,
+	blockInt int64,
+	blockHash string,
+	allDocIDs []string,
+	batchErrors []error,
+	signatureCollection string,
+	collector *node.BatchCIDCollector,
+) string {
+	for _, be := range batchErrors {
+		logger.Sugar.Warnf("Block %d: batch write error: %v", blockInt, be)
 	}
-	return client.NewDocFromMap(ctx, data, col.Version())
+
+	if len(batchErrors) > 0 {
+		logger.Sugar.Warnf("Block %d: not signing partial block: %d docs, %d batch errors",
+			blockInt, len(allDocIDs), len(batchErrors))
+		return ""
+	}
+
+	cids := collector.GetCIDs()
+	if len(cids) != len(allDocIDs) {
+		logger.Sugar.Warnf("Block %d: not signing, collected %d CIDs for %d documents",
+			blockInt, len(cids), len(allDocIDs))
+		return ""
+	}
+
+	sigID, sigErr := h.signBlockOverCIDs(ctx, blockInt, blockHash, len(allDocIDs), cids, signatureCollection)
+	if sigErr != nil {
+		logger.Sugar.Warnf("Block %d: signing failed: %v", blockInt, sigErr)
+		return ""
+	}
+	return sigID
 }
 
-// buildALEDocument creates a client.Document for an access list entry.
-func (h *BlockHandler) buildALEDocument(ctx context.Context, ale *types.AccessListEntry, txID string, blockNumber int64, col client.Collection) (*client.Document, error) {
-	data := map[string]any{
-		"address":                     ale.Address,
-		constants.BlockNumberKeyValue: blockNumber,
-		"storageKeys":                 ale.StorageKeys,
-		"_transactionID":              txID,
+// storeBlockDoc creates the block document in its own transaction.
+func (h *BlockHandler) storeBlockDoc(ctx context.Context, blockData map[string]any, blockColName string) (string, error) {
+	txn, err := h.db.NewTxn(false)
+	if err != nil {
+		return "", fmt.Errorf("create txn for block: %w", err) //nolint:err113
 	}
-	return client.NewDocFromMap(ctx, data, col.Version())
+
+	col, err := txn.GetCollectionByName(ctx, blockColName)
+	if err != nil {
+		txn.Discard()
+		return "", fmt.Errorf("get block collection: %w", err) //nolint:err113
+	}
+
+	doc, err := client.NewDocFromMap(ctx, blockData, col.Version())
+	if err != nil {
+		txn.Discard()
+		return "", fmt.Errorf("build block document: %w", err) //nolint:err113
+	}
+
+	if err := col.AddDocument(ctx, doc); err != nil {
+		txn.Discard()
+		if errors.IsErrAlreadyExists(err) {
+			return "", fmt.Errorf("block already exists") //nolint:err113
+		}
+		return "", fmt.Errorf("create block: %w", err) //nolint:err113
+	}
+
+	blockID := doc.ID().String()
+
+	if err := txn.Commit(); err != nil {
+		return "", fmt.Errorf("commit block: %w", err) //nolint:err113
+	}
+
+	return blockID, nil
+}
+
+// storeTxGroup writes transaction documents in batches, setting _blockID on each
+// and recording the hash→docID mapping for downstream link resolution.
+func (h *BlockHandler) storeTxGroup(
+	ctx context.Context,
+	blockInt int64,
+	group chains.DocumentGroup,
+	blockID string,
+) (ids []string, hashToID map[string]string, err error) {
+	hashToID = make(map[string]string)
+	batchSize := h.txBatchSize()
+
+	for i := 0; i < len(group.Docs); i += batchSize {
+		end := min(i+batchSize, len(group.Docs))
+		batch := group.Docs[i:end]
+		if len(batch) == 0 {
+			continue
+		}
+		for j := range batch {
+			batch[j]["_blockID"] = blockID
+		}
+		var batchIDs []string
+		batchErr := h.writeBatchWithRetry(ctx, blockInt, "transaction", func() error {
+			var e error
+			batchIDs, e = h.createDocsInTxn(ctx, group.Collection, batch)
+			return e
+		})
+		if batchErr != nil {
+			return ids, hashToID, batchErr
+		}
+		for j, id := range batchIDs {
+			txHash, _ := batch[j]["hash"].(string)
+			hashToID[txHash] = id
+		}
+		ids = append(ids, batchIDs...)
+	}
+	return ids, hashToID, nil
+}
+
+// storeLogGroup writes log documents in batches, setting _blockID and
+// _transactionID (resolved by matching transactionHash↔hash).
+func (h *BlockHandler) storeLogGroup(
+	ctx context.Context,
+	blockInt int64,
+	group chains.DocumentGroup,
+	blockID string,
+	txHashToID map[string]string,
+) ([]string, error) {
+	for i := range group.Docs {
+		group.Docs[i]["_blockID"] = blockID
+		txHash, _ := group.Docs[i]["transactionHash"].(string)
+		if txID, ok := txHashToID[txHash]; ok {
+			group.Docs[i]["_transactionID"] = txID
+		}
+	}
+	return h.createDocBatch(ctx, blockInt, group.Collection, group.Docs, h.logBatchSize())
+}
+
+// storeALEGroup writes access-list entry documents in batches, setting
+// _transactionID resolved from the group's ParentRef parallel array.
+func (h *BlockHandler) storeALEGroup(
+	ctx context.Context,
+	blockInt int64,
+	group chains.DocumentGroup,
+	txHashToID map[string]string,
+) ([]string, error) {
+	for i := range group.Docs {
+		if i < len(group.ParentRef) {
+			if txID, ok := txHashToID[group.ParentRef[i]]; ok {
+				group.Docs[i]["_transactionID"] = txID
+			}
+		}
+	}
+	return h.createDocBatch(ctx, blockInt, group.Collection, group.Docs, h.aleBatchSize())
+}
+
+// createDocBatch writes documents in batches of batchSize, returning all docIDs.
+func (h *BlockHandler) createDocBatch(
+	ctx context.Context,
+	blockInt int64,
+	colName string,
+	dataMaps []map[string]any,
+	batchSize int,
+) ([]string, error) {
+	var allIDs []string
+	for i := 0; i < len(dataMaps); i += batchSize {
+		end := min(i+batchSize, len(dataMaps))
+		batch := dataMaps[i:end]
+		if len(batch) == 0 {
+			continue
+		}
+		var ids []string
+		err := h.writeBatchWithRetry(ctx, blockInt, colName, func() error {
+			var e error
+			ids, e = h.createDocsInTxn(ctx, colName, batch)
+			return e
+		})
+		allIDs = append(allIDs, ids...)
+		if err != nil {
+			return allIDs, err
+		}
+	}
+	return allIDs, nil
+}
+
+// createDocsInTxn creates documents from data maps in a single transaction.
+func (h *BlockHandler) createDocsInTxn(
+	ctx context.Context,
+	colName string,
+	dataMaps []map[string]any,
+) ([]string, error) {
+	txn, err := h.db.NewTxn(false)
+	if err != nil {
+		return nil, fmt.Errorf("create txn for %s: %w", colName, err) //nolint:err113
+	}
+
+	col, err := txn.GetCollectionByName(ctx, colName)
+	if err != nil {
+		txn.Discard()
+		return nil, fmt.Errorf("get collection %s: %w", colName, err) //nolint:err113
+	}
+
+	docs := make([]*client.Document, 0, len(dataMaps))
+	for _, data := range dataMaps {
+		doc, err := client.NewDocFromMap(ctx, data, col.Version())
+		if err != nil {
+			txn.Discard()
+			return nil, fmt.Errorf("create doc in %s: %w", colName, err) //nolint:err113
+		}
+		docs = append(docs, doc)
+	}
+
+	if len(docs) == 0 {
+		txn.Discard()
+		return nil, nil
+	}
+
+	if err := col.AddManyDocuments(ctx, docs); err != nil {
+		txn.Discard()
+		if errors.IsErrAlreadyExists(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("add documents to %s: %w", colName, err) //nolint:err113
+	}
+
+	if err := txn.Commit(); err != nil {
+		return nil, fmt.Errorf("commit %s batch: %w", colName, err) //nolint:err113
+	}
+
+	ids := make([]string, len(docs))
+	for i, doc := range docs {
+		ids[i] = doc.ID().String()
+	}
+	return ids, nil
+}
+
+// SignExisting creates a block signature for a block that has already been
+// stored. It collects the stored docIDs by querying each group's collection
+// for the given block number, waits for CIDs, then signs over them.
+//
+// The groups parameter identifies which collections to query (typically the
+// same groups produced by Convert, minus the signature group). The
+// signatureCollection parameter names the collection where the block signature
+// document will be stored. The vp parameter is retained in the interface
+// signature for future use but is not needed by the current implementation.
+func (h *BlockHandler) SignExisting(
+	ctx context.Context,
+	groups []chains.DocumentGroup,
+	signatureCollection string,
+	blockHash string,
+	blockNumber int64,
+	_ chains.CollectionVersionProvider,
+) (string, error) {
+	if h.db == nil {
+		return "", fmt.Errorf("defraNode is nil") //nolint:err113
+	}
+
+	blockColName := extractCollection(h.collections, chains.TypeBlock)
+
+	var allDocIDs []string
+	for _, g := range groups {
+		field := constants.BlockNumberKeyValue
+		if g.Collection == blockColName {
+			field = constants.NumberFieldValue
+		}
+		docIDs, err := h.queryCollectionDocIDs(ctx, g.Collection, field, blockNumber, blockNumber)
+		if err != nil {
+			return "", fmt.Errorf("query docIDs for %s: %w", g.Collection, err) //nolint:err113
+		}
+		allDocIDs = append(allDocIDs, docIDs...)
+	}
+
+	cids, err := h.waitForCIDs(ctx, blockNumber, allDocIDs)
+	if err != nil {
+		return "", err
+	}
+
+	return h.signBlockOverCIDs(ctx, blockNumber, blockHash, len(allDocIDs), cids, signatureCollection)
 }
 
 // buildBlockSignatureDocument creates a client.Document for a block signature.
@@ -774,95 +789,150 @@ func (h *BlockHandler) buildBlockSignatureDocument(ctx context.Context, blockSig
 	return client.NewDocFromMap(ctx, data, col.Version())
 }
 
-// CreateBlockSignatureForExistingBlock creates a block signature for a block that already exists.
-func (h *BlockHandler) CreateBlockSignatureForExistingBlock(
-	ctx context.Context,
-	blockNumber int64,
-	blockHash string,
-	_ *types.Block,
-	_ []*types.Transaction,
-	_ []*types.TransactionReceipt,
-) (string, error) {
-	if h.db == nil {
-		return "", fmt.Errorf("defraNode is nil") //nolint: err113
-	}
+// waitForCIDs collects the CIDs for allDocIDs, retrying while they are still arriving (P2P data
+// can lag). It returns the CIDs only once every document has one; partial coverage is an error so
+// a signature is never made over a subset of the block.
+func (h *BlockHandler) waitForCIDs(ctx context.Context, blockNumber int64, allDocIDs []string) ([]cid.Cid, error) {
+	maxRetries := h.maxCIDRetries
+	var lastCIDCount int
+	var lastErr error
 
-	allDocIDs, err := h.collectExistingBlockDocIDs(ctx, blockNumber)
-	if err != nil {
-		return "", err
-	}
-
-	cids, err := h.waitForCIDs(ctx, blockNumber, allDocIDs)
-	if err != nil {
-		return "", err
-	}
-
-	return h.signBlockOverCIDs(ctx, blockNumber, blockHash, len(allDocIDs), cids)
-}
-
-// collectExistingBlockDocIDs queries the DB for all docIDs associated with the given block number.
-func (h *BlockHandler) collectExistingBlockDocIDs(ctx context.Context, blockNumber int64) ([]string, error) {
-	var allDocIDs []string
-
-	blockDocIDs, err := h.queryCollectionDocIDs(ctx, extractCollection(h.collections, "block"), constants.NumberFieldValue, blockNumber, blockNumber)
-	if err != nil {
-		return nil, fmt.Errorf("query block docIDs: %w", err)
-	}
-	allDocIDs = append(allDocIDs, blockDocIDs...)
-
-	txDocIDs, err := h.queryCollectionDocIDs(ctx, extractCollection(h.collections, "transaction"), constants.BlockNumberKeyValue, blockNumber, blockNumber)
-	if err != nil {
-		return nil, fmt.Errorf("query tx docIDs: %w", err)
-	}
-	allDocIDs = append(allDocIDs, txDocIDs...)
-
-	logDocIDs, err := h.queryCollectionDocIDs(ctx, extractCollection(h.collections, "log"), constants.BlockNumberKeyValue, blockNumber, blockNumber)
-	if err != nil {
-		return nil, fmt.Errorf("query log docIDs: %w", err)
-	}
-	allDocIDs = append(allDocIDs, logDocIDs...)
-
-	aleDocIDs, err := h.queryCollectionDocIDs(ctx, extractCollection(h.collections, "accessListEntry"), constants.BlockNumberKeyValue, blockNumber, blockNumber)
-	if err != nil {
-		return nil, fmt.Errorf("query ale docIDs: %w", err)
-	}
-	allDocIDs = append(allDocIDs, aleDocIDs...)
-
-	return allDocIDs, nil
-}
-
-// GetDocIDsByBlockRange queries all relevant collections for document IDs
-// whose block-number field falls in [from, to] inclusive. Returns docIDs
-// grouped by collection name. SnapshotSignature is excluded; BlockSignature
-// is included.
-//
-// Queries use chunked _geq/_leq GraphQL range filters, matching the
-// snapshotter's approach (pkg/snapshot/kv_snapshot.go). This works on
-// locally-indexed data; P2P-replicated data may require a different
-// strategy (see pruner).
-func (h *BlockHandler) GetDocIDsByBlockRange(ctx context.Context, from, to int64) (map[string][]string, error) {
-	collections := []struct {
-		name  string
-		field string
-	}{
-		{extractCollection(h.collections, "block"), constants.NumberFieldValue},
-		{extractCollection(h.collections, "transaction"), constants.BlockNumberKeyValue},
-		{extractCollection(h.collections, "log"), constants.BlockNumberKeyValue},
-		{extractCollection(h.collections, "accessListEntry"), constants.BlockNumberKeyValue},
-		{extractCollection(h.collections, "blockSignature"), constants.BlockNumberKeyValue},
-	}
-
-	result := make(map[string][]string)
-	for _, col := range collections {
-		docIDs, err := h.queryCollectionDocIDs(ctx, col.name, col.field, from, to)
+	for attempt := range maxRetries {
+		cids, err := h.collectDocCIDsFn(ctx, allDocIDs)
 		if err != nil {
-			return nil, fmt.Errorf("query docIDs for %s: %w", col.name, err)
+			lastErr = err
+			logger.Sugar.Warnf("Block %d: CID query failed (attempt %d/%d): %v", blockNumber, attempt+1, maxRetries, err)
+			if attempt < maxRetries-1 {
+				time.Sleep(h.retryBackoffFn(attempt))
+			}
+			continue
 		}
-		if len(docIDs) > 0 {
-			result[col.name] = docIDs
+
+		lastCIDCount = len(cids)
+		if len(cids) >= len(allDocIDs) {
+			return cids, nil
+		}
+
+		lastErr = fmt.Errorf("got %d CIDs for %d docs", len(cids), len(allDocIDs)) //nolint:err113
+		if attempt < maxRetries-1 {
+			logger.Sugar.Debugf("Block %d: waiting for P2P data (%d/%d CIDs, attempt %d/%d)",
+				blockNumber, len(cids), len(allDocIDs), attempt+1, maxRetries)
+			time.Sleep(h.retryBackoffFn(attempt))
 		}
 	}
-	return result, nil
+
+	if lastCIDCount == 0 {
+		return nil, fmt.Errorf("no CIDs found for block %d after %d retries (%d docs): %w", //nolint:err113
+			blockNumber, maxRetries, len(allDocIDs), lastErr)
+	}
+	return nil, fmt.Errorf("incomplete CID coverage for block %d after %d retries (%d/%d docs): %w", //nolint:err113
+		blockNumber, maxRetries, lastCIDCount, len(allDocIDs), lastErr)
+}
+
+// signBlockOverCIDs signs the block over cids and stores the signature, returning its document id.
+// docCount is the number of documents the CIDs cover and is used only for logging.
+// signatureCollection names the collection where the signature document is stored.
+func (h *BlockHandler) signBlockOverCIDs(ctx context.Context, blockNumber int64, blockHash string, docCount int, cids []cid.Cid, signatureCollection string) (string, error) {
+	collector := node.NewBatchCIDCollector()
+	for _, c := range cids {
+		collector.Add(c)
+	}
+
+	blockSig, err := h.signBatchFn(ctx, collector)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign block: %w", err) //nolint: err113
+	}
+	if blockSig == nil {
+		return "", fmt.Errorf("signing returned nil (no identity?)") //nolint: err113
+	}
+
+	// The signature must verify over the CIDs it is about to attest. A failure means signing
+	// produced an inconsistent signature, so it is not stored.
+	if valid, verifyErr := h.verifyBatchSigFn(blockSig, cids); verifyErr != nil {
+		return "", fmt.Errorf("verify block signature: %w", verifyErr) //nolint: err113
+	} else if !valid {
+		return "", fmt.Errorf("block signature failed self-verification") //nolint: err113
+	}
+
+	sigTxn, err := h.db.NewTxn(false)
+	if err != nil {
+		return "", fmt.Errorf("failed to create signing transaction: %w", err) //nolint: err113
+	}
+
+	colBlockSig, err := sigTxn.GetCollectionByName(ctx, signatureCollection)
+	if err != nil {
+		sigTxn.Discard()
+		return "", fmt.Errorf("failed to get block signature collection: %w", err) //nolint: err113
+	}
+
+	sortedCIDs := sortedCIDStrings(cids)
+	blockSigDoc, err := h.buildBlockSignatureDocument(ctx, blockSig, blockHash, blockNumber, colBlockSig, sortedCIDs)
+	if err != nil {
+		sigTxn.Discard()
+		return "", fmt.Errorf("failed to build block signature document: %w", err) //nolint: err113
+	}
+
+	if err := colBlockSig.AddDocument(ctx, blockSigDoc); err != nil {
+		sigTxn.Discard()
+		return "", fmt.Errorf("failed to create block signature document: %w", err) //nolint: err113
+	}
+
+	if err := sigTxn.Commit(); err != nil {
+		return "", fmt.Errorf("failed to commit block signature: %w", err) //nolint: err113
+	}
+
+	docID := blockSigDoc.ID().String()
+	logger.Sugar.Infof("Block %d: signed (%d docs, %d CIDs, identity: %s...)",
+		blockNumber, docCount, len(cids), truncate(string(blockSig.Header.Identity), 16)) //nolint:mnd
+
+	return docID, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+const (
+	// maxBatchRetries caps how many times a batch write is attempted when it hits a transaction
+	// conflict. Document creates share the /seq/doc sequence, so concurrent writers collide; a
+	// retry rebuilds and re-commits the batch.
+	maxBatchRetries = 3
+	// batchConflictRetryDelay is the base delay between batch retries; the wait grows linearly with
+	// the attempt (50ms, 100ms, ...).
+	batchConflictRetryDelay = 50 * time.Millisecond
+)
+
+// writeBatchWithRetry runs write, retrying on a transaction conflict up to maxBatchRetries with
+// backoff. A discarded attempt's collected CIDs are rolled back so the collector reflects only
+// committed writes. kind names the batch for the retry log.
+func (h *BlockHandler) writeBatchWithRetry(ctx context.Context, blockInt int64, kind string, write func() error) error {
+	collector := node.BatchSigningCollectorFromContext(ctx)
+	for attempt := range maxBatchRetries {
+		mark := 0
+		if collector != nil {
+			mark = collector.Len()
+		}
+		err := write()
+		if err == nil {
+			return nil
+		}
+		if collector != nil {
+			collector.Truncate(mark)
+		}
+		if !errors.IsErrTransactionConflict(err) {
+			return err
+		}
+		if attempt == maxBatchRetries-1 {
+			logger.Sugar.Warnf("Block %d: %s batch still conflicting after %d attempts, giving up", blockInt, kind, maxBatchRetries)
+			return err
+		}
+		logger.Sugar.Infof("Block %d: %s batch conflict, retrying (attempt %d/%d)", blockInt, kind, attempt+1, maxBatchRetries)
+		time.Sleep(time.Duration(attempt+1) * batchConflictRetryDelay)
+	}
+	return nil
 }
 
 // queryCollectionDocIDs queries a single collection for all document IDs
@@ -923,609 +993,4 @@ func (h *BlockHandler) queryCollectionDocIDs(ctx context.Context, colName, field
 	}
 
 	return allDocIDs, nil
-}
-
-// waitForCIDs collects the CIDs for allDocIDs, retrying while they are still arriving (P2P data
-// can lag). It returns the CIDs only once every document has one; partial coverage is an error so
-// a signature is never made over a subset of the block.
-func (h *BlockHandler) waitForCIDs(ctx context.Context, blockNumber int64, allDocIDs []string) ([]cid.Cid, error) {
-	maxRetries := h.maxCIDRetries
-	var lastCIDCount int
-	var lastErr error
-
-	for attempt := range maxRetries {
-		cids, err := h.collectDocCIDsFn(ctx, allDocIDs)
-		if err != nil {
-			lastErr = err
-			logger.Sugar.Warnf("Block %d: CID query failed (attempt %d/%d): %v", blockNumber, attempt+1, maxRetries, err)
-			if attempt < maxRetries-1 {
-				time.Sleep(h.retryBackoffFn(attempt))
-			}
-			continue
-		}
-
-		lastCIDCount = len(cids)
-		if len(cids) >= len(allDocIDs) {
-			return cids, nil
-		}
-
-		lastErr = fmt.Errorf("got %d CIDs for %d docs", len(cids), len(allDocIDs)) //nolint:err113
-		if attempt < maxRetries-1 {
-			logger.Sugar.Debugf("Block %d: waiting for P2P data (%d/%d CIDs, attempt %d/%d)",
-				blockNumber, len(cids), len(allDocIDs), attempt+1, maxRetries)
-			time.Sleep(h.retryBackoffFn(attempt))
-		}
-	}
-
-	if lastCIDCount == 0 {
-		return nil, fmt.Errorf("no CIDs found for block %d after %d retries (%d docs): %w", //nolint:err113
-			blockNumber, maxRetries, len(allDocIDs), lastErr)
-	}
-	return nil, fmt.Errorf("incomplete CID coverage for block %d after %d retries (%d/%d docs): %w", //nolint:err113
-		blockNumber, maxRetries, lastCIDCount, len(allDocIDs), lastErr)
-}
-
-// signBlockOverCIDs signs the block over cids and stores the signature, returning its document id.
-// docCount is the number of documents the CIDs cover and is used only for logging.
-func (h *BlockHandler) signBlockOverCIDs(ctx context.Context, blockNumber int64, blockHash string, docCount int, cids []cid.Cid) (string, error) {
-	collector := node.NewBatchCIDCollector()
-	for _, c := range cids {
-		collector.Add(c)
-	}
-
-	blockSig, err := h.signBatchFn(ctx, collector)
-	if err != nil {
-		return "", fmt.Errorf("failed to sign block: %w", err) //nolint: err113
-	}
-	if blockSig == nil {
-		return "", fmt.Errorf("signing returned nil (no identity?)") //nolint: err113
-	}
-
-	// The signature must verify over the CIDs it is about to attest. A failure means signing
-	// produced an inconsistent signature, so it is not stored.
-	if valid, verifyErr := h.verifyBatchSigFn(blockSig, cids); verifyErr != nil {
-		return "", fmt.Errorf("verify block signature: %w", verifyErr) //nolint: err113
-	} else if !valid {
-		return "", fmt.Errorf("block signature failed self-verification") //nolint: err113
-	}
-
-	sigTxn, err := h.db.NewTxn(false)
-	if err != nil {
-		return "", fmt.Errorf("failed to create signing transaction: %w", err) //nolint: err113
-	}
-
-	colBlockSig, err := sigTxn.GetCollectionByName(ctx, extractCollection(h.collections, "blockSignature"))
-	if err != nil {
-		sigTxn.Discard()
-		return "", fmt.Errorf("failed to get block signature collection: %w", err) //nolint: err113
-	}
-
-	sortedCIDs := sortedCIDStrings(cids)
-	blockSigDoc, err := h.buildBlockSignatureDocument(ctx, blockSig, blockHash, blockNumber, colBlockSig, sortedCIDs)
-	if err != nil {
-		sigTxn.Discard()
-		return "", fmt.Errorf("failed to build block signature document: %w", err) //nolint: err113
-	}
-
-	if err := colBlockSig.AddDocument(ctx, blockSigDoc); err != nil {
-		sigTxn.Discard()
-		return "", fmt.Errorf("failed to create block signature document: %w", err) //nolint: err113
-	}
-
-	if err := sigTxn.Commit(); err != nil {
-		return "", fmt.Errorf("failed to commit block signature: %w", err) //nolint: err113
-	}
-
-	docID := blockSigDoc.ID().String()
-	logger.Sugar.Infof("Block %d: signed (%d docs, %d CIDs, identity: %s...)",
-		blockNumber, docCount, len(cids), truncate(string(blockSig.Header.Identity), 16)) //nolint:mnd
-
-	return docID, nil
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n]
-}
-
-// expectedBlockDocCount returns how many documents a fully written block contains: one Block,
-// one per transaction, one per log, and one per access-list entry. A shortfall against the
-// written set means a batch was dropped, so the block must not be signed.
-func expectedBlockDocCount(transactions []*types.Transaction, receiptMap map[string]*types.TransactionReceipt) int {
-	txs, logs, ales := 0, 0, 0
-	for _, tx := range transactions {
-		if tx == nil {
-			continue
-		}
-		txs++
-		if receipt, ok := receiptMap[tx.Hash]; ok && receipt != nil {
-			logs += len(receipt.Logs)
-		}
-		ales += len(tx.AccessList)
-	}
-	return 1 + txs + logs + ales
-}
-
-// createBlockBatched creates all documents for a block using batched transactions. It is the
-// path for blocks exceeding maxDocsPerTxn.
-func (h *BlockHandler) createBlockBatched(ctx context.Context, block *types.Block, blockInt int64, transactions []*types.Transaction, receiptMap map[string]*types.TransactionReceipt) (string, error) {
-	// The batch collector puts DefraDB in batch-signing mode: per-block signing is skipped and the
-	// block is signed once, below, over the CIDs the writes commit. The collector records one CID
-	// per document (its composite head), which is the set the signature attests.
-	collector := node.NewBatchCIDCollector()
-	ctx = node.ContextWithBatchSigning(ctx, collector)
-
-	blockID, err := h.createBlockDocument(ctx, block, blockInt)
-	if err != nil {
-		return "", err
-	}
-
-	txHashToID, batchErrors := h.batchCreateTransactions(ctx, blockInt, transactions, blockID)
-	allTxIDs := make([]string, 0, len(txHashToID))
-	for _, id := range txHashToID {
-		allTxIDs = append(allTxIDs, id)
-	}
-
-	allLogIDs, logErrors := h.batchCreateLogs(ctx, blockInt, transactions, receiptMap, blockID, txHashToID)
-	batchErrors = append(batchErrors, logErrors...)
-
-	allALEIDs, aleErrors := h.batchCreateALEs(ctx, blockInt, transactions, txHashToID)
-	batchErrors = append(batchErrors, aleErrors...)
-
-	allDocIDs := make([]string, 0, 1+len(allTxIDs)+len(allLogIDs)+len(allALEIDs))
-	allDocIDs = append(allDocIDs, blockID)
-	allDocIDs = append(allDocIDs, allTxIDs...)
-	allDocIDs = append(allDocIDs, allLogIDs...)
-	allDocIDs = append(allDocIDs, allALEIDs...)
-
-	for _, be := range batchErrors {
-		logger.Sugar.Warnf("Block %d: batch write error: %v", blockInt, be)
-	}
-
-	// Sign only a fully written block, over the CIDs the DB committed. A conflict can drop a
-	// batch and leave the set short; such a block stays unsigned rather than attesting a merkle
-	// root over documents it does not hold.
-	blockSigDocID := ""
-	expectedDocs := expectedBlockDocCount(transactions, receiptMap)
-	if len(batchErrors) == 0 && len(allDocIDs) == expectedDocs {
-		// The collector holds one CID per committed document. Read it before signBlockOverCIDs
-		// writes the signature doc, which would add its own CID. A count short of the written set
-		// means a document was missed, so skip signing rather than attest a subset.
-		cids := collector.GetCIDs()
-		if len(cids) != len(allDocIDs) {
-			logger.Sugar.Warnf("Block %d: not signing, collected %d CIDs for %d documents", blockInt, len(cids), len(allDocIDs))
-		} else if sigID, sigErr := h.signBlockOverCIDs(ctx, blockInt, block.Hash, len(allDocIDs), cids); sigErr != nil {
-			logger.Sugar.Warnf("Block %d: signing failed: %v", blockInt, sigErr)
-		} else {
-			blockSigDocID = sigID
-		}
-	} else {
-		logger.Sugar.Warnf("Block %d: not signing partial block: %d/%d docs (txs %d, logs %d, ALEs %d), %d batch errors",
-			blockInt, len(allDocIDs), expectedDocs, len(allTxIDs), len(allLogIDs), len(allALEIDs), len(batchErrors))
-	}
-
-	if h.docIDTracker != nil {
-		result := &BlockCreationResult{
-			BlockNumber:              blockInt,
-			BlockID:                  blockID,
-			BlockSignatureID:         blockSigDocID,
-			BlockSignatureCollection: extractCollection(h.collections, "blockSignature"),
-			OtherDocIDs: map[string][]string{
-				extractCollection(h.collections, "transaction"):     allTxIDs,
-				extractCollection(h.collections, "log"):             allLogIDs,
-				extractCollection(h.collections, "accessListEntry"): allALEIDs,
-			},
-		}
-		if err := h.docIDTracker.TrackBlock(ctx, blockInt, result); err != nil {
-			logger.Sugar.Warnf("Failed to track docIDs for block %d: %v", blockInt, err)
-		}
-	}
-
-	if len(batchErrors) > 0 {
-		return blockID, fmt.Errorf("block %d partially indexed with %d batch errors (first: %w)", blockInt, len(batchErrors), batchErrors[0])
-	}
-
-	return blockID, nil
-}
-
-// createBlockDocument creates the block document in its own transaction.
-func (h *BlockHandler) createBlockDocument(ctx context.Context, block *types.Block, blockInt int64) (string, error) {
-	txn, err := h.db.NewTxn(false)
-	if err != nil {
-		return "", errors.NewQueryFailed("defra", "createBlockBatched", "failed to create transaction", err)
-	}
-
-	colBlock, err := txn.GetCollectionByName(ctx, extractCollection(h.collections, "block"))
-	if err != nil {
-		txn.Discard()
-		return "", errors.NewQueryFailed("defra", "createBlockBatched", "failed to get block collection", err)
-	}
-
-	blockDoc, err := h.buildBlockDocument(ctx, block, blockInt, colBlock)
-	if err != nil {
-		txn.Discard()
-		return "", errors.NewQueryFailed("defra", "createBlockBatched", "failed to build block document", err)
-	}
-
-	if err := colBlock.AddDocument(ctx, blockDoc); err != nil {
-		txn.Discard()
-		if errors.IsErrAlreadyExists(err) {
-			return "", fmt.Errorf("block already exists") //nolint: err113
-		}
-		return "", errors.NewQueryFailed("defra", "createBlockBatched", "failed to create block", err)
-	}
-
-	blockID := blockDoc.ID().String()
-
-	if err := txn.Commit(); err != nil {
-		return "", errors.NewQueryFailed("defra", "createBlockBatched", "failed to commit block", err)
-	}
-
-	return blockID, nil
-}
-
-const (
-	// maxBatchRetries caps how many times a batch write is attempted when it hits a transaction
-	// conflict. Document creates share the /seq/doc sequence, so concurrent writers collide; a
-	// retry rebuilds and re-commits the batch.
-	maxBatchRetries = 3
-	// batchConflictRetryDelay is the base delay between batch retries; the wait grows linearly with
-	// the attempt (50ms, 100ms, ...).
-	batchConflictRetryDelay = 50 * time.Millisecond
-)
-
-// writeBatchWithRetry runs write, retrying on a transaction conflict up to maxBatchRetries with
-// backoff. A discarded attempt's collected CIDs are rolled back so the collector reflects only
-// committed writes. kind names the batch for the retry log.
-func (h *BlockHandler) writeBatchWithRetry(ctx context.Context, blockInt int64, kind string, write func() error) error {
-	collector := node.BatchSigningCollectorFromContext(ctx)
-	for attempt := range maxBatchRetries {
-		mark := 0
-		if collector != nil {
-			mark = collector.Len()
-		}
-		err := write()
-		if err == nil {
-			return nil
-		}
-		if collector != nil {
-			collector.Truncate(mark)
-		}
-		if !errors.IsErrTransactionConflict(err) {
-			return err
-		}
-		if attempt == maxBatchRetries-1 {
-			logger.Sugar.Warnf("Block %d: %s batch still conflicting after %d attempts, giving up", blockInt, kind, maxBatchRetries)
-			return err
-		}
-		logger.Sugar.Infof("Block %d: %s batch conflict, retrying (attempt %d/%d)", blockInt, kind, attempt+1, maxBatchRetries)
-		time.Sleep(time.Duration(attempt+1) * batchConflictRetryDelay)
-	}
-	return nil
-}
-
-// batchCreateTransactions creates transaction documents in batches, retrying a batch on conflict.
-func (h *BlockHandler) batchCreateTransactions(ctx context.Context, blockInt int64, transactions []*types.Transaction, blockID string) (map[string]string, []error) {
-	txHashToID := make(map[string]string)
-	var batchErrors []error
-
-	txBS := h.txBatchSize()
-	for i := 0; i < len(transactions); i += txBS {
-		end := min(i+txBS, len(transactions))
-		batch := transactions[i:end]
-		if len(batch) == 0 {
-			continue
-		}
-
-		var ids map[string]string
-		err := h.writeBatchWithRetry(ctx, blockInt, "transaction", func() error {
-			var e error
-			ids, e = h.createTransactionBatch(ctx, blockInt, batch, blockID)
-			return e
-		})
-		maps.Copy(txHashToID, ids)
-		if err != nil {
-			batchErrors = append(batchErrors, err)
-		}
-	}
-
-	return txHashToID, batchErrors
-}
-
-// createTransactionBatch writes one batch of transaction documents in a single transaction and
-// returns the hash-to-docID map for the batch.
-func (h *BlockHandler) createTransactionBatch(ctx context.Context, blockInt int64, batch []*types.Transaction, blockID string) (map[string]string, error) {
-	txn, err := h.db.NewTxn(false)
-	if err != nil {
-		return nil, fmt.Errorf("create txn for tx batch: %w", err)
-	}
-	colTx, err := txn.GetCollectionByName(ctx, extractCollection(h.collections, "transaction"))
-	if err != nil {
-		txn.Discard()
-		return nil, fmt.Errorf("get tx collection: %w", err)
-	}
-
-	txDocs := make([]*client.Document, 0, len(batch))
-	txHashes := make([]string, 0, len(batch))
-	for _, tx := range batch {
-		if tx == nil {
-			continue
-		}
-		txDoc, err := h.buildTransactionDocument(ctx, tx, blockID, colTx)
-		if err != nil {
-			logger.Sugar.Warnf("Block %d: failed to build tx document %s, skipping: %v", blockInt, tx.Hash, err)
-			continue
-		}
-		txDocs = append(txDocs, txDoc)
-		txHashes = append(txHashes, tx.Hash)
-	}
-
-	ids := make(map[string]string, len(txDocs))
-	if len(txDocs) > 0 {
-		if err := colTx.AddManyDocuments(ctx, txDocs); err != nil {
-			txn.Discard()
-			if errors.IsErrAlreadyExists(err) {
-				logger.Sugar.Warnf("Block %d: transaction batch already exists, skipping %d txs; their logs and access-list entries are skipped too", blockInt, len(txDocs))
-				return ids, nil
-			}
-			return nil, fmt.Errorf("create tx batch: %w", err)
-		}
-		for i, doc := range txDocs {
-			ids[txHashes[i]] = doc.ID().String()
-		}
-	}
-
-	if err := txn.Commit(); err != nil {
-		return nil, fmt.Errorf("commit tx batch: %w", err)
-	}
-
-	return ids, nil
-}
-
-// batchCreateLogs creates log documents in batches.
-func (h *BlockHandler) batchCreateLogs(ctx context.Context, blockInt int64, transactions []*types.Transaction, receiptMap map[string]*types.TransactionReceipt, blockID string, txHashToID map[string]string) ([]string, []error) {
-	var allLogs []logEntry
-	skippedLogs := 0
-	for _, tx := range transactions {
-		if tx == nil {
-			continue
-		}
-		receipt, ok := receiptMap[tx.Hash]
-		if !ok || receipt == nil {
-			continue
-		}
-		txID, ok := txHashToID[tx.Hash]
-		if !ok {
-			skippedLogs += len(receipt.Logs)
-			continue
-		}
-		for i := range receipt.Logs {
-			allLogs = append(allLogs, logEntry{log: &receipt.Logs[i], txID: txID})
-		}
-	}
-	if skippedLogs > 0 {
-		logger.Sugar.Warnf("Block %d: skipping %d logs whose transaction was not written", blockInt, skippedLogs)
-	}
-
-	var allLogIDs []string
-	var batchErrors []error
-	logBS := h.logBatchSize()
-	for i := 0; i < len(allLogs); i += logBS {
-		end := min(i+logBS, len(allLogs))
-		batch := allLogs[i:end]
-		if len(batch) == 0 {
-			continue
-		}
-		var ids []string
-		err := h.writeBatchWithRetry(ctx, blockInt, "log", func() error {
-			var e error
-			ids, e = h.createLogBatch(ctx, blockInt, blockID, batch)
-			return e
-		})
-		allLogIDs = append(allLogIDs, ids...)
-		if err != nil {
-			batchErrors = append(batchErrors, err)
-		}
-	}
-
-	return allLogIDs, batchErrors
-}
-
-// createLogBatch creates a single batch of log documents in one transaction.
-func (h *BlockHandler) createLogBatch(ctx context.Context, blockInt int64, blockID string, batch []logEntry) ([]string, error) {
-	txn, err := h.db.NewTxn(false)
-	if err != nil {
-		return nil, fmt.Errorf("create txn for log batch: %w", err)
-	}
-	colLog, err := txn.GetCollectionByName(ctx, extractCollection(h.collections, "log"))
-	if err != nil {
-		txn.Discard()
-		return nil, fmt.Errorf("get log collection: %w", err)
-	}
-
-	var ids []string
-	logDocs := make([]*client.Document, 0, len(batch))
-	for _, entry := range batch {
-		if entry.log == nil {
-			continue
-		}
-		logDoc, err := h.buildLogDocument(ctx, entry.log, blockID, entry.txID, colLog)
-		if err != nil {
-			logger.Sugar.Warnf("Block %d: failed to build log document, skipping: %v", blockInt, err)
-			continue
-		}
-		logDocs = append(logDocs, logDoc)
-	}
-
-	if len(logDocs) > 0 {
-		if err := colLog.AddManyDocuments(ctx, logDocs); err != nil {
-			txn.Discard()
-			if errors.IsErrAlreadyExists(err) {
-				logger.Sugar.Warnf("Block %d: log batch already exists, skipping %d logs", blockInt, len(logDocs))
-				return nil, nil
-			}
-			return nil, fmt.Errorf("create log batch: %w", err)
-		}
-		for _, doc := range logDocs {
-			ids = append(ids, doc.ID().String())
-		}
-	}
-
-	if err := txn.Commit(); err != nil {
-		return nil, fmt.Errorf("commit log batch: %w", err)
-	}
-
-	return ids, nil
-}
-
-// batchCreateALEs creates access list entry documents in batches.
-func (h *BlockHandler) batchCreateALEs(ctx context.Context, blockInt int64, transactions []*types.Transaction, txHashToID map[string]string) ([]string, []error) {
-	var allALEs []aleEntry
-	skippedALEs := 0
-	for _, tx := range transactions {
-		if tx == nil {
-			continue
-		}
-		txID, ok := txHashToID[tx.Hash]
-		if !ok {
-			skippedALEs += len(tx.AccessList)
-			continue
-		}
-		for i := range tx.AccessList {
-			allALEs = append(allALEs, aleEntry{ale: &tx.AccessList[i], txID: txID, blockNumber: blockInt})
-		}
-	}
-	if skippedALEs > 0 {
-		logger.Sugar.Warnf("Block %d: skipping %d access-list entries whose transaction was not written", blockInt, skippedALEs)
-	}
-
-	var allALEIDs []string
-	var batchErrors []error
-	aleBS := h.aleBatchSize()
-	for i := 0; i < len(allALEs); i += aleBS {
-		end := min(i+aleBS, len(allALEs))
-		batch := allALEs[i:end]
-		var ids []string
-		err := h.writeBatchWithRetry(ctx, blockInt, "access-list", func() error {
-			var e error
-			ids, e = h.createALEBatch(ctx, blockInt, batch)
-			return e
-		})
-		allALEIDs = append(allALEIDs, ids...)
-		if err != nil {
-			batchErrors = append(batchErrors, err)
-		}
-	}
-
-	return allALEIDs, batchErrors
-}
-
-// createALEBatch creates a single batch of ALE documents in one transaction.
-func (h *BlockHandler) createALEBatch(ctx context.Context, blockInt int64, batch []aleEntry) ([]string, error) {
-	txn, err := h.db.NewTxn(false)
-	if err != nil {
-		return nil, fmt.Errorf("create txn for ALE batch: %w", err)
-	}
-	colALE, err := txn.GetCollectionByName(ctx, extractCollection(h.collections, "accessListEntry"))
-	if err != nil {
-		txn.Discard()
-		return nil, fmt.Errorf("get ALE collection: %w", err)
-	}
-
-	var ids []string
-	aleDocs := make([]*client.Document, 0, len(batch))
-	for _, entry := range batch {
-		if entry.ale == nil {
-			continue
-		}
-		aleDoc, err := h.buildALEDocument(ctx, entry.ale, entry.txID, entry.blockNumber, colALE)
-		if err != nil {
-			logger.Sugar.Warnf("Block %d: failed to build access-list document, skipping: %v", blockInt, err)
-			continue
-		}
-		aleDocs = append(aleDocs, aleDoc)
-	}
-
-	if len(aleDocs) > 0 {
-		if err := colALE.AddManyDocuments(ctx, aleDocs); err != nil {
-			txn.Discard()
-			if errors.IsErrAlreadyExists(err) {
-				logger.Sugar.Warnf("Block %d: access-list batch already exists, skipping %d entries", blockInt, len(aleDocs))
-				return nil, nil
-			}
-			return nil, fmt.Errorf("create ALE batch: %w", err)
-		}
-		for _, doc := range aleDocs {
-			ids = append(ids, doc.ID().String())
-		}
-	}
-
-	if err := txn.Commit(); err != nil {
-		return nil, fmt.Errorf("commit ALE batch: %w", err)
-	}
-
-	return ids, nil
-}
-
-// GetHighestBlockNumber returns the highest block number stored in DefraDB.
-func (h *BlockHandler) GetHighestBlockNumber(ctx context.Context) (int64, error) {
-	return h.queryBlockNumber(ctx, "DESC", "GetHighestBlockNumber")
-}
-
-// GetLowestBlockNumber returns the lowest block number stored in DefraDB.
-// It mirrors GetHighestBlockNumber but orders ascending and selects the first
-// row. It returns an error matching errors.IsErrNotFound when no blocks are
-// stored.
-func (h *BlockHandler) GetLowestBlockNumber(ctx context.Context) (int64, error) {
-	return h.queryBlockNumber(ctx, "ASC", "GetLowestBlockNumber")
-}
-
-// queryBlockNumber runs the single-row block-number query with the given
-// ordering ("DESC" or "ASC") and tags all errors with opName.
-func (h *BlockHandler) queryBlockNumber(ctx context.Context, order, opName string) (int64, error) {
-	blockCol := extractCollection(h.collections, "block")
-	query := `query {` + blockCol + ` (order: {number: ` + order + `}, limit: 1) { number }}`
-
-	result := h.db.ExecRequest(ctx, query)
-	if len(result.GQL.Errors) > 0 {
-		return 0, errors.NewQueryFailed("defra", opName, query, result.GQL.Errors[0])
-	}
-
-	data, ok := result.GQL.Data.(map[string]any)
-	if !ok {
-		return 0, errors.NewDocumentNotFound("defra", opName, blockCol, "no data")
-	}
-
-	var block map[string]any
-	switch arr := data[blockCol].(type) {
-	case []any:
-		if len(arr) == 0 {
-			return 0, errors.NewDocumentNotFound("defra", opName, blockCol, "no blocks")
-		}
-		var ok bool
-		block, ok = arr[0].(map[string]any)
-		if !ok {
-			return 0, fmt.Errorf("%s: %w", opName, ErrBlockNumberCorrupt)
-		}
-	case []map[string]any:
-		if len(arr) == 0 {
-			return 0, errors.NewDocumentNotFound("defra", opName, blockCol, "no blocks")
-		}
-		block = arr[0]
-	default:
-		return 0, errors.NewDocumentNotFound("defra", opName, blockCol, "no blocks")
-	}
-
-	switch v := block[constants.NumberFieldValue].(type) {
-	case float64:
-		return int64(v), nil
-	case int64:
-		return v, nil
-	case int:
-		return int64(v), nil
-	}
-
-	return 0, fmt.Errorf("%s: %w", opName, ErrBlockNumberCorrupt)
 }

--- a/pkg/defra/block_handler_defra_test.go
+++ b/pkg/defra/block_handler_defra_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
@@ -105,11 +106,21 @@ func mockReceipt(txHash string, blockNumber string) *types.TransactionReceipt {
 }
 
 // buildGroups is a test helper that converts raw EVM types into DocumentGroups.
-func buildGroups(t *testing.T, cols chains.Collections, block *types.Block, txs []*types.Transaction, receipts []*types.TransactionReceipt) ([]chains.DocumentGroup, string) {
+func buildGroups(t *testing.T, cols chains.Collections, block *types.Block, txs []*types.Transaction, receipts []*types.TransactionReceipt) chains.ConversionResult {
 	t.Helper()
-	groups, sigCol, err := testutils.BuildEVMGroups(cols, block, txs, receipts)
+	result, err := testutils.BuildEVMGroups(cols, block, txs, receipts)
 	require.NoError(t, err)
-	return groups, sigCol
+	return result
+}
+
+// extractCollection is a test helper that resolves a collection name by role,
+// panicking on failure (programmer error).
+func extractCollection(collections chains.Collections, role string) string {
+	name, err := collections.GetCollection(role)
+	if err != nil {
+		panic(fmt.Sprintf("programmer error: %v", err))
+	}
+	return name
 }
 
 // ---------------------------------------------------------------------------
@@ -120,7 +131,7 @@ func TestNewBlockHandler_WithNode(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 	assert.Equal(t, 1000, handler.maxDocsPerTxn)
@@ -130,12 +141,12 @@ func TestNewBlockHandler_DefaultMaxDocsWithNode(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 
-	handler, err := NewBlockHandler(td.Node, 0, chains.NewStubCollections("Ethereum__Mainnet"))
+	handler, err := NewBlockHandler(td.Node, 0)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 	assert.Equal(t, 1000, handler.maxDocsPerTxn, "maxDocsPerTxn should default to 1000 when 0")
 
-	handler2, err := NewBlockHandler(td.Node, -5, chains.NewStubCollections("Ethereum__Mainnet"))
+	handler2, err := NewBlockHandler(td.Node, -5)
 	require.NoError(t, err)
 	require.NotNil(t, handler2)
 	assert.Equal(t, 1000, handler2.maxDocsPerTxn, "maxDocsPerTxn should default to 1000 when negative")
@@ -160,12 +171,12 @@ func TestStore_BlockOnly(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0x64") // 100
-	groups, sigCol := buildGroups(t, cols, block, nil, nil)
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, nil, nil)
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -174,15 +185,15 @@ func TestStore_WithTransaction(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0xC8") // 200
 	tx := mockTransaction("0xabc1000000000000000000000000000000000000000000000000000000000001", "200")
 	receipt := mockReceipt("0xabc1000000000000000000000000000000000000000000000000000000000001", "0xC8")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -191,7 +202,7 @@ func TestStore_WithAccessList(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0x12C") // 300
@@ -204,8 +215,8 @@ func TestStore_WithAccessList(t *testing.T) {
 	}
 	receipt := mockReceipt("0xabc2000000000000000000000000000000000000000000000000000000000002", "0x12C")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -213,7 +224,7 @@ func TestStore_WithAccessList(t *testing.T) {
 func TestStore_NilBlock(t *testing.T) {
 	t.Parallel()
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	_, _, err := testutils.BuildEVMGroups(cols, nil, nil, nil)
+	_, err := testutils.BuildEVMGroups(cols, nil, nil, nil)
 	require.Error(t, err)
 }
 
@@ -221,7 +232,7 @@ func TestStore_InvalidBlockNumber(t *testing.T) {
 	t.Parallel()
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
 	block := mockBlock("invalid")
-	_, _, err := testutils.BuildEVMGroups(cols, block, nil, nil)
+	_, err := testutils.BuildEVMGroups(cols, block, nil, nil)
 	require.Error(t, err)
 }
 
@@ -229,16 +240,16 @@ func TestStore_DuplicateBlock(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0x190") // 400
-	groups, sigCol := buildGroups(t, cols, block, nil, nil)
-	_, err = handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(context.Background(), result)
 	require.NoError(t, err)
 
-	groups2, sigCol2 := buildGroups(t, cols, block, nil, nil)
-	_, err = handler.Store(context.Background(), groups2, sigCol2, nil)
+	result2 := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(context.Background(), result2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }
@@ -246,7 +257,7 @@ func TestStore_DuplicateBlock(t *testing.T) {
 func TestStore_NilDefraNode(t *testing.T) {
 	t.Parallel()
 	handler := &BlockHandler{maxDocsPerTxn: 1000}
-	_, err := handler.Store(context.Background(), nil, "", nil)
+	_, err := handler.Store(context.Background(), chains.ConversionResult{})
 	require.Error(t, err)
 }
 
@@ -254,7 +265,7 @@ func TestStore_WithDocIDTracker(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
@@ -264,8 +275,8 @@ func TestStore_WithDocIDTracker(t *testing.T) {
 	tx := mockTransaction("0xabc3000000000000000000000000000000000000000000000000000000000003", "500")
 	receipt := mockReceipt("0xabc3000000000000000000000000000000000000000000000000000000000003", "0x1F4")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 
@@ -280,15 +291,15 @@ func TestStore_NilTransaction(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0x258") // 600
 	txs := []*types.Transaction{nil, mockTransaction("0xabc4000000000000000000000000000000000000000000000000000000000004", "600")}
 	receipt := mockReceipt("0xabc4000000000000000000000000000000000000000000000000000000000004", "0x258")
 
-	groups, sigCol := buildGroups(t, cols, block, txs, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, txs, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -297,15 +308,15 @@ func TestStore_NilReceipt(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0x2BC") // 700
 	tx := mockTransaction("0xabc5000000000000000000000000000000000000000000000000000000000005", "700")
 	receipts := []*types.TransactionReceipt{nil}
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, receipts)
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, receipts)
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -318,7 +329,7 @@ func TestStore_BatchedMode(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	block := mockBlock("0x320") // 800
@@ -327,8 +338,8 @@ func TestStore_BatchedMode(t *testing.T) {
 	receipt1 := mockReceipt("0xabc6000000000000000000000000000000000000000000000000000000000006", "0x320")
 	receipt2 := mockReceipt("0xabc7000000000000000000000000000000000000000000000000000000000007", "0x320")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -337,7 +348,7 @@ func TestStore_BatchedMode_WithTracker(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
@@ -349,8 +360,8 @@ func TestStore_BatchedMode_WithTracker(t *testing.T) {
 	receipt1 := mockReceipt("0xabc8000000000000000000000000000000000000000000000000000000000008", "0x384")
 	receipt2 := mockReceipt("0xabc9000000000000000000000000000000000000000000000000000000000009", "0x384")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 
@@ -365,19 +376,19 @@ func TestStore_BatchedMode_DuplicateBlock(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	block := mockBlock("0x3E8") // 1000
 	tx1 := mockTransaction("0xabca000000000000000000000000000000000000000000000000000000000010", "1000")
 	receipt1 := mockReceipt("0xabca000000000000000000000000000000000000000000000000000000000010", "0x3E8")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
-	_, err = handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	_, err = handler.Store(context.Background(), result)
 	require.NoError(t, err)
 
-	groups2, sigCol2 := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
-	_, err = handler.Store(context.Background(), groups2, sigCol2, nil)
+	result2 := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	_, err = handler.Store(context.Background(), result2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }
@@ -390,15 +401,15 @@ func TestStore_MultipleTransactionsNoReceipts(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0x44C") // 1100
 	tx1 := mockTransaction("0xabcb000000000000000000000000000000000000000000000000000000000011", "1100")
 	tx2 := mockTransaction("0xabcc000000000000000000000000000000000000000000000000000000000012", "1100")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, nil)
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, nil)
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -411,7 +422,7 @@ func TestStore_BatchedMode_WithAccessList(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	block := mockBlock("0x4B0") // 1200
@@ -428,8 +439,8 @@ func TestStore_BatchedMode_WithAccessList(t *testing.T) {
 	}
 	receipt := mockReceipt("0xabcd000000000000000000000000000000000000000000000000000000000013", "0x4B0")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -453,13 +464,13 @@ func TestStore_WithSigningIdentity_BlockOnly(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
 	block := mockBlock("0x514") // 1300
-	groups, sigCol := buildGroups(t, cols, block, nil, nil)
-	res, err := handler.Store(ctx, groups, sigCol, nil)
+	result := buildGroups(t, cols, block, nil, nil)
+	res, err := handler.Store(ctx, result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -468,7 +479,7 @@ func TestStore_WithSigningIdentity_FullBlock(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
@@ -482,8 +493,8 @@ func TestStore_WithSigningIdentity_FullBlock(t *testing.T) {
 	}
 	receipt := mockReceipt("0xaaa1000000000000000000000000000000000000000000000000000000000001", "0x578")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(ctx, groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(ctx, result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -492,7 +503,7 @@ func TestStore_WithSigningIdentity_AndTracker(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
@@ -503,8 +514,8 @@ func TestStore_WithSigningIdentity_AndTracker(t *testing.T) {
 	tx := mockTransaction("0xaaa2000000000000000000000000000000000000000000000000000000000002", "1500")
 	receipt := mockReceipt("0xaaa2000000000000000000000000000000000000000000000000000000000002", "0x5DC")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(ctx, groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(ctx, result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 
@@ -518,17 +529,17 @@ func TestStore_DuplicateWithIdentity(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
 	block := mockBlock("0x640") // 1600
-	groups, sigCol := buildGroups(t, cols, block, nil, nil)
-	_, err = handler.Store(ctx, groups, sigCol, nil)
+	result := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(ctx, result)
 	require.NoError(t, err)
 
-	groups2, sigCol2 := buildGroups(t, cols, block, nil, nil)
-	_, err = handler.Store(ctx, groups2, sigCol2, nil)
+	result2 := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(ctx, result2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }
@@ -541,7 +552,7 @@ func TestStore_BatchedMode_WithSigningIdentity(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
@@ -551,8 +562,8 @@ func TestStore_BatchedMode_WithSigningIdentity(t *testing.T) {
 	receipt1 := mockReceipt("0xbbb1000000000000000000000000000000000000000000000000000000000001", "0x6A4")
 	receipt2 := mockReceipt("0xbbb2000000000000000000000000000000000000000000000000000000000002", "0x6A4")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
-	res, err := handler.Store(ctx, groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(ctx, result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -561,7 +572,7 @@ func TestStore_BatchedMode_WithSigningIdentity_AndTracker(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
@@ -580,8 +591,8 @@ func TestStore_BatchedMode_WithSigningIdentity_AndTracker(t *testing.T) {
 	receipt1 := mockReceipt("0xbbb3000000000000000000000000000000000000000000000000000000000003", "0x708")
 	receipt2 := mockReceipt("0xbbb4000000000000000000000000000000000000000000000000000000000004", "0x708")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
-	res, err := handler.Store(ctx, groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(ctx, result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 
@@ -598,7 +609,7 @@ func TestStore_BatchedMode_SignsOverCommittedDocumentCIDs(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
@@ -624,8 +635,8 @@ func TestStore_BatchedMode_SignsOverCommittedDocumentCIDs(t *testing.T) {
 	receipt1 := mockReceipt("0xccc1000000000000000000000000000000000000000000000000000000000001", "0x76C")
 	receipt2 := mockReceipt("0xccc2000000000000000000000000000000000000000000000000000000000002", "0x76C")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
-	res, err := handler.Store(ctx, groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(ctx, result)
 	require.NoError(t, err)
 	require.NotEmpty(t, res.BlockID)
 
@@ -634,6 +645,7 @@ func TestStore_BatchedMode_SignsOverCommittedDocumentCIDs(t *testing.T) {
 	require.NotEmpty(t, signedCIDs)
 
 	var docIDs []string
+	var collectionNames []string
 	for _, role := range []string{chains.TypeBlock, chains.TypeTransaction, chains.TypeLog, chains.TypeAccessListEntry} {
 		colName := extractCollection(cols, role)
 		field := "blockNumber"
@@ -643,8 +655,9 @@ func TestStore_BatchedMode_SignsOverCommittedDocumentCIDs(t *testing.T) {
 		ids, err := handler.queryCollectionDocIDs(ctx, colName, field, 1900, 1900)
 		require.NoError(t, err)
 		docIDs = append(docIDs, ids...)
+		collectionNames = append(collectionNames, colName)
 	}
-	queriedCIDs, err := handler.defaultCollectDocCIDs(ctx, docIDs)
+	queriedCIDs, err := handler.defaultCollectDocCIDs(ctx, docIDs, collectionNames)
 	require.NoError(t, err)
 	require.NotEmpty(t, queriedCIDs)
 	assert.ElementsMatch(t, sortedCIDStrings(queriedCIDs), sortedCIDStrings(signedCIDs),
@@ -655,7 +668,7 @@ func TestStore_BatchedMode_DuplicateWithIdentity(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
@@ -663,12 +676,12 @@ func TestStore_BatchedMode_DuplicateWithIdentity(t *testing.T) {
 	tx1 := mockTransaction("0xbbb5000000000000000000000000000000000000000000000000000000000005", "1900")
 	receipt1 := mockReceipt("0xbbb5000000000000000000000000000000000000000000000000000000000005", "0x76C")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
-	_, err = handler.Store(ctx, groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	_, err = handler.Store(ctx, result)
 	require.NoError(t, err)
 
-	groups2, sigCol2 := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
-	_, err = handler.Store(ctx, groups2, sigCol2, nil)
+	result2 := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	_, err = handler.Store(ctx, result2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }
@@ -681,7 +694,7 @@ func TestStore_BatchedMode_NilTransactionsInBatch(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	block := mockBlock("0x7D0") // 2000
@@ -689,8 +702,8 @@ func TestStore_BatchedMode_NilTransactionsInBatch(t *testing.T) {
 	receipt1 := mockReceipt("0xccc1000000000000000000000000000000000000000000000000000000000001", "0x7D0")
 	txs := []*types.Transaction{nil, tx1, nil}
 
-	groups, sigCol := buildGroups(t, cols, block, txs, []*types.TransactionReceipt{receipt1})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, txs, []*types.TransactionReceipt{receipt1})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -703,7 +716,7 @@ func TestStore_BatchedMode_NilReceipts(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	block := mockBlock("0x834") // 2100
@@ -711,8 +724,8 @@ func TestStore_BatchedMode_NilReceipts(t *testing.T) {
 	tx2 := mockTransaction("0xccc3000000000000000000000000000000000000000000000000000000000003", "2100")
 	receipts := []*types.TransactionReceipt{nil}
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, receipts)
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, receipts)
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -725,7 +738,7 @@ func TestStore_BatchedMode_ManyLogs(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	block := mockBlock("0x898") // 2200
@@ -777,8 +790,8 @@ func TestStore_BatchedMode_ManyLogs(t *testing.T) {
 		},
 	}
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -790,7 +803,7 @@ func TestStore_BatchedMode_ManyLogs(t *testing.T) {
 func TestSignExisting_NilDefraNode(t *testing.T) {
 	t.Parallel()
 	handler := &BlockHandler{maxDocsPerTxn: 1000}
-	_, err := handler.SignExisting(context.Background(), nil, "", "0xhash", 100, nil)
+	_, err := handler.SignExisting(context.Background(), chains.ConversionResult{}, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "defraNode is nil")
 }
@@ -799,19 +812,19 @@ func TestSignExisting_Success(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0x8FC") // 2300
 	tx := mockTransaction("0xddd1000000000000000000000000000000000000000000000000000000000001", "2300")
 	receipt := mockReceipt("0xddd1000000000000000000000000000000000000000000000000000000000001", "0x8FC")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	_, err = handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	_, err = handler.Store(context.Background(), result)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
-	sigDocID, err := handler.SignExisting(ctx, groups, sigCol, block.Hash, 2300, nil)
+	sigDocID, err := handler.SignExisting(ctx, result, block.Hash, 2300)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sigDocID)
 }
@@ -820,7 +833,7 @@ func TestSignExisting_WithAccessList(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0x960") // 2400
@@ -833,12 +846,12 @@ func TestSignExisting_WithAccessList(t *testing.T) {
 	}
 	receipt := mockReceipt("0xddd2000000000000000000000000000000000000000000000000000000000002", "0x960")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	_, err = handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	_, err = handler.Store(context.Background(), result)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
-	sigDocID, err := handler.SignExisting(ctx, groups, sigCol, block.Hash, 2400, nil)
+	sigDocID, err := handler.SignExisting(ctx, result, block.Hash, 2400)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sigDocID)
 }
@@ -847,17 +860,17 @@ func TestSignExisting_NilTransactionsAndReceipts(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0x9C4") // 2500
 
-	groups, sigCol := buildGroups(t, cols, block, nil, nil)
-	_, err = handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(context.Background(), result)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
-	sigDocID, err := handler.SignExisting(ctx, groups, sigCol, block.Hash, 2500, nil)
+	sigDocID, err := handler.SignExisting(ctx, result, block.Hash, 2500)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sigDocID)
 }
@@ -866,20 +879,20 @@ func TestSignExisting_NilTxInList(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0xA28") // 2600
 	tx := mockTransaction("0xddd3000000000000000000000000000000000000000000000000000000000003", "2600")
 	receipt := mockReceipt("0xddd3000000000000000000000000000000000000000000000000000000000003", "0xA28")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	_, err = handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	_, err = handler.Store(context.Background(), result)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
-	groups2, sigCol2 := buildGroups(t, cols, block, []*types.Transaction{nil, tx}, []*types.TransactionReceipt{receipt})
-	sigDocID, err := handler.SignExisting(ctx, groups2, sigCol2, block.Hash, 2600, nil)
+	result2 := buildGroups(t, cols, block, []*types.Transaction{nil, tx}, []*types.TransactionReceipt{receipt})
+	sigDocID, err := handler.SignExisting(ctx, result2, block.Hash, 2600)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sigDocID)
 }
@@ -888,15 +901,15 @@ func TestSignExisting_NoIdentity(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0xA8C") // 2700
-	groups, sigCol := buildGroups(t, cols, block, nil, nil)
-	_, err = handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(context.Background(), result)
 	require.NoError(t, err)
 
-	_, err = handler.SignExisting(context.Background(), groups, sigCol, block.Hash, 2700, nil)
+	_, err = handler.SignExisting(context.Background(), result, block.Hash, 2700)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no identity available for signing")
 }
@@ -909,15 +922,15 @@ func TestStore_TxWithNoMatchingReceipt(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1000, cols)
+	handler, err := NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	block := mockBlock("0xB54") // 2900
 	tx := mockTransaction("0xeee1000000000000000000000000000000000000000000000000000000000001", "2900")
 	receipt := mockReceipt("0xeee2000000000000000000000000000000000000000000000000000000000099", "0xB54")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID, "block should be created even without matching receipt")
 }
@@ -930,7 +943,7 @@ func TestStore_BatchedMode_TxWithNoMatchingReceipt(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	block := mockBlock("0xBB8") // 3000
@@ -938,8 +951,8 @@ func TestStore_BatchedMode_TxWithNoMatchingReceipt(t *testing.T) {
 	tx2 := mockTransaction("0xeee4000000000000000000000000000000000000000000000000000000000004", "3000")
 	receipt1 := mockReceipt("0xeee3000000000000000000000000000000000000000000000000000000000003", "0xBB8")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -952,7 +965,7 @@ func TestStore_BatchedMode_ManyAccessListEntries(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 2, cols)
+	handler, err := NewBlockHandler(td.Node, 2)
 	require.NoError(t, err)
 
 	block := mockBlock("0xC1C") // 3100
@@ -973,8 +986,8 @@ func TestStore_BatchedMode_ManyAccessListEntries(t *testing.T) {
 	}
 	receipt := mockReceipt("0xeee5000000000000000000000000000000000000000000000000000000000005", "0xC1C")
 
-	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	result := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }
@@ -987,7 +1000,7 @@ func TestStore_BatchedMode_TransactionsMultipleBatches(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
 	cols := chains.NewStubCollections("Ethereum__Mainnet")
-	handler, err := NewBlockHandler(td.Node, 1, cols)
+	handler, err := NewBlockHandler(td.Node, 1)
 	require.NoError(t, err)
 
 	block := mockBlock("0xCE4") // 3300
@@ -998,11 +1011,11 @@ func TestStore_BatchedMode_TransactionsMultipleBatches(t *testing.T) {
 	receipt2 := mockReceipt("0xfff2000000000000000000000000000000000000000000000000000000000002", "0xCE4")
 	receipt3 := mockReceipt("0xfff3000000000000000000000000000000000000000000000000000000000003", "0xCE4")
 
-	groups, sigCol := buildGroups(t, cols, block,
+	result := buildGroups(t, cols, block,
 		[]*types.Transaction{tx1, tx2, tx3},
 		[]*types.TransactionReceipt{receipt1, receipt2, receipt3},
 	)
-	res, err := handler.Store(context.Background(), groups, sigCol, nil)
+	res, err := handler.Store(context.Background(), result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.BlockID)
 }

--- a/pkg/defra/block_handler_defra_test.go
+++ b/pkg/defra/block_handler_defra_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"math/big"
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
@@ -105,6 +104,14 @@ func mockReceipt(txHash string, blockNumber string) *types.TransactionReceipt {
 	}
 }
 
+// buildGroups is a test helper that converts raw EVM types into DocumentGroups.
+func buildGroups(t *testing.T, cols chains.Collections, block *types.Block, txs []*types.Transaction, receipts []*types.TransactionReceipt) ([]chains.DocumentGroup, string) {
+	t.Helper()
+	groups, sigCol, err := testutils.BuildEVMGroups(cols, block, txs, receipts)
+	require.NoError(t, err)
+	return groups, sigCol
+}
+
 // ---------------------------------------------------------------------------
 // NewBlockHandler with real node
 // ---------------------------------------------------------------------------
@@ -146,40 +153,45 @@ func TestGetPort_WithNode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// CreateBlockBatch — single transaction mode (small block)
+// Store — single transaction mode (small block)
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_SingleTxn_BlockOnly(t *testing.T) {
+func TestStore_BlockOnly(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x64") // 100
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, nil, nil)
+	groups, sigCol := buildGroups(t, cols, block, nil, nil)
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
-func TestCreateBlockBatch_SingleTxn_WithTransaction(t *testing.T) {
+func TestStore_WithTransaction(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0xC8") // 200
 	tx := mockTransaction("0xabc1000000000000000000000000000000000000000000000000000000000001", "200")
 	receipt := mockReceipt("0xabc1000000000000000000000000000000000000000000000000000000000001", "0xC8")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
-func TestCreateBlockBatch_SingleTxn_WithAccessList(t *testing.T) {
+func TestStore_WithAccessList(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x12C") // 300
@@ -192,60 +204,57 @@ func TestCreateBlockBatch_SingleTxn_WithAccessList(t *testing.T) {
 	}
 	receipt := mockReceipt("0xabc2000000000000000000000000000000000000000000000000000000000002", "0x12C")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
-func TestCreateBlockBatch_NilBlock(t *testing.T) {
+func TestStore_NilBlock(t *testing.T) {
 	t.Parallel()
-	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-	require.NoError(t, err)
-
-	_, err = handler.CreateBlockBatch(context.Background(), nil, nil, nil)
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	_, _, err := testutils.BuildEVMGroups(cols, nil, nil, nil)
 	require.Error(t, err)
 }
 
-func TestCreateBlockBatch_InvalidBlockNumber(t *testing.T) {
+func TestStore_InvalidBlockNumber(t *testing.T) {
 	t.Parallel()
-	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-	require.NoError(t, err)
-
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
 	block := mockBlock("invalid")
-	_, err = handler.CreateBlockBatch(context.Background(), block, nil, nil)
+	_, _, err := testutils.BuildEVMGroups(cols, block, nil, nil)
 	require.Error(t, err)
 }
 
-func TestCreateBlockBatch_DuplicateBlock(t *testing.T) {
+func TestStore_DuplicateBlock(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x190") // 400
-	_, err = handler.CreateBlockBatch(context.Background(), block, nil, nil)
+	groups, sigCol := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
 
-	// Attempting to create the same block again should fail
-	_, err = handler.CreateBlockBatch(context.Background(), block, nil, nil)
+	groups2, sigCol2 := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(context.Background(), groups2, sigCol2, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }
 
-func TestCreateBlockBatch_NilDefraNode(t *testing.T) {
+func TestStore_NilDefraNode(t *testing.T) {
 	t.Parallel()
 	handler := &BlockHandler{maxDocsPerTxn: 1000}
-	block := mockBlock("0x1")
-	_, err := handler.CreateBlockBatch(context.Background(), block, nil, nil)
+	_, err := handler.Store(context.Background(), nil, "", nil)
 	require.Error(t, err)
 }
 
-func TestCreateBlockBatch_WithDocIDTracker(t *testing.T) {
+func TestStore_WithDocIDTracker(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
@@ -255,59 +264,61 @@ func TestCreateBlockBatch_WithDocIDTracker(t *testing.T) {
 	tx := mockTransaction("0xabc3000000000000000000000000000000000000000000000000000000000003", "500")
 	receipt := mockReceipt("0xabc3000000000000000000000000000000000000000000000000000000000003", "0x1F4")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 
-	// Verify tracker was called
 	require.Len(t, tracker.trackedBlocks, 1)
 	assert.Equal(t, int64(500), tracker.trackedBlocks[0])
-	assert.Equal(t, blockID, tracker.trackedResults[0].BlockID)
-	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(chains.NewStubCollections("Ethereum__Mainnet"), "transaction")], 1)
-	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(chains.NewStubCollections("Ethereum__Mainnet"), "log")], 1)
+	assert.Equal(t, res.BlockID, tracker.trackedResults[0].BlockID)
+	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(cols, chains.TypeTransaction)], 1)
+	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(cols, chains.TypeLog)], 1)
 }
 
-func TestCreateBlockBatch_NilTransaction(t *testing.T) {
+func TestStore_NilTransaction(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x258") // 600
-	// Include a nil transaction in the list
 	txs := []*types.Transaction{nil, mockTransaction("0xabc4000000000000000000000000000000000000000000000000000000000004", "600")}
 	receipt := mockReceipt("0xabc4000000000000000000000000000000000000000000000000000000000004", "0x258")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, txs, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, txs, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
-func TestCreateBlockBatch_NilReceipt(t *testing.T) {
+func TestStore_NilReceipt(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x2BC") // 700
 	tx := mockTransaction("0xabc5000000000000000000000000000000000000000000000000000000000005", "700")
-	// nil receipt in the list
 	receipts := []*types.TransactionReceipt{nil}
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, receipts)
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, receipts)
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
 // ---------------------------------------------------------------------------
-// CreateBlockBatch — batched mode (large block exceeding maxDocsPerTxn)
+// Store — batched mode (large block exceeding maxDocsPerTxn)
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_BatchedMode(t *testing.T) {
+func TestStore_BatchedMode(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	// Set very low maxDocsPerTxn to force batched mode
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x320") // 800
@@ -316,15 +327,17 @@ func TestCreateBlockBatch_BatchedMode(t *testing.T) {
 	receipt1 := mockReceipt("0xabc6000000000000000000000000000000000000000000000000000000000006", "0x320")
 	receipt2 := mockReceipt("0xabc7000000000000000000000000000000000000000000000000000000000007", "0x320")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
-func TestCreateBlockBatch_BatchedMode_WithTracker(t *testing.T) {
+func TestStore_BatchedMode_WithTracker(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
@@ -336,171 +349,69 @@ func TestCreateBlockBatch_BatchedMode_WithTracker(t *testing.T) {
 	receipt1 := mockReceipt("0xabc8000000000000000000000000000000000000000000000000000000000008", "0x384")
 	receipt2 := mockReceipt("0xabc9000000000000000000000000000000000000000000000000000000000009", "0x384")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 
-	// Verify tracker was called
 	require.Len(t, tracker.trackedBlocks, 1)
 	assert.Equal(t, int64(900), tracker.trackedBlocks[0])
-	assert.Equal(t, blockID, tracker.trackedResults[0].BlockID)
-	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(chains.NewStubCollections("Ethereum__Mainnet"), "transaction")], 2)
-	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(chains.NewStubCollections("Ethereum__Mainnet"), "log")], 2)
+	assert.Equal(t, res.BlockID, tracker.trackedResults[0].BlockID)
+	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(cols, chains.TypeTransaction)], 2)
+	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(cols, chains.TypeLog)], 2)
 }
 
-func TestCreateBlockBatch_BatchedMode_DuplicateBlock(t *testing.T) {
+func TestStore_BatchedMode_DuplicateBlock(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x3E8") // 1000
 	tx1 := mockTransaction("0xabca000000000000000000000000000000000000000000000000000000000010", "1000")
 	receipt1 := mockReceipt("0xabca000000000000000000000000000000000000000000000000000000000010", "0x3E8")
 
-	_, err = handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	_, err = handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
 
-	// Try again — should fail with "already exists"
-	_, err = handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	groups2, sigCol2 := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	_, err = handler.Store(context.Background(), groups2, sigCol2, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
-}
-
-// ---------------------------------------------------------------------------
-// GetHighestBlockNumber
-// ---------------------------------------------------------------------------
-
-func TestGetHighestBlockNumber_EmptyDB(t *testing.T) {
-	t.Parallel()
-	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-	require.NoError(t, err)
-
-	_, err = handler.GetHighestBlockNumber(context.Background())
-	require.Error(t, err, "should fail on empty DB")
-}
-
-func TestGetHighestBlockNumber_AfterInserts(t *testing.T) {
-	t.Parallel()
-	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-	require.NoError(t, err)
-
-	// Insert block 100
-	block1 := mockBlock("0x64") // 100
-	_, err = handler.CreateBlockBatch(context.Background(), block1, nil, nil)
-	require.NoError(t, err)
-
-	highest, err := handler.GetHighestBlockNumber(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(100), highest)
-
-	// Insert block 200
-	block2 := mockBlock("0xC8") // 200
-	_, err = handler.CreateBlockBatch(context.Background(), block2, nil, nil)
-	require.NoError(t, err)
-
-	highest, err = handler.GetHighestBlockNumber(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(200), highest)
-}
-
-func TestGetHighestBlockNumber_NonSequential(t *testing.T) {
-	t.Parallel()
-	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-	require.NoError(t, err)
-
-	// Insert blocks in non-sequential order
-	blocks := []string{"0x1F4", "0x64", "0x12C"} // 500, 100, 300
-	for _, num := range blocks {
-		block := mockBlock(num)
-		_, err = handler.CreateBlockBatch(context.Background(), block, nil, nil)
-		require.NoError(t, err)
-	}
-
-	highest, err := handler.GetHighestBlockNumber(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(500), highest)
-}
-
-func TestGetLowestBlockNumber(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name        string
-		blocks      []string
-		wantErr     bool
-		errContains string
-		wantLowest  int64
-		wantHighest *int64
-	}{
-		{"EmptyDB", nil, true, "not found", 0, nil},
-		{"SingleBlock", []string{"0x64"}, false, "", 100, nil},
-		{"AfterInserts", []string{"0xC8", "0x64"}, false, "", 100, nil},
-		{"NonSequential", []string{"0x1F4", "0x64", "0x12C"}, false, "", 100, nil},
-		{"LessThanHighest", []string{"0x3E8", "0x64", "0x12C"}, false, "", 100, new(int64(1000))},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			td := testutils.SetupTestDefraDB(t)
-			handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-			require.NoError(t, err)
-
-			for _, num := range tc.blocks {
-				_, err = handler.CreateBlockBatch(context.Background(), mockBlock(num), nil, nil)
-				require.NoError(t, err)
-			}
-
-			lowest, err := handler.GetLowestBlockNumber(context.Background())
-			if tc.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.errContains)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tc.wantLowest, lowest)
-
-			if tc.wantHighest != nil {
-				highest, err := handler.GetHighestBlockNumber(context.Background())
-				require.NoError(t, err)
-				assert.Equal(t, *tc.wantHighest, highest)
-				assert.Less(t, lowest, highest)
-			}
-		})
-	}
 }
 
 // ---------------------------------------------------------------------------
 // Multiple transactions with no receipts (no logs)
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_MultipleTransactionsNoReceipts(t *testing.T) {
+func TestStore_MultipleTransactionsNoReceipts(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x44C") // 1100
 	tx1 := mockTransaction("0xabcb000000000000000000000000000000000000000000000000000000000011", "1100")
 	tx2 := mockTransaction("0xabcc000000000000000000000000000000000000000000000000000000000012", "1100")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx1, tx2}, nil)
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, nil)
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
 // ---------------------------------------------------------------------------
 // Batched mode with access list entries
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_BatchedMode_WithAccessList(t *testing.T) {
+func TestStore_BatchedMode_WithAccessList(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x4B0") // 1200
@@ -517,17 +428,16 @@ func TestCreateBlockBatch_BatchedMode_WithAccessList(t *testing.T) {
 	}
 	receipt := mockReceipt("0xabcd000000000000000000000000000000000000000000000000000000000013", "0x4B0")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
 // ---------------------------------------------------------------------------
 // Helper: context with signing identity
 // ---------------------------------------------------------------------------
 
-// ctxWithIdentity creates a context with a generated signing identity.
-// This enables block signing (buildBlockSignatureDocument path) in tests.
 func ctxWithIdentity(t *testing.T) context.Context {
 	t.Helper()
 	ident, err := identity.Generate(crypto.KeyTypeSecp256k1)
@@ -536,26 +446,29 @@ func ctxWithIdentity(t *testing.T) context.Context {
 }
 
 // ---------------------------------------------------------------------------
-// createBlockSingleTransaction — block signature path (with identity)
+// Store — block signature path (with identity)
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_SingleTxn_WithSigningIdentity_BlockOnly(t *testing.T) {
+func TestStore_WithSigningIdentity_BlockOnly(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
 	block := mockBlock("0x514") // 1300
-	blockID, err := handler.CreateBlockBatch(ctx, block, nil, nil)
+	groups, sigCol := buildGroups(t, cols, block, nil, nil)
+	res, err := handler.Store(ctx, groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
-func TestCreateBlockBatch_SingleTxn_WithSigningIdentity_FullBlock(t *testing.T) {
+func TestStore_WithSigningIdentity_FullBlock(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
@@ -569,15 +482,17 @@ func TestCreateBlockBatch_SingleTxn_WithSigningIdentity_FullBlock(t *testing.T) 
 	}
 	receipt := mockReceipt("0xaaa1000000000000000000000000000000000000000000000000000000000001", "0x578")
 
-	blockID, err := handler.CreateBlockBatch(ctx, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(ctx, groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
-func TestCreateBlockBatch_SingleTxn_WithSigningIdentity_AndTracker(t *testing.T) {
+func TestStore_WithSigningIdentity_AndTracker(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
@@ -588,42 +503,45 @@ func TestCreateBlockBatch_SingleTxn_WithSigningIdentity_AndTracker(t *testing.T)
 	tx := mockTransaction("0xaaa2000000000000000000000000000000000000000000000000000000000002", "1500")
 	receipt := mockReceipt("0xaaa2000000000000000000000000000000000000000000000000000000000002", "0x5DC")
 
-	blockID, err := handler.CreateBlockBatch(ctx, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(ctx, groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 
-	// Verify tracker was called and captured the BlockSignatureID
 	require.Len(t, tracker.trackedBlocks, 1)
 	assert.Equal(t, int64(1500), tracker.trackedBlocks[0])
-	assert.Equal(t, blockID, tracker.trackedResults[0].BlockID)
+	assert.Equal(t, res.BlockID, tracker.trackedResults[0].BlockID)
 	assert.NotEmpty(t, tracker.trackedResults[0].BlockSignatureID, "BlockSignatureID should be set when signing identity is present")
 }
 
-func TestCreateBlockBatch_SingleTxn_DuplicateWithIdentity(t *testing.T) {
+func TestStore_DuplicateWithIdentity(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
 	block := mockBlock("0x640") // 1600
-	_, err = handler.CreateBlockBatch(ctx, block, nil, nil)
+	groups, sigCol := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(ctx, groups, sigCol, nil)
 	require.NoError(t, err)
 
-	// Attempting to create the same block again should fail with "already exists"
-	_, err = handler.CreateBlockBatch(ctx, block, nil, nil)
+	groups2, sigCol2 := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(ctx, groups2, sigCol2, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }
 
 // ---------------------------------------------------------------------------
-// createBlockBatched — block signature path (with identity)
+// Store — batched mode block signature path (with identity)
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_BatchedMode_WithSigningIdentity(t *testing.T) {
+func TestStore_BatchedMode_WithSigningIdentity(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched mode
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
@@ -633,15 +551,17 @@ func TestCreateBlockBatch_BatchedMode_WithSigningIdentity(t *testing.T) {
 	receipt1 := mockReceipt("0xbbb1000000000000000000000000000000000000000000000000000000000001", "0x6A4")
 	receipt2 := mockReceipt("0xbbb2000000000000000000000000000000000000000000000000000000000002", "0x6A4")
 
-	blockID, err := handler.CreateBlockBatch(ctx, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(ctx, groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
-func TestCreateBlockBatch_BatchedMode_WithSigningIdentity_AndTracker(t *testing.T) {
+func TestStore_BatchedMode_WithSigningIdentity_AndTracker(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched mode
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
@@ -660,33 +580,30 @@ func TestCreateBlockBatch_BatchedMode_WithSigningIdentity_AndTracker(t *testing.
 	receipt1 := mockReceipt("0xbbb3000000000000000000000000000000000000000000000000000000000003", "0x708")
 	receipt2 := mockReceipt("0xbbb4000000000000000000000000000000000000000000000000000000000004", "0x708")
 
-	blockID, err := handler.CreateBlockBatch(ctx, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(ctx, groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 
-	// Verify tracker was called and captured BlockSignatureID
 	require.Len(t, tracker.trackedBlocks, 1)
 	assert.Equal(t, int64(1800), tracker.trackedBlocks[0])
-	assert.Equal(t, blockID, tracker.trackedResults[0].BlockID)
+	assert.Equal(t, res.BlockID, tracker.trackedResults[0].BlockID)
 	assert.NotEmpty(t, tracker.trackedResults[0].BlockSignatureID, "BlockSignatureID should be set in batched mode with identity")
-	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(chains.NewStubCollections("Ethereum__Mainnet"), "transaction")], 2)
-	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(chains.NewStubCollections("Ethereum__Mainnet"), "log")], 2)
-	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(chains.NewStubCollections("Ethereum__Mainnet"), "accessListEntry")], 1)
+	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(cols, chains.TypeTransaction)], 2)
+	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(cols, chains.TypeLog)], 2)
+	assert.Len(t, tracker.trackedResults[0].OtherDocIDs[extractCollection(cols, chains.TypeAccessListEntry)], 1)
 }
 
-// The batched path signs over the CIDs the writes commit (via the in-context collector), not a
-// post-write query. The signed set must equal the block's document CIDs, so the merkle root
-// matches what any other indexer signing the same block produces.
-func TestCreateBlockBatch_BatchedMode_SignsOverCommittedDocumentCIDs(t *testing.T) {
+func TestStore_BatchedMode_SignsOverCommittedDocumentCIDs(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched mode
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	tracker := &mockDocIDTracker{}
 	handler.SetDocIDTracker(tracker)
 
-	// Capture the CIDs handed to the signer.
 	var signedCIDs []cid.Cid
 	inner := handler.signBatchFn
 	handler.signBatchFn = func(ctx context.Context, collector *node.BatchCIDCollector) (*node.BatchSignature, error) {
@@ -707,19 +624,26 @@ func TestCreateBlockBatch_BatchedMode_SignsOverCommittedDocumentCIDs(t *testing.
 	receipt1 := mockReceipt("0xccc1000000000000000000000000000000000000000000000000000000000001", "0x76C")
 	receipt2 := mockReceipt("0xccc2000000000000000000000000000000000000000000000000000000000002", "0x76C")
 
-	blockID, err := handler.CreateBlockBatch(ctx, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1, receipt2})
+	res, err := handler.Store(ctx, groups, sigCol, nil)
 	require.NoError(t, err)
-	require.NotEmpty(t, blockID)
+	require.NotEmpty(t, res.BlockID)
 
-	// The block was signed: signBlockOverCIDs self-verifies before storing, so a stored signature
-	// id means the collected CIDs produced a consistent signature.
 	require.Len(t, tracker.trackedResults, 1)
 	require.NotEmpty(t, tracker.trackedResults[0].BlockSignatureID, "batched block should be signed")
 	require.NotEmpty(t, signedCIDs)
 
-	// Collect the block's document CIDs independently via the query path and compare sets.
-	docIDs, err := handler.collectExistingBlockDocIDs(ctx, 1900)
-	require.NoError(t, err)
+	var docIDs []string
+	for _, role := range []string{chains.TypeBlock, chains.TypeTransaction, chains.TypeLog, chains.TypeAccessListEntry} {
+		colName := extractCollection(cols, role)
+		field := "blockNumber"
+		if role == chains.TypeBlock {
+			field = "number"
+		}
+		ids, err := handler.queryCollectionDocIDs(ctx, colName, field, 1900, 1900)
+		require.NoError(t, err)
+		docIDs = append(docIDs, ids...)
+	}
 	queriedCIDs, err := handler.defaultCollectDocCIDs(ctx, docIDs)
 	require.NoError(t, err)
 	require.NotEmpty(t, queriedCIDs)
@@ -727,10 +651,11 @@ func TestCreateBlockBatch_BatchedMode_SignsOverCommittedDocumentCIDs(t *testing.
 		"batched signature must attest exactly the block's document CIDs")
 }
 
-func TestCreateBlockBatch_BatchedMode_DuplicateWithIdentity(t *testing.T) {
+func TestStore_BatchedMode_DuplicateWithIdentity(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched mode
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	ctx := ctxWithIdentity(t)
@@ -738,65 +663,69 @@ func TestCreateBlockBatch_BatchedMode_DuplicateWithIdentity(t *testing.T) {
 	tx1 := mockTransaction("0xbbb5000000000000000000000000000000000000000000000000000000000005", "1900")
 	receipt1 := mockReceipt("0xbbb5000000000000000000000000000000000000000000000000000000000005", "0x76C")
 
-	_, err = handler.CreateBlockBatch(ctx, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	_, err = handler.Store(ctx, groups, sigCol, nil)
 	require.NoError(t, err)
 
-	// Try again -- should fail with "already exists"
-	_, err = handler.CreateBlockBatch(ctx, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	groups2, sigCol2 := buildGroups(t, cols, block, []*types.Transaction{tx1}, []*types.TransactionReceipt{receipt1})
+	_, err = handler.Store(ctx, groups2, sigCol2, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }
 
 // ---------------------------------------------------------------------------
-// createBlockBatched — nil transactions in batch
+// Store — nil transactions in batch
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_BatchedMode_NilTransactionsInBatch(t *testing.T) {
+func TestStore_BatchedMode_NilTransactionsInBatch(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x7D0") // 2000
 	tx1 := mockTransaction("0xccc1000000000000000000000000000000000000000000000000000000000001", "2000")
 	receipt1 := mockReceipt("0xccc1000000000000000000000000000000000000000000000000000000000001", "0x7D0")
-	// Include nil transactions in the list
 	txs := []*types.Transaction{nil, tx1, nil}
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, txs, []*types.TransactionReceipt{receipt1})
+	groups, sigCol := buildGroups(t, cols, block, txs, []*types.TransactionReceipt{receipt1})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
 // ---------------------------------------------------------------------------
-// createBlockBatched — nil receipt handling
+// Store — nil receipt handling
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_BatchedMode_NilReceipts(t *testing.T) {
+func TestStore_BatchedMode_NilReceipts(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x834") // 2100
 	tx1 := mockTransaction("0xccc2000000000000000000000000000000000000000000000000000000000002", "2100")
 	tx2 := mockTransaction("0xccc3000000000000000000000000000000000000000000000000000000000003", "2100")
-	// nil receipt in the list
 	receipts := []*types.TransactionReceipt{nil}
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx1, tx2}, receipts)
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, receipts)
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
 // ---------------------------------------------------------------------------
-// createBlockBatched — multiple batches of logs
+// Store — multiple batches of logs
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_BatchedMode_ManyLogs(t *testing.T) {
+func TestStore_BatchedMode_ManyLogs(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x898") // 2200
@@ -848,53 +777,50 @@ func TestCreateBlockBatch_BatchedMode_ManyLogs(t *testing.T) {
 		},
 	}
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
 // ---------------------------------------------------------------------------
-// CreateBlockSignatureForExistingBlock
+// SignExisting
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockSignatureForExistingBlock_NilDefraNode(t *testing.T) {
+func TestSignExisting_NilDefraNode(t *testing.T) {
 	t.Parallel()
 	handler := &BlockHandler{maxDocsPerTxn: 1000}
-	_, err := handler.CreateBlockSignatureForExistingBlock(
-		context.Background(), 100, "0xhash", mockBlock("0x64"), nil, nil,
-	)
+	_, err := handler.SignExisting(context.Background(), nil, "", "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "defraNode is nil")
 }
 
-func TestCreateBlockSignatureForExistingBlock_Success(t *testing.T) {
+func TestSignExisting_Success(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
-	// Create a block WITHOUT identity (simulates P2P replication where block arrives
-	// without a signature). Then create a signature for the existing block.
 	block := mockBlock("0x8FC") // 2300
 	tx := mockTransaction("0xddd1000000000000000000000000000000000000000000000000000000000001", "2300")
 	receipt := mockReceipt("0xddd1000000000000000000000000000000000000000000000000000000000001", "0x8FC")
 
-	_, err = handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	_, err = handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
 
-	// Now create a block signature for the existing block (with identity)
 	ctx := ctxWithIdentity(t)
-	sigDocID, err := handler.CreateBlockSignatureForExistingBlock(
-		ctx, 2300, block.Hash, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt},
-	)
+	sigDocID, err := handler.SignExisting(ctx, groups, sigCol, block.Hash, 2300, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sigDocID)
 }
 
-func TestCreateBlockSignatureForExistingBlock_WithAccessList(t *testing.T) {
+func TestSignExisting_WithAccessList(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x960") // 2400
@@ -907,167 +833,126 @@ func TestCreateBlockSignatureForExistingBlock_WithAccessList(t *testing.T) {
 	}
 	receipt := mockReceipt("0xddd2000000000000000000000000000000000000000000000000000000000002", "0x960")
 
-	// Create block without identity (no BlockSignature created)
-	_, err = handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	_, err = handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
 
-	// Now create a signature for the existing block
 	ctx := ctxWithIdentity(t)
-	sigDocID, err := handler.CreateBlockSignatureForExistingBlock(
-		ctx, 2400, block.Hash, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt},
-	)
+	sigDocID, err := handler.SignExisting(ctx, groups, sigCol, block.Hash, 2400, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sigDocID)
 }
 
-func TestCreateBlockSignatureForExistingBlock_NilTransactionsAndReceipts(t *testing.T) {
+func TestSignExisting_NilTransactionsAndReceipts(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0x9C4") // 2500
 
-	// Create the block first without identity
-	_, err = handler.CreateBlockBatch(context.Background(), block, nil, nil)
+	groups, sigCol := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
 
-	// Create signature for existing block with no txs/receipts
 	ctx := ctxWithIdentity(t)
-	sigDocID, err := handler.CreateBlockSignatureForExistingBlock(
-		ctx, 2500, block.Hash, block, nil, nil,
-	)
+	sigDocID, err := handler.SignExisting(ctx, groups, sigCol, block.Hash, 2500, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sigDocID)
 }
 
-func TestCreateBlockSignatureForExistingBlock_NilTxInList(t *testing.T) {
+func TestSignExisting_NilTxInList(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0xA28") // 2600
 	tx := mockTransaction("0xddd3000000000000000000000000000000000000000000000000000000000003", "2600")
 	receipt := mockReceipt("0xddd3000000000000000000000000000000000000000000000000000000000003", "0xA28")
 
-	// Create block without identity
-	_, err = handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	_, err = handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
 
-	// Pass nil transactions in the list (should be skipped gracefully)
 	ctx := ctxWithIdentity(t)
-	sigDocID, err := handler.CreateBlockSignatureForExistingBlock(
-		ctx, 2600, block.Hash, block, []*types.Transaction{nil, tx}, []*types.TransactionReceipt{receipt},
-	)
+	groups2, sigCol2 := buildGroups(t, cols, block, []*types.Transaction{nil, tx}, []*types.TransactionReceipt{receipt})
+	sigDocID, err := handler.SignExisting(ctx, groups2, sigCol2, block.Hash, 2600, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sigDocID)
 }
 
-func TestCreateBlockSignatureForExistingBlock_NoIdentity(t *testing.T) {
+func TestSignExisting_NoIdentity(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
-	// Create a block first without identity
 	block := mockBlock("0xA8C") // 2700
-	_, err = handler.CreateBlockBatch(context.Background(), block, nil, nil)
+	groups, sigCol := buildGroups(t, cols, block, nil, nil)
+	_, err = handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
 
-	// Try to create block signature without identity context
-	// defaultSignBatch returns errNoIdentity, causing "failed to sign block: no identity available for signing"
-	_, err = handler.CreateBlockSignatureForExistingBlock(
-		context.Background(), 2700, block.Hash, block, nil, nil,
-	)
+	_, err = handler.SignExisting(context.Background(), groups, sigCol, block.Hash, 2700, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no identity available for signing")
 }
 
 // ---------------------------------------------------------------------------
-// GetHighestBlockNumber — additional coverage
+// Store — transaction with no matching receipt
 // ---------------------------------------------------------------------------
 
-func TestGetHighestBlockNumber_SingleBlock(t *testing.T) {
+func TestStore_TxWithNoMatchingReceipt(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-	require.NoError(t, err)
-
-	block := mockBlock("0xAF0") // 2800
-	_, err = handler.CreateBlockBatch(context.Background(), block, nil, nil)
-	require.NoError(t, err)
-
-	highest, err := handler.GetHighestBlockNumber(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(2800), highest)
-}
-
-func TestGetHighestBlockNumber_LargeBlockNumber(t *testing.T) {
-	t.Parallel()
-	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-	require.NoError(t, err)
-
-	// Use a large block number to ensure int64 handling works
-	block := mockBlock("0xF4240") // 1000000
-	_, err = handler.CreateBlockBatch(context.Background(), block, nil, nil)
-	require.NoError(t, err)
-
-	highest, err := handler.GetHighestBlockNumber(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(1000000), highest)
-}
-
-// ---------------------------------------------------------------------------
-// createBlockSingleTransaction — transaction with no matching receipt
-// ---------------------------------------------------------------------------
-
-func TestCreateBlockBatch_SingleTxn_TxWithNoMatchingReceipt(t *testing.T) {
-	t.Parallel()
-	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0xB54") // 2900
 	tx := mockTransaction("0xeee1000000000000000000000000000000000000000000000000000000000001", "2900")
-	// Receipt hash doesn't match the transaction hash
 	receipt := mockReceipt("0xeee2000000000000000000000000000000000000000000000000000000000099", "0xB54")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID, "block should be created even without matching receipt")
+	assert.NotEmpty(t, res.BlockID, "block should be created even without matching receipt")
 }
 
 // ---------------------------------------------------------------------------
-// createBlockBatched — transaction with no matching receipt
+// Store — batched mode transaction with no matching receipt
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_BatchedMode_TxWithNoMatchingReceipt(t *testing.T) {
+func TestStore_BatchedMode_TxWithNoMatchingReceipt(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0xBB8") // 3000
 	tx1 := mockTransaction("0xeee3000000000000000000000000000000000000000000000000000000000003", "3000")
 	tx2 := mockTransaction("0xeee4000000000000000000000000000000000000000000000000000000000004", "3000")
-	// Receipt for tx1 only, tx2 has no matching receipt
 	receipt1 := mockReceipt("0xeee3000000000000000000000000000000000000000000000000000000000003", "0xBB8")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx1, tx2}, []*types.TransactionReceipt{receipt1})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
 // ---------------------------------------------------------------------------
-// createBlockBatched — many access list entries across batches
+// Store — batched mode many access list entries
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_BatchedMode_ManyAccessListEntries(t *testing.T) {
+func TestStore_BatchedMode_ManyAccessListEntries(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 2, chains.NewStubCollections("Ethereum__Mainnet")) // force batched
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 2, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0xC1C") // 3100
@@ -1088,19 +973,21 @@ func TestCreateBlockBatch_BatchedMode_ManyAccessListEntries(t *testing.T) {
 	}
 	receipt := mockReceipt("0xeee5000000000000000000000000000000000000000000000000000000000005", "0xC1C")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	groups, sigCol := buildGroups(t, cols, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	assert.NotEmpty(t, res.BlockID)
 }
 
 // ---------------------------------------------------------------------------
-// createBlockBatched — transactions that span multiple batches
+// Store — batched mode transactions that span multiple batches
 // ---------------------------------------------------------------------------
 
-func TestCreateBlockBatch_BatchedMode_TransactionsMultipleBatches(t *testing.T) {
+func TestStore_BatchedMode_TransactionsMultipleBatches(t *testing.T) {
 	t.Parallel()
 	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1, chains.NewStubCollections("Ethereum__Mainnet")) // force batched with batchSize=1
+	cols := chains.NewStubCollections("Ethereum__Mainnet")
+	handler, err := NewBlockHandler(td.Node, 1, cols)
 	require.NoError(t, err)
 
 	block := mockBlock("0xCE4") // 3300
@@ -1111,172 +998,11 @@ func TestCreateBlockBatch_BatchedMode_TransactionsMultipleBatches(t *testing.T) 
 	receipt2 := mockReceipt("0xfff2000000000000000000000000000000000000000000000000000000000002", "0xCE4")
 	receipt3 := mockReceipt("0xfff3000000000000000000000000000000000000000000000000000000000003", "0xCE4")
 
-	blockID, err := handler.CreateBlockBatch(context.Background(), block,
+	groups, sigCol := buildGroups(t, cols, block,
 		[]*types.Transaction{tx1, tx2, tx3},
 		[]*types.TransactionReceipt{receipt1, receipt2, receipt3},
 	)
+	res, err := handler.Store(context.Background(), groups, sigCol, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
-}
-
-// ---------------------------------------------------------------------------
-// GetHighestBlockNumber — multiple blocks to ensure ORDER DESC works
-// ---------------------------------------------------------------------------
-
-func TestGetHighestBlockNumber_ThreeBlocksDescOrder(t *testing.T) {
-	t.Parallel()
-	td := testutils.SetupTestDefraDB(t)
-	handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-	require.NoError(t, err)
-
-	blocks := []struct {
-		hex    string
-		number int64
-	}{
-		{"0xD48", 3400},
-		{"0xDAC", 3500},
-		{"0xE10", 3600},
-	}
-
-	for _, b := range blocks {
-		block := mockBlock(b.hex)
-		_, err = handler.CreateBlockBatch(context.Background(), block, nil, nil)
-		require.NoError(t, err)
-	}
-
-	highest, err := handler.GetHighestBlockNumber(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(3600), highest)
-}
-
-// ---------------------------------------------------------------------------
-// GetDocIDsByBlockRange
-// ---------------------------------------------------------------------------
-
-func TestGetDocIDsByBlockRange(t *testing.T) {
-	t.Parallel()
-
-	type blockSeed struct {
-		num     int64
-		txCount int
-	}
-
-	type collectionExpect struct {
-		name  string
-		count int
-	}
-
-	hexNum := func(n int64) string {
-		return "0x" + big.NewInt(n).Text(16)
-	}
-
-	cases := []struct {
-		name        string
-		seeds       []blockSeed
-		from        int64
-		to          int64
-		expects     []collectionExpect
-		expectEmpty bool
-	}{
-		{
-			name:        "EmptyStore",
-			from:        100,
-			to:          200,
-			expectEmpty: true,
-		},
-		{
-			name:  "SingleBlockWithTx",
-			seeds: []blockSeed{{100, 2}},
-			from:  100,
-			to:    100,
-			expects: []collectionExpect{
-				{"Ethereum__Mainnet__Block", 1},
-				{"Ethereum__Mainnet__Transaction", 2},
-				{"Ethereum__Mainnet__Log", 2},
-				{"Ethereum__Mainnet__AccessListEntry", 2},
-				{"Ethereum__Mainnet__BlockSignature", 1},
-			},
-		},
-		{
-			name:  "MultiBlockFullRange",
-			seeds: []blockSeed{{100, 0}, {101, 0}, {102, 0}},
-			from:  100,
-			to:    102,
-			expects: []collectionExpect{
-				{"Ethereum__Mainnet__Block", 3},
-				{"Ethereum__Mainnet__BlockSignature", 3},
-			},
-		},
-		{
-			name:  "MultiBlockSingleBlockRange",
-			seeds: []blockSeed{{100, 0}, {101, 0}, {102, 0}},
-			from:  100,
-			to:    100,
-			expects: []collectionExpect{
-				{"Ethereum__Mainnet__Block", 1},
-				{"Ethereum__Mainnet__BlockSignature", 1},
-			},
-		},
-		{
-			name:        "EmptyRangeNoMatch",
-			seeds:       []blockSeed{{100, 0}, {101, 0}, {102, 0}},
-			from:        200,
-			to:          300,
-			expectEmpty: true,
-		},
-		{
-			name:  "PartialRange",
-			seeds: []blockSeed{{100, 0}, {101, 0}, {102, 0}, {103, 0}, {104, 0}, {105, 0}},
-			from:  102,
-			to:    103,
-			expects: []collectionExpect{
-				{"Ethereum__Mainnet__Block", 2},
-				{"Ethereum__Mainnet__BlockSignature", 2},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			td := testutils.SetupTestDefraDB(t)
-			handler, err := NewBlockHandler(td.Node, 1000, chains.NewStubCollections("Ethereum__Mainnet"))
-			require.NoError(t, err)
-
-			ctx := ctxWithIdentity(t)
-
-			for _, s := range tc.seeds {
-				block := mockBlock(hexNum(s.num))
-				var txs []*types.Transaction
-				var receipts []*types.TransactionReceipt
-				for i := range s.txCount {
-					txHash := deterministicHash("tx-" + big.NewInt(s.num).String() + "-" + big.NewInt(int64(i)).String())
-					tx := mockTransaction(txHash, big.NewInt(s.num).String())
-					tx.AccessList = []types.AccessListEntry{{
-						Address:     "0x0000000000000000000000000000000000000010",
-						StorageKeys: []string{"0x0000000000000000000000000000000000000000000000000000000000000001"},
-					}}
-					txs = append(txs, tx)
-					receipts = append(receipts, mockReceipt(txHash, hexNum(s.num)))
-				}
-				_, err := handler.CreateBlockBatch(ctx, block, txs, receipts)
-				require.NoError(t, err)
-			}
-
-			result, err := handler.GetDocIDsByBlockRange(ctx, tc.from, tc.to)
-			require.NoError(t, err)
-			assert.NotNil(t, result)
-
-			if tc.expectEmpty {
-				assert.Empty(t, result)
-				return
-			}
-
-			for _, exp := range tc.expects {
-				assert.Contains(t, result, exp.name)
-				assert.Len(t, result[exp.name], exp.count, "collection %s", exp.name)
-			}
-			assert.NotContains(t, result, "Ethereum__Mainnet__SnapshotSignature")
-		})
-	}
+	assert.NotEmpty(t, res.BlockID)
 }

--- a/pkg/defra/block_handler_mock_test.go
+++ b/pkg/defra/block_handler_mock_test.go
@@ -100,14 +100,13 @@ func newMockHandler(t *testing.T, db *mockBlockDB) *BlockHandler {
 	return &BlockHandler{
 		db:            db,
 		maxDocsPerTxn: 1000,
-		collections:   chains.NewStubCollections("Ethereum__Mainnet"),
 		signBatchFn: func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
 			return nil, nil
 		},
 		verifyBatchSigFn: func(_ *node.BatchSignature, _ []cid.Cid) (bool, error) {
 			return true, nil
 		},
-		collectDocCIDsFn: func(_ context.Context, _ []string) ([]cid.Cid, error) {
+		collectDocCIDsFn: func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 			return nil, nil
 		},
 		maxCIDRetries:  1,
@@ -127,11 +126,11 @@ func testReceipt() *types.TransactionReceipt {
 	return mockReceipt("0xabc1000000000000000000000000000000000000000000000000000000000001", "0x64")
 }
 
-func buildSigGroups(t *testing.T, block *types.Block, txs []*types.Transaction, receipts []*types.TransactionReceipt) []chains.DocumentGroup {
+func buildSigGroups(t *testing.T, block *types.Block, txs []*types.Transaction, receipts []*types.TransactionReceipt) chains.ConversionResult {
 	t.Helper()
-	groups, _, err := testutils.BuildEVMGroups(chains.NewStubCollections("Ethereum__Mainnet"), block, txs, receipts)
+	result, err := testutils.BuildEVMGroups(chains.NewStubCollections("Ethereum__Mainnet"), block, txs, receipts)
 	require.NoError(t, err)
-	return groups
+	return result
 }
 
 // =========================================================================
@@ -209,9 +208,9 @@ func TestExistingSig_GQLQuery_Error(t *testing.T) {
 		},
 	}
 	h := newMockHandler(t, db)
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "query docIDs for")
 }
@@ -222,9 +221,9 @@ func TestExistingSig_GetBlockCol_Error(t *testing.T) {
 		execReqFn: execReqFnWithErrorForCol(colBlock),
 	}
 	h := newMockHandler(t, db)
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "query docIDs for")
 }
@@ -235,9 +234,9 @@ func TestExistingSig_GetTxCol_Error(t *testing.T) {
 		execReqFn: execReqFnWithErrorForCol(colTransaction),
 	}
 	h := newMockHandler(t, db)
-	groups := buildSigGroups(t, testBlock(), []*types.Transaction{testTx()}, nil)
+	result := buildSigGroups(t, testBlock(), []*types.Transaction{testTx()}, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "query docIDs for")
 }
@@ -248,9 +247,9 @@ func TestExistingSig_GetLogCol_Error(t *testing.T) {
 		execReqFn: execReqFnWithErrorForCol(colLog),
 	}
 	h := newMockHandler(t, db)
-	groups := buildSigGroups(t, testBlock(), []*types.Transaction{testTx()}, []*types.TransactionReceipt{testReceipt()})
+	result := buildSigGroups(t, testBlock(), []*types.Transaction{testTx()}, []*types.TransactionReceipt{testReceipt()})
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "query docIDs for")
 }
@@ -263,9 +262,9 @@ func TestExistingSig_GetALECol_Error(t *testing.T) {
 	h := newMockHandler(t, db)
 	tx := testTx()
 	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	groups := buildSigGroups(t, testBlock(), []*types.Transaction{tx}, []*types.TransactionReceipt{testReceipt()})
+	result := buildSigGroups(t, testBlock(), []*types.Transaction{tx}, []*types.TransactionReceipt{testReceipt()})
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "query docIDs for")
 }
@@ -276,12 +275,12 @@ func TestExistingSig_CIDRetry_CollectError(t *testing.T) {
 		execReqFn: emptyExecReqFn(),
 	}
 	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return nil, fmt.Errorf("collect error") //nolint:err113
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no CIDs found")
 }
@@ -293,12 +292,12 @@ func TestExistingSig_CIDRetry_InsufficientCIDs(t *testing.T) {
 	}
 	h := newMockHandler(t, db)
 	h.maxCIDRetries = 2
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return nil, nil
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no CIDs found")
 }
@@ -309,9 +308,9 @@ func TestExistingSig_CIDRetry_TxnError(t *testing.T) {
 		execReqFn: execReqFnWithDocIDs(),
 	}
 	h := newMockHandler(t, db)
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no CIDs found")
 }
@@ -323,15 +322,15 @@ func TestExistingSig_SigningTxn_Error(t *testing.T) {
 		newTxnFn:  func(_ bool) (client.Txn, error) { return nil, fmt.Errorf("signing txn error") }, //nolint:err113
 	}
 	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
 		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signing txn error")
 }
@@ -342,15 +341,15 @@ func TestExistingSig_SignBlock_Error(t *testing.T) {
 		execReqFn: emptyExecReqFn(),
 	}
 	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
 		return nil, fmt.Errorf("sign error") //nolint:err113
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sign error")
 }
@@ -361,12 +360,12 @@ func TestExistingSig_NilBlockSig(t *testing.T) {
 		execReqFn: emptyExecReqFn(),
 	}
 	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signing returned nil")
 }
@@ -383,15 +382,15 @@ func TestExistingSig_GetSigCol_Error(t *testing.T) {
 		newTxnFn:  func(_ bool) (client.Txn, error) { return sigTxn, nil },
 	}
 	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
 		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no sig col")
 }
@@ -410,15 +409,15 @@ func TestExistingSig_BuildSigDoc_Error(t *testing.T) {
 		newTxnFn:  func(_ bool) (client.Txn, error) { return sigTxn, nil },
 	}
 	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
 		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "field does not exist")
 }
@@ -439,15 +438,15 @@ func TestExistingSig_CreateSigDoc_Error(t *testing.T) {
 		newTxnFn:  func(_ bool) (client.Txn, error) { return sigTxn, nil },
 	}
 	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
 		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create error")
 }
@@ -466,15 +465,15 @@ func TestExistingSig_Commit_Error(t *testing.T) {
 		newTxnFn:  func(_ bool) (client.Txn, error) { return sigTxn, nil },
 	}
 	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
 		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "commit error")
 }
@@ -490,7 +489,7 @@ func TestExistingSig_CIDRetry_BackoffPath(t *testing.T) {
 	}
 	h := newMockHandler(t, db)
 	h.maxCIDRetries = 2
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		collectCount++
 		if collectCount == 1 {
 			return nil, nil
@@ -503,9 +502,9 @@ func TestExistingSig_CIDRetry_BackoffPath(t *testing.T) {
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
 		return nil, fmt.Errorf("sign error") //nolint:err113
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 }
 
@@ -516,12 +515,12 @@ func TestExistingSig_BuildLogDoc_Continue(t *testing.T) {
 		execReqFn: emptyExecReqFn(),
 	}
 	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return nil, fmt.Errorf("no cids") //nolint:err113
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no CIDs found")
 }
@@ -534,9 +533,9 @@ func TestExistingSig_CIDRetry_TxnError_Backoff(t *testing.T) {
 	}
 	h := newMockHandler(t, db)
 	h.maxCIDRetries = 2
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no CIDs found")
 }
@@ -549,12 +548,12 @@ func TestExistingSig_CIDRetry_CollectError_Backoff(t *testing.T) {
 	}
 	h := newMockHandler(t, db)
 	h.maxCIDRetries = 2
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+	h.collectDocCIDsFn = func(_ context.Context, _ []string, _ []string) ([]cid.Cid, error) {
 		return nil, fmt.Errorf("collect error") //nolint:err113
 	}
-	groups := buildSigGroups(t, testBlock(), nil, nil)
+	result := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
+	_, err := h.SignExisting(context.Background(), result, "0xhash", 100)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no CIDs found")
 }

--- a/pkg/defra/block_handler_mock_test.go
+++ b/pkg/defra/block_handler_mock_test.go
@@ -2,7 +2,6 @@ package defra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -16,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/chains"
-	"github.com/shinzonetwork/shinzo-generator-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/testutils"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/types"
 	"github.com/sourcenetwork/defradb/client"
@@ -25,17 +23,12 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 )
 
-// Default EVM collection name constants for Ethereum Mainnet.
-// These mirror the constants in pkg/chains/evm/collections.go but are
-// declared here because pkg/defra tests cannot import pkg/chains/evm
-// (the evm package imports pkg/defra via adapter.go, creating a cycle).
 const (
-	colBlock             = "Ethereum__Mainnet__Block"
-	colTransaction       = "Ethereum__Mainnet__Transaction"
-	colLog               = "Ethereum__Mainnet__Log"
-	colAccessListEntry   = "Ethereum__Mainnet__AccessListEntry"
-	colBlockSignature    = "Ethereum__Mainnet__BlockSignature"
-	colSnapshotSignature = "Ethereum__Mainnet__SnapshotSignature"
+	colBlock           = "Ethereum__Mainnet__Block"
+	colTransaction     = "Ethereum__Mainnet__Transaction"
+	colLog             = "Ethereum__Mainnet__Log"
+	colAccessListEntry = "Ethereum__Mainnet__AccessListEntry"
+	colBlockSignature  = "Ethereum__Mainnet__BlockSignature"
 )
 
 var testDocIDCounter atomic.Uint64
@@ -47,10 +40,6 @@ func nextTestDocID() client.DocID {
 	c := cid.NewCidV1(cid.DagCBOR, h)
 	return client.NewDocIDV0(c)
 }
-
-// ---------------------------------------------------------------------------
-// mockBlockDB: implements the blockDB interface for unit tests
-// ---------------------------------------------------------------------------
 
 type mockBlockDB struct {
 	newTxnFn  func(readOnly bool) (client.Txn, error)
@@ -68,26 +57,12 @@ func (m *mockBlockDB) ExecRequest(ctx context.Context, request string, opts ...o
 	return &client.RequestResult{}
 }
 
-// ---------------------------------------------------------------------------
-// errDocIDTracker: tracker that always returns an error
-// ---------------------------------------------------------------------------
-
-type errDocIDTracker struct{}
-
-func (e *errDocIDTracker) TrackBlock(_ context.Context, _ int64, _ *BlockCreationResult) error {
-	return errors.New("tracker error") //nolint: err113
-}
-
-// emptyExecReqFn returns an execReqFn that yields empty GQL data (no docIDs).
-// collectExistingBlockDocIDs will return an empty allDocIDs slice.
 func emptyExecReqFn() func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
 	return func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
 		return &client.RequestResult{GQL: client.GQLResult{Data: map[string]any{}}}
 	}
 }
 
-// execReqFnWithDocIDs returns an execReqFn that yields one docID for every
-// collection query, so allDocIDs is non-empty (4 elements for 4 collections).
 func execReqFnWithDocIDs() func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
 	return func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
 		arr := []any{map[string]any{"_docID": "test-doc-id-1"}}
@@ -104,8 +79,6 @@ func execReqFnWithDocIDs() func(_ context.Context, _ string, _ ...options.Enumer
 	}
 }
 
-// execReqFnWithErrorForCol returns an execReqFn that returns a GQL error when
-// the request targets the given collection name, and empty data otherwise.
 func execReqFnWithErrorForCol(targetCol string) func(_ context.Context, request string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
 	return func(_ context.Context, request string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
 		if strings.Contains(request, targetCol) {
@@ -117,25 +90,11 @@ func execReqFnWithErrorForCol(targetCol string) func(_ context.Context, request 
 	}
 }
 
-// oneTestCID returns a reusable CID for mock tests.
 func oneTestCID() cid.Cid {
 	c, _ := cid.Decode("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
 	return c
 }
 
-// testCID is used only by the disabled TestBatched_SignsCompleteBlock; kept (commented) alongside it.
-/*
-func testCID(seed string) cid.Cid {
-	h, _ := mh.Sum([]byte(seed), mh.SHA2_256, -1)
-	return cid.NewCidV1(cid.DagCBOR, h)
-}
-*/
-
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
-
-// newMockHandler creates a handler with a mock DB and default signing stubs.
 func newMockHandler(t *testing.T, db *mockBlockDB) *BlockHandler {
 	t.Helper()
 	return &BlockHandler{
@@ -143,7 +102,7 @@ func newMockHandler(t *testing.T, db *mockBlockDB) *BlockHandler {
 		maxDocsPerTxn: 1000,
 		collections:   chains.NewStubCollections("Ethereum__Mainnet"),
 		signBatchFn: func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-			return nil, nil // no identity → nil sig
+			return nil, nil
 		},
 		verifyBatchSigFn: func(_ *node.BatchSignature, _ []cid.Cid) (bool, error) {
 			return true, nil
@@ -151,39 +110,8 @@ func newMockHandler(t *testing.T, db *mockBlockDB) *BlockHandler {
 		collectDocCIDsFn: func(_ context.Context, _ []string) ([]cid.Cid, error) {
 			return nil, nil
 		},
-		blockExistsFn:  func(_ context.Context, _ int64) (bool, error) { return false, nil },
 		maxCIDRetries:  1,
 		retryBackoffFn: func(int) time.Duration { return 0 },
-	}
-}
-
-// testDefraCollections bundles mock collections with empty versions for
-// triggering buildDocument errors, or with real versions for success paths.
-type testDefraCollections struct {
-	block    client.Collection
-	tx       client.Collection
-	log      client.Collection
-	ale      client.Collection
-	blockSig client.Collection
-}
-
-// emptyVersionCollections returns mock collections with empty versions.
-// NewDocFromMap will fail because Set returns "field not found" for any field.
-func emptyVersionCollections(t *testing.T) *testDefraCollections {
-	t.Helper()
-	mk := func() *mocks.Collection {
-		c := mocks.NewCollection(t)
-		c.EXPECT().Version().Return(client.CollectionVersion{}).Maybe()
-		c.EXPECT().AddDocument(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-		c.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-		return c
-	}
-	return &testDefraCollections{
-		block:    mk(),
-		tx:       mk(),
-		log:      mk(),
-		ale:      mk(),
-		blockSig: mk(),
 	}
 }
 
@@ -199,989 +127,17 @@ func testReceipt() *types.TransactionReceipt {
 	return mockReceipt("0xabc1000000000000000000000000000000000000000000000000000000000001", "0x64")
 }
 
-// =========================================================================
-// createBlockSingleTransaction error paths
-// =========================================================================
-
-func TestSingleTxn_NewBlindWriteTxn_Error(t *testing.T) {
-	t.Parallel()
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			return nil, fmt.Errorf("txn error") //nolint: err113
-		},
-	}
-	h := newMockHandler(t, db)
-
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "txn error")
-}
-
-func TestSingleTxn_GetCollection_Block_Error(t *testing.T) {
-	t.Parallel()
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).
-		Return(nil, fmt.Errorf("no such collection")) //nolint: err113
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no such collection")
-}
-
-func TestSingleTxn_GetCollection_Tx_Error(t *testing.T) {
-	t.Parallel()
-	txn := mocks.NewTxn(t)
-	cols := emptyVersionCollections(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(cols.block, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).
-		Return(nil, fmt.Errorf("no tx col")) //nolint: err113
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	// buildBlockDocument will fail because empty version → covers that error path too
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-}
-
-func TestSingleTxn_GetCollection_Log_Error(t *testing.T) {
-	t.Parallel()
-	txn := mocks.NewTxn(t)
-	cols := emptyVersionCollections(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(cols.block, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(cols.tx, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).
-		Return(nil, fmt.Errorf("no log col")) //nolint: err113
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-}
-
-func TestSingleTxn_GetCollection_ALE_Error(t *testing.T) {
-	t.Parallel()
-	txn := mocks.NewTxn(t)
-	cols := emptyVersionCollections(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(cols.block, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(cols.tx, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(cols.log, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).
-		Return(nil, fmt.Errorf("no ale col")) //nolint: err113
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-}
-
-func TestSingleTxn_GetCollection_BlockSig_Error(t *testing.T) {
-	t.Parallel()
-	txn := mocks.NewTxn(t)
-	cols := emptyVersionCollections(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(cols.block, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(cols.tx, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(cols.log, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(cols.ale, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).
-		Return(nil, fmt.Errorf("no sig col")) //nolint: err113
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-}
-
-func TestSingleTxn_BuildBlockDocument_Error(t *testing.T) {
-	t.Parallel()
-	// Empty version collection → buildBlockDocument fails because fields don't exist
-	txn := mocks.NewTxn(t)
-	cols := emptyVersionCollections(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(cols.block, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(cols.tx, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(cols.log, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(cols.ale, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(cols.blockSig, nil)
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "field does not exist")
-}
-
-func TestSingleTxn_BlockCreate_NonDuplicateError(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-
-	txn := mocks.NewTxn(t)
-	blockCol := mocks.NewCollection(t)
-	blockCol.EXPECT().Version().Return(td.blockVersion)
-	blockCol.EXPECT().AddDocument(mock.Anything, mock.Anything, mock.Anything).
-		Return(fmt.Errorf("some internal error"))
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(blockCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txCol(t), nil).Maybe()
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil).Maybe()
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil).Maybe()
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil).Maybe()
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "some internal error")
-}
-
-func TestSingleTxn_BuildTxDocument_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-
-	blockCol := td.blockColWithAddDocument(t, nil) // Create succeeds
-	txCol := mocks.NewCollection(t)
-	txCol.EXPECT().Version().Return(client.CollectionVersion{}) // empty → build fails
-
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(blockCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(txCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	tx := testTx()
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "field does not exist")
-}
-
-func TestSingleTxn_CreateManyTx_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-
-	blockCol := td.blockColWithAddDocument(t, nil)
-	txCol := mocks.NewCollection(t)
-	txCol.EXPECT().Version().Return(td.txVersion)
-	txCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("create many tx error")) //nolint: err113
-
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(blockCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(txCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	tx := testTx()
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "create many tx error")
-}
-
-func TestSingleTxn_BuildLogDocument_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-
-	blockCol := td.blockColWithAddDocument(t, nil)
-	txCol := td.txColWithAddManyDocuments(t, nil)
-	logCol := mocks.NewCollection(t)
-	logCol.EXPECT().Version().Return(client.CollectionVersion{}) // empty → build fails
-
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(blockCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(txCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(logCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "field does not exist")
-}
-
-func TestSingleTxn_CreateManyLogs_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-
-	blockCol := td.blockColWithAddDocument(t, nil)
-	txCol := td.txColWithAddManyDocuments(t, nil)
-	logCol := mocks.NewCollection(t)
-	logCol.EXPECT().Version().Return(td.logVersion)
-	logCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("create many logs error")) //nolint: err113
-
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(blockCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(txCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(logCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "create many logs error")
-}
-
-func TestSingleTxn_BuildALEDocument_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-
-	blockCol := td.blockColWithAddDocument(t, nil)
-	txCol := td.txColWithAddManyDocuments(t, nil)
-	logCol := td.logColWithAddManyDocuments(t, nil)
-	aleCol := mocks.NewCollection(t)
-	aleCol.EXPECT().Version().Return(client.CollectionVersion{}) // empty → build fails
-
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(blockCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(txCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(logCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(aleCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	tx := testTx()
-	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "field does not exist")
-}
-
-func TestSingleTxn_CreateManyALE_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-
-	blockCol := td.blockColWithAddDocument(t, nil)
-	txCol := td.txColWithAddManyDocuments(t, nil)
-	logCol := td.logColWithAddManyDocuments(t, nil)
-	aleCol := mocks.NewCollection(t)
-	aleCol.EXPECT().Version().Return(td.aleVersion)
-	aleCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("create many ALE error")) //nolint: err113
-
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(blockCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(txCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(logCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(aleCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	tx := testTx()
-	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "create many ALE error")
-}
-
-func TestSingleTxn_SignBlock_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Commit().Return(nil)
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return nil, fmt.Errorf("signing error") //nolint: err113
-	}
-
-	blockID, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.NoError(t, err) // signing error is logged, not returned
-	assert.NotEmpty(t, blockID)
-}
-
-func TestSingleTxn_VerifyBlockSig_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	// No AddDocument expectation on the signature collection: a signature that fails verification must not be stored.
-	sigCol := td.sigCol(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(sigCol, nil)
-	txn.EXPECT().Commit().Return(nil)
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil
-	}
-	h.verifyBatchSigFn = func(_ *node.BatchSignature, _ []cid.Cid) (bool, error) {
-		return false, fmt.Errorf("verify error") //nolint: err113
-	}
-
-	blockID, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.NoError(t, err) // block is committed; the unverifiable signature is not stored
-	assert.NotEmpty(t, blockID)
-}
-
-func TestSingleTxn_VerifyBlockSig_False(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	// No AddDocument expectation on the signature collection: a signature that fails verification must not be stored.
-	sigCol := td.sigCol(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(sigCol, nil)
-	txn.EXPECT().Commit().Return(nil)
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil
-	}
-	h.verifyBatchSigFn = func(_ *node.BatchSignature, _ []cid.Cid) (bool, error) {
-		return false, nil
-	}
-
-	blockID, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.NoError(t, err) // block is committed; the unverifiable signature is not stored
-	assert.NotEmpty(t, blockID)
-}
-
-func TestSingleTxn_BuildBlockSigDoc_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	emptySigCol := mocks.NewCollection(t)
-	emptySigCol.EXPECT().Version().Return(client.CollectionVersion{}) // build fails
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(emptySigCol, nil)
-	txn.EXPECT().Commit().Return(nil)
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil
-	}
-	h.verifyBatchSigFn = func(_ *node.BatchSignature, _ []cid.Cid) (bool, error) {
-		return true, nil
-	}
-
-	blockID, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.NoError(t, err) // build sig error is logged, not returned
-	assert.NotEmpty(t, blockID)
-}
-
-func TestSingleTxn_CreateBlockSig_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	sigCol := mocks.NewCollection(t)
-	sigCol.EXPECT().Version().Return(td.sigVersion)
-	sigCol.EXPECT().AddDocument(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("create sig error")) //nolint: err113
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(sigCol, nil)
-	txn.EXPECT().Commit().Return(nil)
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil
-	}
-	h.verifyBatchSigFn = func(_ *node.BatchSignature, _ []cid.Cid) (bool, error) {
-		return true, nil
-	}
-
-	blockID, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.NoError(t, err) // create sig error is logged
-	assert.NotEmpty(t, blockID)
-}
-
-func TestSingleTxn_Commit_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Commit().Return(fmt.Errorf("commit error")) //nolint: err113
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-
-	_, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "commit error")
-}
-
-func TestSingleTxn_TrackBlock_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(td.aleCol(t), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Commit().Return(nil)
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.docIDTracker = &errDocIDTracker{}
-
-	blockID, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, nil, nil)
-	require.NoError(t, err) // tracker error is logged, not returned
-	assert.NotEmpty(t, blockID)
-}
-
-// =========================================================================
-// createBlockBatched error paths
-// =========================================================================
-
-func TestBatched_NewTxn_Initial_Error(t *testing.T) {
-	t.Parallel()
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			return nil, fmt.Errorf("txn error") //nolint: err113
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	_, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "txn error")
-}
-
-func TestBatched_GetCollection_Block_Error(t *testing.T) {
-	t.Parallel()
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).
-		Return(nil, fmt.Errorf("no block col")) //nolint: err113
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	_, err := h.createBlockBatched(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no block col")
-}
-
-func TestBatched_BuildBlockDoc_Error(t *testing.T) {
-	t.Parallel()
-	txn := mocks.NewTxn(t)
-	cols := emptyVersionCollections(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(cols.block, nil)
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	_, err := h.createBlockBatched(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "field does not exist")
-}
-
-func TestBatched_BlockCreate_NonDuplicateError(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-
-	blockCol := mocks.NewCollection(t)
-	blockCol.EXPECT().Version().Return(td.blockVersion)
-	blockCol.EXPECT().AddDocument(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("internal error")) //nolint: err113
-
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(blockCol, nil)
-	txn.EXPECT().Discard()
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	_, err := h.createBlockBatched(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "internal error")
-}
-
-func TestBatched_BlockCommit_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	txn.EXPECT().Commit().Return(fmt.Errorf("commit block error")) //nolint: err113
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	_, err := h.createBlockBatched(context.Background(), testBlock(), 100, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "commit block error")
-}
-
-func TestBatched_TxBatch_NewTxn_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil // block creation txn
-			}
-			return nil, fmt.Errorf("batch txn error") //nolint: err113 all subsequent txns fail
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-func TestBatched_TxBatch_GetCollection_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	batchTxn := mocks.NewTxn(t)
-	batchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(nil, fmt.Errorf("no tx col")) //nolint: err113
-	batchTxn.EXPECT().Discard()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			return batchTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-func TestBatched_TxBatch_BuildTxDoc_Warn(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	emptyTxCol := mocks.NewCollection(t)
-	emptyTxCol.EXPECT().Version().Return(client.CollectionVersion{}) // build fails
-
-	batchTxn := mocks.NewTxn(t)
-	batchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(emptyTxCol, nil)
-	batchTxn.EXPECT().Commit().Return(nil)
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return batchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
+func buildSigGroups(t *testing.T, block *types.Block, txs []*types.Transaction, receipts []*types.TransactionReceipt) []chains.DocumentGroup {
+	t.Helper()
+	groups, _, err := testutils.BuildEVMGroups(chains.NewStubCollections("Ethereum__Mainnet"), block, txs, receipts)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
+	return groups
 }
 
-func TestBatched_TxBatch_CreateMany_NonDupError(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
+// =========================================================================
+// writeBatchWithRetry
+// =========================================================================
 
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txCol := mocks.NewCollection(t)
-	txCol.EXPECT().Version().Return(td.txVersion)
-	txCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("batch create error")) //nolint: err113
-
-	batchTxn := mocks.NewTxn(t)
-	batchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(txCol, nil)
-	batchTxn.EXPECT().Discard()
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return batchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-func TestBatched_TxBatch_Commit_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	batchTxn := mocks.NewTxn(t)
-	batchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	batchTxn.EXPECT().Commit().Return(fmt.Errorf("commit tx batch error")) //nolint: err113
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return batchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-// TestBatched_SignsCompleteBlock is disabled and kept for reference (commented out below).
-//
-// It asserts the batched path signs over CIDs re-queried from the committed DB (the read-back path,
-// via collectDocCIDsFn). createBlockBatched now signs over the in-context BatchCIDCollector instead,
-// and the collector is filled by the defra write path (coreblock store) which these mocks do not
-// exercise — so a mock-based test cannot drive the current signing path. The batched signing behavior
-// is covered by the real-defra TestCreateBlockBatch_BatchedMode_SignsOverCommittedDocumentCIDs, which
-// asserts the signed set equals the block's document CIDs.
-/*
-func TestBatched_SignsCompleteBlock(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txTxn := mocks.NewTxn(t)
-	txTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txTxn.EXPECT().Commit().Return(nil)
-
-	logTxn := mocks.NewTxn(t)
-	logTxn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logColWithAddManyDocuments(t, nil), nil)
-	logTxn.EXPECT().Commit().Return(nil)
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigColWithAddDocument(t, nil), nil)
-	sigTxn.EXPECT().Commit().Return(nil)
-
-	callCount := 0
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) {
-		callCount++
-		switch callCount {
-		case 1:
-			return blockTxn, nil
-		case 2:
-			return txTxn, nil
-		case 3:
-			return logTxn, nil
-		default:
-			return sigTxn, nil
-		}
-	}}
-	h := newMockHandler(t, db)
-	committedCIDs := []cid.Cid{testCID("cid-a"), testCID("cid-b"), testCID("cid-c")}
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
-		return committedCIDs, nil
-	}
-	var signedCIDs []cid.Cid
-	h.signBatchFn = func(_ context.Context, collector *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		signedCIDs = collector.GetCIDs()
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
-	}
-
-	tx := testTx()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: testReceipt()}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
-	// The block is signed over the CIDs re-queried from the committed DB, not the in-memory collector.
-	assert.Equal(t, committedCIDs, signedCIDs)
-}
-*/
-
-// TestBatched_SkipsSign_OnBatchError checks that a block whose write reported an error is not
-// signed: the block is created, an error is returned, and signing never runs.
-func TestBatched_SkipsSign_OnBatchError(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txTxn := mocks.NewTxn(t)
-	txTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txTxn.EXPECT().Commit().Return(nil)
-
-	logTxn := mocks.NewTxn(t)
-	logTxn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logColWithAddManyDocuments(t, fmt.Errorf("log write error")), nil) //nolint:err113
-	logTxn.EXPECT().Discard().Maybe()
-
-	callCount := 0
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) {
-		callCount++
-		switch callCount {
-		case 1:
-			return blockTxn, nil
-		case 2:
-			return txTxn, nil
-		default:
-			return logTxn, nil
-		}
-	}}
-	h := newMockHandler(t, db)
-	signed := false
-	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		signed = true
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
-	}
-
-	tx := testTx()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: testReceipt()}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "batch errors")
-	assert.NotEmpty(t, blockID)
-	assert.False(t, signed)
-}
-
-// TestBatched_SkipsSign_OnDroppedBatch checks that a silently dropped batch is not signed: an
-// already-exists batch leaves the block a document short without reporting a batch error, so the
-// doc-count gate must catch it.
-func TestBatched_SkipsSign_OnDroppedBatch(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txTxn := mocks.NewTxn(t)
-	txTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txTxn.EXPECT().Commit().Return(nil)
-
-	logTxn := mocks.NewTxn(t)
-	logTxn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logColWithAddManyDocuments(t, fmt.Errorf("already exists")), nil) //nolint:err113
-	logTxn.EXPECT().Discard().Maybe()
-
-	callCount := 0
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) {
-		callCount++
-		switch callCount {
-		case 1:
-			return blockTxn, nil
-		case 2:
-			return txTxn, nil
-		default:
-			return logTxn, nil
-		}
-	}}
-	h := newMockHandler(t, db)
-	signed := false
-	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		signed = true
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
-	}
-
-	tx := testTx()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: testReceipt()}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.NoError(t, err) // already-exists is not reported as a batch error
-	assert.NotEmpty(t, blockID)
-	assert.False(t, signed)
-}
-
-// TestBatched_SkipsSign_OnVerifyFailure checks that a signature which fails its own verification
-// is not stored: the block is created but no signature transaction is opened.
-func TestBatched_SkipsSign_OnVerifyFailure(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name   string
-		verify func(*node.BatchSignature, []cid.Cid) (bool, error)
-	}{
-		{"does not verify", func(*node.BatchSignature, []cid.Cid) (bool, error) { return false, nil }},
-		{"verify errors", func(*node.BatchSignature, []cid.Cid) (bool, error) {
-			return false, fmt.Errorf("verify error") //nolint:err113
-		}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			td := setupRealCollectionVersions(t)
-
-			blockTxn := mocks.NewTxn(t)
-			blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-			blockTxn.EXPECT().Commit().Return(nil)
-
-			txTxn := mocks.NewTxn(t)
-			txTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-			txTxn.EXPECT().Commit().Return(nil)
-
-			logTxn := mocks.NewTxn(t)
-			logTxn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logColWithAddManyDocuments(t, nil), nil)
-			logTxn.EXPECT().Commit().Return(nil)
-
-			callCount := 0
-			db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) {
-				callCount++
-				switch callCount {
-				case 1:
-					return blockTxn, nil
-				case 2:
-					return txTxn, nil
-				case 3:
-					return logTxn, nil
-				default:
-					return nil, fmt.Errorf("signature transaction should not be opened") //nolint:err113
-				}
-			}}
-			h := newMockHandler(t, db)
-			h.collectDocCIDsFn = func(_ context.Context, docIDs []string) ([]cid.Cid, error) {
-				cids := make([]cid.Cid, len(docIDs))
-				for i := range docIDs {
-					cids[i] = oneTestCID()
-				}
-				return cids, nil
-			}
-			h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-				return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
-			}
-			h.verifyBatchSigFn = tc.verify
-
-			tx := testTx()
-			receiptMap := map[string]*types.TransactionReceipt{tx.Hash: testReceipt()}
-			blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-			require.NoError(t, err)
-			assert.NotEmpty(t, blockID)
-			assert.Equal(t, 3, callCount) // signature transaction never opened
-		})
-	}
-}
-
-// TestWriteBatchWithRetry checks the retry loop: a conflict is retried, a non-conflict error is
-// not, it gives up after maxBatchRetries, and a discarded attempt's CIDs are rolled back.
 func TestWriteBatchWithRetry(t *testing.T) {
 	t.Parallel()
 	h := newMockHandler(t, &mockBlockDB{})
@@ -1221,12 +177,12 @@ func TestWriteBatchWithRetry(t *testing.T) {
 
 	t.Run("rolls back a discarded attempt's CIDs", func(t *testing.T) {
 		collector := node.NewBatchCIDCollector()
-		collector.Add(oneTestCID()) // a CID from an earlier committed batch
+		collector.Add(oneTestCID())
 		ctx := node.ContextWithBatchSigning(context.Background(), collector)
 
 		calls := 0
 		err := h.writeBatchWithRetry(ctx, 100, "log", func() error {
-			collector.Add(oneTestCID()) // the attempt records its CID before the transaction commits
+			collector.Add(oneTestCID())
 			calls++
 			if calls == 1 {
 				return fmt.Errorf("transaction conflict") //nolint:err113
@@ -1235,96 +191,12 @@ func TestWriteBatchWithRetry(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, 2, calls)
-		// Earlier CID plus the committed attempt's CID; the discarded attempt's CID was rolled back.
 		assert.Equal(t, 2, collector.Len())
 	})
 }
 
-// TestBatchCreateTransactions_RetriesConflict checks that a transaction batch whose commit
-// conflicts is retried and the transaction is still written.
-func TestBatchCreateTransactions_RetriesConflict(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-
-	txn1 := mocks.NewTxn(t)
-	txn1.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txn1.EXPECT().Commit().Return(fmt.Errorf("transaction conflict")) //nolint:err113
-	txn2 := mocks.NewTxn(t)
-	txn2.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txn2.EXPECT().Commit().Return(nil)
-
-	callCount := 0
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) {
-		callCount++
-		if callCount == 1 {
-			return txn1, nil
-		}
-		return txn2, nil
-	}}
-	h := newMockHandler(t, db)
-
-	blockID := nextTestDocID().String()
-	txHashToID, batchErrors := h.batchCreateTransactions(context.Background(), 100, []*types.Transaction{testTx()}, blockID)
-	assert.Empty(t, batchErrors)
-	assert.Len(t, txHashToID, 1)
-	assert.Equal(t, 2, callCount) // one conflict, one retry
-}
-
-// TestBatchCreateTransactions_AlreadyExistsDrops checks that an already-exists batch is dropped
-// without retrying and without reporting a batch error (it is P2P echo, not a conflict).
-func TestBatchCreateTransactions_AlreadyExistsDrops(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, fmt.Errorf("already exists")), nil) //nolint:err113
-	txn.EXPECT().Discard().Maybe()
-
-	callCount := 0
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) {
-		callCount++
-		return txn, nil
-	}}
-	h := newMockHandler(t, db)
-
-	blockID := nextTestDocID().String()
-	txHashToID, batchErrors := h.batchCreateTransactions(context.Background(), 100, []*types.Transaction{testTx()}, blockID)
-	assert.Empty(t, batchErrors)  // already-exists is not a batch error
-	assert.Empty(t, txHashToID)   // the batch was dropped
-	assert.Equal(t, 1, callCount) // not retried
-}
-
-func TestBatched_TrackBlock_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.docIDTracker = &errDocIDTracker{}
-
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, nil, nil)
-	require.NoError(t, err) // tracker error is logged
-	assert.NotEmpty(t, blockID)
-}
-
 // =========================================================================
-// CreateBlockSignatureForExistingBlock error paths
+// SignExisting error paths
 // =========================================================================
 
 func TestExistingSig_GQLQuery_Error(t *testing.T) {
@@ -1337,10 +209,11 @@ func TestExistingSig_GQLQuery_Error(t *testing.T) {
 		},
 	}
 	h := newMockHandler(t, db)
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "query block docIDs")
+	assert.Contains(t, err.Error(), "query docIDs for")
 }
 
 func TestExistingSig_GetBlockCol_Error(t *testing.T) {
@@ -1349,10 +222,11 @@ func TestExistingSig_GetBlockCol_Error(t *testing.T) {
 		execReqFn: execReqFnWithErrorForCol(colBlock),
 	}
 	h := newMockHandler(t, db)
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "query block docIDs")
+	assert.Contains(t, err.Error(), "query docIDs for")
 }
 
 func TestExistingSig_GetTxCol_Error(t *testing.T) {
@@ -1361,10 +235,11 @@ func TestExistingSig_GetTxCol_Error(t *testing.T) {
 		execReqFn: execReqFnWithErrorForCol(colTransaction),
 	}
 	h := newMockHandler(t, db)
+	groups := buildSigGroups(t, testBlock(), []*types.Transaction{testTx()}, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "query tx docIDs")
+	assert.Contains(t, err.Error(), "query docIDs for")
 }
 
 func TestExistingSig_GetLogCol_Error(t *testing.T) {
@@ -1373,10 +248,11 @@ func TestExistingSig_GetLogCol_Error(t *testing.T) {
 		execReqFn: execReqFnWithErrorForCol(colLog),
 	}
 	h := newMockHandler(t, db)
+	groups := buildSigGroups(t, testBlock(), []*types.Transaction{testTx()}, []*types.TransactionReceipt{testReceipt()})
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "query log docIDs")
+	assert.Contains(t, err.Error(), "query docIDs for")
 }
 
 func TestExistingSig_GetALECol_Error(t *testing.T) {
@@ -1385,10 +261,13 @@ func TestExistingSig_GetALECol_Error(t *testing.T) {
 		execReqFn: execReqFnWithErrorForCol(colAccessListEntry),
 	}
 	h := newMockHandler(t, db)
+	tx := testTx()
+	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
+	groups := buildSigGroups(t, testBlock(), []*types.Transaction{tx}, []*types.TransactionReceipt{testReceipt()})
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "query ale docIDs")
+	assert.Contains(t, err.Error(), "query docIDs for")
 }
 
 func TestExistingSig_CIDRetry_CollectError(t *testing.T) {
@@ -1398,10 +277,11 @@ func TestExistingSig_CIDRetry_CollectError(t *testing.T) {
 	}
 	h := newMockHandler(t, db)
 	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
-		return nil, fmt.Errorf("collect error") // nolint:err113
+		return nil, fmt.Errorf("collect error") //nolint:err113
 	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no CIDs found")
 }
@@ -1414,10 +294,11 @@ func TestExistingSig_CIDRetry_InsufficientCIDs(t *testing.T) {
 	h := newMockHandler(t, db)
 	h.maxCIDRetries = 2
 	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
-		return nil, nil // 0 CIDs < len(allDocIDs)=4
+		return nil, nil
 	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no CIDs found")
 }
@@ -1428,8 +309,9 @@ func TestExistingSig_CIDRetry_TxnError(t *testing.T) {
 		execReqFn: execReqFnWithDocIDs(),
 	}
 	h := newMockHandler(t, db)
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no CIDs found")
 }
@@ -1438,17 +320,18 @@ func TestExistingSig_SigningTxn_Error(t *testing.T) {
 	t.Parallel()
 	db := &mockBlockDB{
 		execReqFn: emptyExecReqFn(),
-		newTxnFn:  func(_ bool) (client.Txn, error) { return nil, fmt.Errorf("signing txn error") }, // nolint:err113
+		newTxnFn:  func(_ bool) (client.Txn, error) { return nil, fmt.Errorf("signing txn error") }, //nolint:err113
 	}
 	h := newMockHandler(t, db)
 	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil
+		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signing txn error")
 }
@@ -1463,10 +346,11 @@ func TestExistingSig_SignBlock_Error(t *testing.T) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return nil, fmt.Errorf("sign error") // nolint:err113
+		return nil, fmt.Errorf("sign error") //nolint:err113
 	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sign error")
 }
@@ -1480,9 +364,9 @@ func TestExistingSig_NilBlockSig(t *testing.T) {
 	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
-	// signBatchFn returns nil, nil -> "signing returned nil"
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signing returned nil")
 }
@@ -1491,7 +375,7 @@ func TestExistingSig_GetSigCol_Error(t *testing.T) {
 	t.Parallel()
 	sigTxn := mocks.NewTxn(t)
 	sigTxn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).
-		Return(nil, fmt.Errorf("no sig col")) // nolint:err113
+		Return(nil, fmt.Errorf("no sig col")) //nolint:err113
 	sigTxn.EXPECT().Discard()
 
 	db := &mockBlockDB{
@@ -1503,10 +387,11 @@ func TestExistingSig_GetSigCol_Error(t *testing.T) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil
+		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no sig col")
 }
@@ -1529,10 +414,11 @@ func TestExistingSig_BuildSigDoc_Error(t *testing.T) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil
+		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "field does not exist")
 }
@@ -1543,7 +429,7 @@ func TestExistingSig_CreateSigDoc_Error(t *testing.T) {
 
 	sigCol := mocks.NewCollection(t)
 	sigCol.EXPECT().Version().Return(td.sigVersion)
-	sigCol.EXPECT().AddDocument(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("create error")) // nolint:err113
+	sigCol.EXPECT().AddDocument(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("create error")) //nolint:err113
 	sigTxn := mocks.NewTxn(t)
 	sigTxn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(sigCol, nil)
 	sigTxn.EXPECT().Discard()
@@ -1557,10 +443,11 @@ func TestExistingSig_CreateSigDoc_Error(t *testing.T) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil
+		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create error")
 }
@@ -1572,7 +459,7 @@ func TestExistingSig_Commit_Error(t *testing.T) {
 	sigCol := td.sigColWithAddDocument(t, nil)
 	sigTxn := mocks.NewTxn(t)
 	sigTxn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(sigCol, nil)
-	sigTxn.EXPECT().Commit().Return(fmt.Errorf("commit error")) // nolint:err113
+	sigTxn.EXPECT().Commit().Return(fmt.Errorf("commit error")) //nolint:err113
 
 	db := &mockBlockDB{
 		execReqFn: emptyExecReqFn(),
@@ -1583,194 +470,93 @@ func TestExistingSig_Commit_Error(t *testing.T) {
 		return []cid.Cid{oneTestCID()}, nil
 	}
 	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil
+		return &node.BatchSignature{MerkleRoot: make([]byte, 32)}, nil //nolint:mnd
 	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "commit error")
 }
 
-// =========================================================================
-// GetHighestBlockNumber mock tests
-// =========================================================================
+// --- CID retry backoff paths ---
 
-func TestGetHighestBlockNumber_GQLError(t *testing.T) {
+func TestExistingSig_CIDRetry_BackoffPath(t *testing.T) {
 	t.Parallel()
+	collectCount := 0
+
 	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{
-					Errors: []error{fmt.Errorf("gql error")},
-				},
-			}
-		},
+		execReqFn: execReqFnWithDocIDs(),
 	}
 	h := newMockHandler(t, db)
+	h.maxCIDRetries = 2
+	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+		collectCount++
+		if collectCount == 1 {
+			return nil, nil
+		}
+		if collectCount == 2 {
+			return []cid.Cid{oneTestCID()}, nil
+		}
+		return nil, fmt.Errorf("sign error") //nolint:err113
+	}
+	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
+		return nil, fmt.Errorf("sign error") //nolint:err113
+	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.GetHighestBlockNumber(context.Background())
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
 }
 
-func TestGetHighestBlockNumber_DataCastFailure(t *testing.T) {
+func TestExistingSig_BuildLogDoc_Continue(t *testing.T) {
 	t.Parallel()
+
 	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{Data: "not a map"},
-			}
-		},
+		execReqFn: emptyExecReqFn(),
 	}
 	h := newMockHandler(t, db)
+	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+		return nil, fmt.Errorf("no cids") //nolint:err113
+	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.GetHighestBlockNumber(context.Background())
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no CIDs found")
 }
 
-func TestGetHighestBlockNumber_MapSliceBranch(t *testing.T) {
+func TestExistingSig_CIDRetry_TxnError_Backoff(t *testing.T) {
 	t.Parallel()
+
 	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{
-					Data: map[string]any{
-						colBlock: []map[string]any{
-							{constants.NumberFieldValue: float64(42)},
-						},
-					},
-				},
-			}
-		},
+		execReqFn: execReqFnWithDocIDs(),
 	}
 	h := newMockHandler(t, db)
+	h.maxCIDRetries = 2
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	num, err := h.GetHighestBlockNumber(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(42), num)
-}
-
-func TestGetHighestBlockNumber_MapSlice_Empty(t *testing.T) {
-	t.Parallel()
-	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{
-					Data: map[string]any{
-						colBlock: []map[string]any{},
-					},
-				},
-			}
-		},
-	}
-	h := newMockHandler(t, db)
-
-	_, err := h.GetHighestBlockNumber(context.Background())
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no CIDs found")
 }
 
-func TestGetHighestBlockNumber_DefaultBranch(t *testing.T) {
+func TestExistingSig_CIDRetry_CollectError_Backoff(t *testing.T) {
 	t.Parallel()
+
 	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{
-					Data: map[string]any{
-						colBlock: "unexpected type",
-					},
-				},
-			}
-		},
+		execReqFn: emptyExecReqFn(),
 	}
 	h := newMockHandler(t, db)
+	h.maxCIDRetries = 2
+	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
+		return nil, fmt.Errorf("collect error") //nolint:err113
+	}
+	groups := buildSigGroups(t, testBlock(), nil, nil)
 
-	_, err := h.GetHighestBlockNumber(context.Background())
+	_, err := h.SignExisting(context.Background(), groups, colBlockSignature, "0xhash", 100, nil)
 	require.Error(t, err)
-}
-
-func TestGetHighestBlockNumber_Int64Branch(t *testing.T) {
-	t.Parallel()
-	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{
-					Data: map[string]any{
-						colBlock: []any{
-							map[string]any{constants.NumberFieldValue: int64(99)},
-						},
-					},
-				},
-			}
-		},
-	}
-	h := newMockHandler(t, db)
-
-	num, err := h.GetHighestBlockNumber(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(99), num)
-}
-
-func TestGetHighestBlockNumber_IntBranch(t *testing.T) {
-	t.Parallel()
-	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{
-					Data: map[string]any{
-						colBlock: []any{
-							map[string]any{constants.NumberFieldValue: int(77)},
-						},
-					},
-				},
-			}
-		},
-	}
-	h := newMockHandler(t, db)
-
-	num, err := h.GetHighestBlockNumber(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(77), num)
-}
-
-func TestGetHighestBlockNumber_InvalidNumberType(t *testing.T) {
-	t.Parallel()
-	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{
-					Data: map[string]any{
-						colBlock: []any{
-							map[string]any{constants.NumberFieldValue: "not a number"},
-						},
-					},
-				},
-			}
-		},
-	}
-	h := newMockHandler(t, db)
-
-	_, err := h.GetHighestBlockNumber(context.Background())
-	require.Error(t, err)
-}
-
-func TestGetHighestBlockNumber_InvalidFormat(t *testing.T) {
-	t.Parallel()
-	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{
-					Data: map[string]any{
-						colBlock: []any{
-							"not a map",
-						},
-					},
-				},
-			}
-		},
-	}
-	h := newMockHandler(t, db)
-
-	_, err := h.GetHighestBlockNumber(context.Background())
-	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no CIDs found")
 }
 
 // =========================================================================
@@ -1779,11 +565,7 @@ func TestGetHighestBlockNumber_InvalidFormat(t *testing.T) {
 // =========================================================================
 
 type realCollectionVersions struct {
-	blockVersion client.CollectionVersion
-	txVersion    client.CollectionVersion
-	logVersion   client.CollectionVersion
-	aleVersion   client.CollectionVersion
-	sigVersion   client.CollectionVersion
+	sigVersion client.CollectionVersion
 }
 
 func setupRealCollectionVersions(t *testing.T) *realCollectionVersions {
@@ -1801,82 +583,10 @@ func setupRealCollectionVersions(t *testing.T) *realCollectionVersions {
 	}
 
 	v := &realCollectionVersions{
-		blockVersion: getVer(colBlock),
-		txVersion:    getVer(colTransaction),
-		logVersion:   getVer(colLog),
-		aleVersion:   getVer(colAccessListEntry),
-		sigVersion:   getVer(colBlockSignature),
+		sigVersion: getVer(colBlockSignature),
 	}
 	txn.Discard()
 	return v
-}
-
-func (v *realCollectionVersions) blockCol(t *testing.T) *mocks.Collection {
-	t.Helper()
-	c := mocks.NewCollection(t)
-	c.EXPECT().Version().Return(v.blockVersion).Maybe()
-	return c
-}
-
-func (v *realCollectionVersions) blockColWithAddDocument(t *testing.T, createErr error) *mocks.Collection {
-	t.Helper()
-	c := v.blockCol(t)
-	c.EXPECT().AddDocument(mock.Anything, mock.Anything, mock.Anything).Run(func(_ context.Context, doc *client.Document, _ ...options.Enumerable[options.AddDocumentOptions]) {
-		if createErr != nil {
-			return
-		}
-		client.ApplySavedDocumentID(doc, nextTestDocID())
-	}).Return(createErr).Maybe()
-	return c
-}
-
-func (v *realCollectionVersions) txCol(t *testing.T) *mocks.Collection {
-	t.Helper()
-	c := mocks.NewCollection(t)
-	c.EXPECT().Version().Return(v.txVersion).Maybe()
-	return c
-}
-
-func (v *realCollectionVersions) txColWithAddManyDocuments(t *testing.T, err error) *mocks.Collection {
-	t.Helper()
-	c := v.txCol(t)
-	c.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Run(func(_ context.Context, docs []*client.Document, _ ...options.Enumerable[options.AddDocumentOptions]) {
-		if err != nil {
-			return
-		}
-		for _, doc := range docs {
-			client.ApplySavedDocumentID(doc, nextTestDocID())
-		}
-	}).Return(err).Maybe()
-	return c
-}
-
-func (v *realCollectionVersions) logCol(t *testing.T) *mocks.Collection {
-	t.Helper()
-	c := mocks.NewCollection(t)
-	c.EXPECT().Version().Return(v.logVersion).Maybe()
-	return c
-}
-
-func (v *realCollectionVersions) logColWithAddManyDocuments(t *testing.T, err error) *mocks.Collection {
-	t.Helper()
-	c := v.logCol(t)
-	c.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Run(func(_ context.Context, docs []*client.Document, _ ...options.Enumerable[options.AddDocumentOptions]) {
-		if err != nil {
-			return
-		}
-		for _, doc := range docs {
-			client.ApplySavedDocumentID(doc, nextTestDocID())
-		}
-	}).Return(err).Maybe()
-	return c
-}
-
-func (v *realCollectionVersions) aleCol(t *testing.T) *mocks.Collection {
-	t.Helper()
-	c := mocks.NewCollection(t)
-	c.EXPECT().Version().Return(v.aleVersion).Maybe()
-	return c
 }
 
 func (v *realCollectionVersions) sigCol(t *testing.T) *mocks.Collection {
@@ -1896,801 +606,6 @@ func (v *realCollectionVersions) sigColWithAddDocument(t *testing.T, createErr e
 		client.ApplySavedDocumentID(doc, nextTestDocID())
 	}).Return(createErr).Maybe()
 	return c
-}
-
-// =========================================================================
-// Additional coverage tests: log/ALE batched loops, tracker with data, etc.
-// =========================================================================
-
-// TestSingleTxn_TrackBlock_WithALEs covers the aleIDs loop (lines 342-344). We don't need to test the log loop as well since it's the same code and the log batch tests cover it.
-func TestSingleTxn_TrackBlock_WithALEs(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	txn := mocks.NewTxn(t)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logColWithAddManyDocuments(t, nil), nil)
-	aleCol := mocks.NewCollection(t)
-	aleCol.EXPECT().Version().Return(td.aleVersion)
-	aleCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Run(func(_ context.Context, docs []*client.Document, _ ...options.Enumerable[options.AddDocumentOptions]) {
-		for _, doc := range docs {
-			client.ApplySavedDocumentID(doc, nextTestDocID())
-		}
-	}).Return(nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(aleCol, nil)
-	txn.EXPECT().GetCollectionByName(mock.Anything, colBlockSignature, mock.Anything).Return(td.sigCol(t), nil)
-	txn.EXPECT().Commit().Return(nil)
-
-	db := &mockBlockDB{newTxnFn: func(_ bool) (client.Txn, error) { return txn, nil }}
-	h := newMockHandler(t, db)
-	h.docIDTracker = &errDocIDTracker{} // tracker error is logged, not returned.
-
-	tx := testTx()
-	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	blockID, err := h.createBlockSingleTransaction(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
-}
-
-// --- Batched: Log batch error paths ---
-
-func TestBatched_LogBatch_NewTxn_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil // tx batch
-			}
-			if callCount == 3 {
-				return nil, fmt.Errorf("log txn error") // log batch
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-func TestBatched_LogBatch_GetCollection_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	logBatchTxn := mocks.NewTxn(t)
-	logBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(nil, fmt.Errorf("no log col"))
-	logBatchTxn.EXPECT().Discard()
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return logBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-func TestBatched_LogBatch_BuildDoc_Warn(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	emptyLogCol := mocks.NewCollection(t)
-	emptyLogCol.EXPECT().Version().Return(client.CollectionVersion{}) // build fails
-	logBatchTxn := mocks.NewTxn(t)
-	logBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(emptyLogCol, nil)
-	logBatchTxn.EXPECT().Commit().Return(nil)
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return logBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.NoError(t, err) // build warnings, not errors
-	assert.NotEmpty(t, blockID)
-}
-
-func TestBatched_LogBatch_CreateMany_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	logCol := mocks.NewCollection(t)
-	logCol.EXPECT().Version().Return(td.logVersion)
-	logCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("log create many error"))
-	logBatchTxn := mocks.NewTxn(t)
-	logBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(logCol, nil)
-	logBatchTxn.EXPECT().Discard()
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return logBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-func TestBatched_LogBatch_Commit_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	logBatchTxn := mocks.NewTxn(t)
-	logBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(td.logColWithAddManyDocuments(t, nil), nil)
-	logBatchTxn.EXPECT().Commit().Return(fmt.Errorf("log commit error"))
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return logBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-// --- Batched: ALE batch error paths ---
-
-func TestBatched_ALEBatch_NewTxn_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return nil, fmt.Errorf("ale txn error") // ALE batch
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-func TestBatched_ALEBatch_GetCollection_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	aleBatchTxn := mocks.NewTxn(t)
-	aleBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(nil, fmt.Errorf("no ale col"))
-	aleBatchTxn.EXPECT().Discard()
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return aleBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-func TestBatched_ALEBatch_BuildDoc_Warn(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	emptyALECol := mocks.NewCollection(t)
-	emptyALECol.EXPECT().Version().Return(client.CollectionVersion{}) // build fails
-	aleBatchTxn := mocks.NewTxn(t)
-	aleBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(emptyALECol, nil)
-	aleBatchTxn.EXPECT().Commit().Return(nil)
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return aleBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.NoError(t, err) // build warnings only
-	assert.NotEmpty(t, blockID)
-}
-
-func TestBatched_ALEBatch_CreateMany_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	aleCol := mocks.NewCollection(t)
-	aleCol.EXPECT().Version().Return(td.aleVersion)
-	aleCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("ale create many error"))
-	aleBatchTxn := mocks.NewTxn(t)
-	aleBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(aleCol, nil)
-	aleBatchTxn.EXPECT().Discard()
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return aleBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-func TestBatched_ALEBatch_Commit_Error(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	aleCol := mocks.NewCollection(t)
-	aleCol.EXPECT().Version().Return(td.aleVersion)
-	aleCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Run(func(_ context.Context, docs []*client.Document, _ ...options.Enumerable[options.AddDocumentOptions]) {
-		for _, doc := range docs {
-			client.ApplySavedDocumentID(doc, nextTestDocID())
-		}
-	}).Return(nil)
-	aleBatchTxn := mocks.NewTxn(t)
-	aleBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(aleCol, nil)
-	aleBatchTxn.EXPECT().Commit().Return(fmt.Errorf("ale commit error"))
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return aleBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.Error(t, err)
-	assert.NotEmpty(t, blockID)
-	assert.Contains(t, err.Error(), "batch errors")
-}
-
-// --- Batched: "already exists" duplicate paths ---
-
-func TestBatched_TxBatch_CreateMany_DuplicateError(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txCol := mocks.NewCollection(t)
-	txCol.EXPECT().Version().Return(td.txVersion)
-	txCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("document already exists"))
-	batchTxn := mocks.NewTxn(t)
-	batchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(txCol, nil)
-	batchTxn.EXPECT().Discard()
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return batchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.NoError(t, err) // duplicate is logged, not an error
-	assert.NotEmpty(t, blockID)
-}
-
-func TestBatched_LogBatch_CreateMany_DuplicateError(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	logCol := mocks.NewCollection(t)
-	logCol.EXPECT().Version().Return(td.logVersion)
-	logCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("document already exists"))
-	logBatchTxn := mocks.NewTxn(t)
-	logBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colLog, mock.Anything).Return(logCol, nil)
-	logBatchTxn.EXPECT().Discard()
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return logBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	receipt := testReceipt()
-	receiptMap := map[string]*types.TransactionReceipt{tx.Hash: receipt}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, receiptMap)
-	require.NoError(t, err) // duplicate is logged, not an error
-	assert.NotEmpty(t, blockID)
-}
-
-func TestBatched_ALEBatch_CreateMany_DuplicateError(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	aleCol := mocks.NewCollection(t)
-	aleCol.EXPECT().Version().Return(td.aleVersion)
-	aleCol.EXPECT().AddManyDocuments(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("document already exists"))
-	aleBatchTxn := mocks.NewTxn(t)
-	aleBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colAccessListEntry, mock.Anything).Return(aleCol, nil)
-	aleBatchTxn.EXPECT().Discard()
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			if callCount == 3 {
-				return aleBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-
-	tx := testTx()
-	tx.AccessList = []types.AccessListEntry{{Address: "0x01", StorageKeys: []string{"0x02"}}}
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.NoError(t, err) // duplicate is logged, not an error
-	assert.NotEmpty(t, blockID)
-}
-
-// --- GetHighestBlockNumber: []any empty ---
-
-func TestGetHighestBlockNumber_AnySlice_Empty(t *testing.T) {
-	t.Parallel()
-	db := &mockBlockDB{
-		execReqFn: func(_ context.Context, _ string, _ ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
-			return &client.RequestResult{
-				GQL: client.GQLResult{
-					Data: map[string]any{
-						colBlock: []any{},
-					},
-				},
-			}
-		},
-	}
-	h := newMockHandler(t, db)
-
-	_, err := h.GetHighestBlockNumber(context.Background())
-	require.Error(t, err)
-}
-
-// --- Batched: tracker with data (covers batched tracker loop) ---
-
-func TestBatched_TrackBlock_WithData(t *testing.T) {
-	t.Parallel()
-	td := setupRealCollectionVersions(t)
-	callCount := 0
-
-	blockTxn := mocks.NewTxn(t)
-	blockTxn.EXPECT().GetCollectionByName(mock.Anything, colBlock, mock.Anything).Return(td.blockColWithAddDocument(t, nil), nil)
-	blockTxn.EXPECT().Commit().Return(nil)
-
-	txBatchTxn := mocks.NewTxn(t)
-	txBatchTxn.EXPECT().GetCollectionByName(mock.Anything, colTransaction, mock.Anything).Return(td.txColWithAddManyDocuments(t, nil), nil)
-	txBatchTxn.EXPECT().Commit().Return(nil)
-
-	sigTxn := mocks.NewTxn(t)
-	sigTxn.EXPECT().Discard().Maybe()
-
-	db := &mockBlockDB{
-		newTxnFn: func(_ bool) (client.Txn, error) {
-			callCount++
-			if callCount == 1 {
-				return blockTxn, nil
-			}
-			if callCount == 2 {
-				return txBatchTxn, nil
-			}
-			return sigTxn, nil
-		},
-	}
-	h := newMockHandler(t, db)
-	h.maxDocsPerTxn = 2
-	h.docIDTracker = &errDocIDTracker{} // tracker error is logged
-
-	tx := testTx()
-	blockID, err := h.createBlockBatched(context.Background(), testBlock(), 100, []*types.Transaction{tx}, nil)
-	require.NoError(t, err)
-	assert.NotEmpty(t, blockID)
-}
-
-// --- CreateBlockSignatureForExistingBlock: CID retry backoff path ---
-
-func TestExistingSig_CIDRetry_BackoffPath(t *testing.T) {
-	t.Parallel()
-	collectCount := 0
-
-	db := &mockBlockDB{
-		execReqFn: execReqFnWithDocIDs(),
-	}
-	h := newMockHandler(t, db)
-	h.maxCIDRetries = 2
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
-		collectCount++
-		if collectCount == 1 {
-			return nil, nil // insufficient CIDs first time (triggers backoff)
-		}
-		if collectCount == 2 {
-			return []cid.Cid{oneTestCID()}, nil // lastCIDCount=1, loop ends, waitForCIDs returns nil
-		}
-		return nil, fmt.Errorf("sign error") // nolint:err113 // 3rd call in signAndStore
-	}
-	h.signBatchFn = func(_ context.Context, _ *node.BatchCIDCollector) (*node.BatchSignature, error) {
-		return nil, fmt.Errorf("sign error") // nolint:err113
-	}
-
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
-	require.Error(t, err)
-}
-
-// TestExistingSig_BuildLogDoc_Continue covers the CID collection failure path:
-// collectExistingBlockDocIDs returns empty (no docs), collectDocCIDsFn errors,
-// waitForCIDs exhausts retries → "no CIDs found".
-func TestExistingSig_BuildLogDoc_Continue(t *testing.T) {
-	t.Parallel()
-
-	db := &mockBlockDB{
-		execReqFn: emptyExecReqFn(),
-	}
-	h := newMockHandler(t, db)
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
-		return nil, fmt.Errorf("no cids")
-	}
-
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no CIDs found")
-}
-
-// TestExistingSig_CIDRetry_TxnError_Backoff covers the backoff path when
-// collectDocCIDsFn returns insufficient CIDs across multiple attempts.
-func TestExistingSig_CIDRetry_TxnError_Backoff(t *testing.T) {
-	t.Parallel()
-
-	db := &mockBlockDB{
-		execReqFn: execReqFnWithDocIDs(),
-	}
-	h := newMockHandler(t, db)
-	h.maxCIDRetries = 2 // two attempts → first hits backoff, second is last
-
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no CIDs found")
-}
-
-// TestExistingSig_CIDRetry_CollectError_Backoff covers the backoff path when
-// collectDocCIDsFn fails on every attempt.
-func TestExistingSig_CIDRetry_CollectError_Backoff(t *testing.T) {
-	t.Parallel()
-
-	db := &mockBlockDB{
-		execReqFn: emptyExecReqFn(),
-	}
-	h := newMockHandler(t, db)
-	h.maxCIDRetries = 2
-	h.collectDocCIDsFn = func(_ context.Context, _ []string) ([]cid.Cid, error) {
-		return nil, fmt.Errorf("collect error") // both attempts fail, triggers backoff between them
-	}
-
-	_, err := h.CreateBlockSignatureForExistingBlock(context.Background(), 100, "0xhash", testBlock(), nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no CIDs found")
 }
 
 // testutilsSetupDefraDB wraps the testutils helper, extracting the DB interface.

--- a/pkg/defra/block_handler_test.go
+++ b/pkg/defra/block_handler_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 func TestNewBlockHandler_NilNode(t *testing.T) {
 	t.Parallel()
 	// Test that nil node returns error.
-	handler, err := NewBlockHandler(nil, 1000, nil)
+	handler, err := NewBlockHandler(nil, 1000)
 	if err == nil {
 		t.Error("Expected error for nil node, got nil")
 	}
@@ -433,14 +433,14 @@ func TestNewBlockHandler_ZeroMaxDocs(t *testing.T) {
 	// by verifying both the nil-node error path and the default logic.
 
 	// With nil node, verify the error is returned regardless of maxDocsPerTxn
-	_, err := NewBlockHandler(nil, 0, nil)
-	require.Error(t, err, "NewBlockHandler(nil, 0, nil) should return error")
+	_, err := NewBlockHandler(nil, 0)
+	require.Error(t, err, "NewBlockHandler(nil, 0) should return error")
 
-	_, err = NewBlockHandler(nil, -1, nil)
-	require.Error(t, err, "NewBlockHandler(nil, -1, nil) should return error")
+	_, err = NewBlockHandler(nil, -1)
+	require.Error(t, err, "NewBlockHandler(nil, -1) should return error")
 
-	_, err = NewBlockHandler(nil, -100, nil)
-	require.Error(t, err, "NewBlockHandler(nil, -100, nil) should return error")
+	_, err = NewBlockHandler(nil, -100)
+	require.Error(t, err, "NewBlockHandler(nil, -100) should return error")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/defra/block_handler_test.go
+++ b/pkg/defra/block_handler_test.go
@@ -173,10 +173,6 @@ func TestConvertHexToInt_UnhappyPaths(t *testing.T) {
 	}
 }
 
-// Note: Tests for CreateBlockBatch, GetHighestBlockNumber, and other methods
-// that require an embedded DefraDB node should be placed in integration tests
-// since they require a running DefraDB instance.
-
 // ---------------------------------------------------------------------------
 // retryBackoff tests
 // ---------------------------------------------------------------------------

--- a/pkg/defra/error_logging_test.go
+++ b/pkg/defra/error_logging_test.go
@@ -216,7 +216,7 @@ func TestBlockHandlerErrorLogging(t *testing.T) {
 	testLogger := testutils.NewTestLogger(t)
 
 	// Create a block handler with nil node to trigger the error path.
-	_, err := NewBlockHandler(nil, 1000, nil)
+	_, err := NewBlockHandler(nil, 1000)
 	if err == nil {
 		t.Fatal("Expected error for nil node")
 	}

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -2514,10 +2514,6 @@ func TestGetPeerInfo_DeduplicationBranch(t *testing.T) {
 	assert.NotNil(t, info.PeerInfo)
 }
 
-// ---------------------------------------------------------------------------
-// fetchAndProcessBlock — context cancel during CreateBlockBatch retry
-// ---------------------------------------------------------------------------
-
 // ----------------------------------------------------------------------------.
 // openBrowser — test the "default" (linux) case on non-darwin platforms.
 // The function switches on runtime.GOOS. On macOS, only darwin branch runs.
@@ -3749,9 +3745,8 @@ func TestSignMessages_SignWithDefraKeysSucceeds_P2PKeysFails(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // fetchAndProcessBlock — transaction conflict retry path (lines 328-337)
-// We need to trigger IsErrTransactionConflict from CreateBlockBatch.
-// We can do this by running two concurrent processors that try to create,
-// the same block at the same time.
+// We trigger IsErrTransactionConflict by running two concurrent processors
+// that try to create the same block at the same time.
 // ---------------------------------------------------------------------------.
 
 func TestFetchAndProcessBlock_TransactionConflictRetry(t *testing.T) {

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/node"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,19 +47,21 @@ const (
 
 // testChain adapts *defra.BlockHandler to satisfy BlockRangeReader.
 type testChain struct {
-	handler *defra.BlockHandler
+	handler   *defra.BlockHandler
+	node      *node.Node
+	converter chains.Converter
 }
 
 func (tc *testChain) GetLowestStoredBlockNumber(ctx context.Context) (int64, error) {
-	return tc.handler.GetLowestBlockNumber(ctx)
+	return tc.converter.GetLowestStoredBlockNumber(ctx, tc.node)
 }
 
 func (tc *testChain) GetHighestStoredBlockNumber(ctx context.Context) (int64, error) {
-	return tc.handler.GetHighestBlockNumber(ctx)
+	return tc.converter.GetHighestStoredBlockNumber(ctx, tc.node)
 }
 
 func (tc *testChain) GetDocIDsByBlockRange(ctx context.Context, from, to int64) (map[string][]string, error) {
-	return tc.handler.GetDocIDsByBlockRange(ctx, from, to)
+	return tc.converter.GetDocIDsByBlockRange(ctx, tc.node, from, to)
 }
 
 func (tc *testChain) GetCollections() []string {
@@ -72,9 +75,10 @@ func (tc *testChain) Collections() chains.Collections {
 // newTestChainFromNode creates a testChain wrapping a fresh BlockHandler for the given node.
 func newTestChainFromNode(t *testing.T, td *testutils.TestDefraDB) *testChain {
 	t.Helper()
-	handler, err := defra.NewBlockHandler(td.Node, 1000, evm.NewCollectionNames("Ethereum__Mainnet"))
+	cols := evm.NewCollectionNames("Ethereum__Mainnet")
+	handler, err := defra.NewBlockHandler(td.Node, 1000, cols)
 	require.NoError(t, err)
-	return &testChain{handler: handler}
+	return &testChain{handler: handler, node: td.Node, converter: evm.NewConverter(nil)}
 }
 
 func TestMain(m *testing.M) {
@@ -1484,7 +1488,8 @@ func insertTestBlocks(t *testing.T, td *testutils.TestDefraDB, startBlock, endBl
 		block := testBlock(hexNum)
 		tx := testTransaction(fmt.Sprintf("block%d_tx0", i), decNum)
 		receipt := testReceipt(fmt.Sprintf("block%d_tx0", i), hexNum)
-		_, err := handler.CreateBlockBatch(ctx, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+		groups, sigCol, _ := testutils.BuildEVMGroups(evm.NewCollectionNames("Ethereum__Mainnet"), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+		_, err = handler.Store(ctx, groups, sigCol, nil)
 		require.NoError(t, err, "failed to insert block %d", i)
 	}
 	return handler
@@ -3991,7 +3996,8 @@ func insertTestBlocksWithIdentity(t *testing.T, td *testutils.TestDefraDB, start
 		block := testBlock(hexNum)
 		tx := testTransaction(fmt.Sprintf("block%d_tx0", i), decNum)
 		receipt := testReceipt(fmt.Sprintf("block%d_tx0", i), hexNum)
-		_, err := handler.CreateBlockBatch(ctx, block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+		groups, sigCol, _ := testutils.BuildEVMGroups(evm.NewCollectionNames("Ethereum__Mainnet"), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+		_, err = handler.Store(ctx, groups, sigCol, nil)
 		require.NoError(t, err, "failed to insert block %d", i)
 	}
 	return ctx, handler

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -75,8 +75,7 @@ func (tc *testChain) Collections() chains.Collections {
 // newTestChainFromNode creates a testChain wrapping a fresh BlockHandler for the given node.
 func newTestChainFromNode(t *testing.T, td *testutils.TestDefraDB) *testChain {
 	t.Helper()
-	cols := evm.NewCollectionNames("Ethereum__Mainnet")
-	handler, err := defra.NewBlockHandler(td.Node, 1000, cols)
+	handler, err := defra.NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 	return &testChain{handler: handler, node: td.Node, converter: evm.NewConverter(nil)}
 }
@@ -1478,7 +1477,7 @@ func testReceipt(txSeed, blockNumberHex string) *types.TransactionReceipt {
 // Returns the block handler for further use.
 func insertTestBlocks(t *testing.T, td *testutils.TestDefraDB, startBlock, endBlock int64) *defra.BlockHandler {
 	t.Helper()
-	handler, err := defra.NewBlockHandler(td.Node, 1000, evm.NewCollectionNames("Ethereum__Mainnet"))
+	handler, err := defra.NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -1488,8 +1487,8 @@ func insertTestBlocks(t *testing.T, td *testutils.TestDefraDB, startBlock, endBl
 		block := testBlock(hexNum)
 		tx := testTransaction(fmt.Sprintf("block%d_tx0", i), decNum)
 		receipt := testReceipt(fmt.Sprintf("block%d_tx0", i), hexNum)
-		groups, sigCol, _ := testutils.BuildEVMGroups(evm.NewCollectionNames("Ethereum__Mainnet"), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-		_, err = handler.Store(ctx, groups, sigCol, nil)
+		result, _ := testutils.BuildEVMGroups(evm.NewCollectionNames("Ethereum__Mainnet"), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+		_, err = handler.Store(ctx, result)
 		require.NoError(t, err, "failed to insert block %d", i)
 	}
 	return handler
@@ -3983,7 +3982,7 @@ func TestQuerySnapshotSignatures_MultipleDocsWithBlockSigRoots(t *testing.T) {
 
 func insertTestBlocksWithIdentity(t *testing.T, td *testutils.TestDefraDB, startBlock, endBlock int64) (context.Context, *defra.BlockHandler) {
 	t.Helper()
-	handler, err := defra.NewBlockHandler(td.Node, 1000, evm.NewCollectionNames("Ethereum__Mainnet"))
+	handler, err := defra.NewBlockHandler(td.Node, 1000)
 	require.NoError(t, err)
 
 	fullIdent, err := identity.Generate(crypto.KeyTypeSecp256k1)
@@ -3996,8 +3995,8 @@ func insertTestBlocksWithIdentity(t *testing.T, td *testutils.TestDefraDB, start
 		block := testBlock(hexNum)
 		tx := testTransaction(fmt.Sprintf("block%d_tx0", i), decNum)
 		receipt := testReceipt(fmt.Sprintf("block%d_tx0", i), hexNum)
-		groups, sigCol, _ := testutils.BuildEVMGroups(evm.NewCollectionNames("Ethereum__Mainnet"), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
-		_, err = handler.Store(ctx, groups, sigCol, nil)
+		result, _ := testutils.BuildEVMGroups(evm.NewCollectionNames("Ethereum__Mainnet"), block, []*types.Transaction{tx}, []*types.TransactionReceipt{receipt})
+		_, err = handler.Store(ctx, result)
 		require.NoError(t, err, "failed to insert block %d", i)
 	}
 	return ctx, handler

--- a/pkg/testutils/evm_groups.go
+++ b/pkg/testutils/evm_groups.go
@@ -3,7 +3,7 @@ package testutils
 // TODO: Once pkg/chains/evm/adapter.go is removed, the import cycle
 // (testutils → chains/evm → testutils via evm test files) is broken. At that
 // point this file should be replaced with a thin wrapper calling
-// evm.NewConverter(nil).Convert(ctx, &evm.BlockBundle{...}, nil) to eliminate
+// evm.NewConverter(nil).Convert(ctx, &evm.BlockBundle{...}) to eliminate
 // the data-map duplication with evm/converter.go.
 
 import (
@@ -16,19 +16,41 @@ import (
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/utils"
 )
 
+// NoopStamper is a chains.LinkStamper that does nothing. Used by test helpers
+// that don't need link resolution.
+type NoopStamper struct{}
+
+// StampLinks implements chains.LinkStamper as a no-op.
+func (NoopStamper) StampLinks(_ []chains.DocumentGroup, _ string, _ []map[string]any, _ []string) {
+}
+
+// WrapResult bundles groups and a signature collection name into a
+// chains.ConversionResult with a NoopStamper. Used by test call sites that
+// need to pass a ConversionResult to BlockHandler.Store or SignExisting.
+func WrapResult(groups []chains.DocumentGroup, sigCol string) chains.ConversionResult {
+	return chains.ConversionResult{
+		Groups:              groups,
+		SignatureCollection: sigCol,
+		LinkStamper:         NoopStamper{},
+	}
+}
+
+// BuildEVMGroups builds a chains.ConversionResult from raw EVM block types,
+// producing document groups for block, transactions, logs, and access list
+// entries with a NoopStamper.
 func BuildEVMGroups(
 	collections chains.Collections,
 	block *types.Block,
 	txs []*types.Transaction,
 	receipts []*types.TransactionReceipt,
-) ([]chains.DocumentGroup, string, error) {
+) (chains.ConversionResult, error) {
 	if block == nil {
-		return nil, "", fmt.Errorf("nil block")
+		return chains.ConversionResult{}, fmt.Errorf("nil block")
 	}
 
 	blockInt, err := utils.HexToInt(block.Number)
 	if err != nil {
-		return nil, "", fmt.Errorf("parse block number: %w", err)
+		return chains.ConversionResult{}, fmt.Errorf("parse block number: %w", err)
 	}
 
 	blockCol, _ := collections.GetCollection(chains.TypeBlock)
@@ -41,31 +63,31 @@ func BuildEVMGroups(
 	txDocs := buildTxDocs(txs)
 	receiptMap := buildReceiptMap(receipts)
 	logDocs := buildLogDocs(txs, receiptMap)
-	aleDocs, aleParentRefs := buildALEDocs(txs, blockInt)
+	aleDocs, _ := buildALEDocs(txs, blockInt)
 
 	groups := []chains.DocumentGroup{
-		{Collection: blockCol, Docs: []map[string]any{blockData}},
+		{Collection: blockCol, Docs: []map[string]any{blockData}, BlockNumField: constants.NumberFieldValue},
 	}
 	if len(txDocs) > 0 {
-		groups = append(groups, chains.DocumentGroup{Collection: txCol, Docs: txDocs})
+		groups = append(groups, chains.DocumentGroup{Collection: txCol, Docs: txDocs, BlockNumField: constants.BlockNumberKeyValue})
 	}
 	if len(logDocs) > 0 {
-		groups = append(groups, chains.DocumentGroup{Collection: logCol, Docs: logDocs})
+		groups = append(groups, chains.DocumentGroup{Collection: logCol, Docs: logDocs, BlockNumField: constants.BlockNumberKeyValue})
 	}
 	if len(aleDocs) > 0 {
-		groups = append(groups, chains.DocumentGroup{
-			Collection: aleCol,
-			Docs:       aleDocs,
-			ParentRef:  aleParentRefs,
-		})
+		groups = append(groups, chains.DocumentGroup{Collection: aleCol, Docs: aleDocs, BlockNumField: constants.BlockNumberKeyValue})
 	}
 
-	return groups, sigCol, nil
+	return chains.ConversionResult{
+		Groups:              groups,
+		SignatureCollection: sigCol,
+		LinkStamper:         NoopStamper{},
+	}, nil
 }
 
 func buildBlockMap(block *types.Block, blockInt int64) map[string]any {
 	return map[string]any{
-		"hash":                     block.Hash,
+		constants.HashKeyValue:     block.Hash,
 		constants.NumberFieldValue: blockInt,
 		"timestamp":                block.Timestamp,
 		"parentHash":               block.ParentHash,
@@ -102,7 +124,7 @@ func buildTxDocs(txs []*types.Transaction) []map[string]any {
 func buildTxMap(tx *types.Transaction) map[string]any {
 	txBlockNum, _ := strconv.ParseInt(tx.BlockNumber, 10, 64)
 	return map[string]any{
-		"hash":                        tx.Hash,
+		constants.HashKeyValue:        tx.Hash,
 		constants.BlockNumberKeyValue: txBlockNum,
 		constants.BlockHashKeyValue:   tx.BlockHash,
 		"transactionIndex":            tx.TransactionIndex,
@@ -156,15 +178,15 @@ func buildLogDocs(txs []*types.Transaction, receiptMap map[string]*types.Transac
 func buildLogMap(logEntry *types.Log) map[string]any {
 	logBlockNum, _ := utils.HexToInt(logEntry.BlockNumber)
 	return map[string]any{
-		"address":                     logEntry.Address,
-		"topics":                      logEntry.Topics,
-		"data":                        logEntry.Data,
-		constants.BlockNumberKeyValue: logBlockNum,
-		"transactionHash":             logEntry.TransactionHash,
-		"transactionIndex":            logEntry.TransactionIndex,
-		constants.BlockHashKeyValue:   logEntry.BlockHash,
-		"logIndex":                    logEntry.LogIndex,
-		"removed":                     fmt.Sprintf("%v", logEntry.Removed),
+		constants.AddressKeyValue:         logEntry.Address,
+		"topics":                          logEntry.Topics,
+		"data":                            logEntry.Data,
+		constants.BlockNumberKeyValue:     logBlockNum,
+		constants.TransactionHashKeyValue: logEntry.TransactionHash,
+		"transactionIndex":                logEntry.TransactionIndex,
+		constants.BlockHashKeyValue:       logEntry.BlockHash,
+		"logIndex":                        logEntry.LogIndex,
+		"removed":                         fmt.Sprintf("%v", logEntry.Removed),
 	}
 }
 
@@ -185,7 +207,7 @@ func buildALEDocs(txs []*types.Transaction, blockInt int64) ([]map[string]any, [
 
 func buildALEMap(ale *types.AccessListEntry, blockNumber int64) map[string]any {
 	return map[string]any{
-		"address":                     ale.Address,
+		constants.AddressKeyValue:     ale.Address,
 		constants.BlockNumberKeyValue: blockNumber,
 		"storageKeys":                 ale.StorageKeys,
 	}

--- a/pkg/testutils/evm_groups.go
+++ b/pkg/testutils/evm_groups.go
@@ -1,0 +1,192 @@
+package testutils
+
+// TODO: Once pkg/chains/evm/adapter.go is removed, the import cycle
+// (testutils → chains/evm → testutils via evm test files) is broken. At that
+// point this file should be replaced with a thin wrapper calling
+// evm.NewConverter(nil).Convert(ctx, &evm.BlockBundle{...}, nil) to eliminate
+// the data-map duplication with evm/converter.go.
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/chains"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/types"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/utils"
+)
+
+func BuildEVMGroups(
+	collections chains.Collections,
+	block *types.Block,
+	txs []*types.Transaction,
+	receipts []*types.TransactionReceipt,
+) ([]chains.DocumentGroup, string, error) {
+	if block == nil {
+		return nil, "", fmt.Errorf("nil block")
+	}
+
+	blockInt, err := utils.HexToInt(block.Number)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse block number: %w", err)
+	}
+
+	blockCol, _ := collections.GetCollection(chains.TypeBlock)
+	txCol, _ := collections.GetCollection(chains.TypeTransaction)
+	logCol, _ := collections.GetCollection(chains.TypeLog)
+	aleCol, _ := collections.GetCollection(chains.TypeAccessListEntry)
+	sigCol, _ := collections.GetCollection(chains.TypeBlockSignature)
+
+	blockData := buildBlockMap(block, blockInt)
+	txDocs := buildTxDocs(txs)
+	receiptMap := buildReceiptMap(receipts)
+	logDocs := buildLogDocs(txs, receiptMap)
+	aleDocs, aleParentRefs := buildALEDocs(txs, blockInt)
+
+	groups := []chains.DocumentGroup{
+		{Collection: blockCol, Docs: []map[string]any{blockData}},
+	}
+	if len(txDocs) > 0 {
+		groups = append(groups, chains.DocumentGroup{Collection: txCol, Docs: txDocs})
+	}
+	if len(logDocs) > 0 {
+		groups = append(groups, chains.DocumentGroup{Collection: logCol, Docs: logDocs})
+	}
+	if len(aleDocs) > 0 {
+		groups = append(groups, chains.DocumentGroup{
+			Collection: aleCol,
+			Docs:       aleDocs,
+			ParentRef:  aleParentRefs,
+		})
+	}
+
+	return groups, sigCol, nil
+}
+
+func buildBlockMap(block *types.Block, blockInt int64) map[string]any {
+	return map[string]any{
+		"hash":                     block.Hash,
+		constants.NumberFieldValue: blockInt,
+		"timestamp":                block.Timestamp,
+		"parentHash":               block.ParentHash,
+		"difficulty":               block.Difficulty,
+		"totalDifficulty":          block.TotalDifficulty,
+		"gasUsed":                  block.GasUsed,
+		"gasLimit":                 block.GasLimit,
+		"baseFeePerGas":            block.BaseFeePerGas,
+		"nonce":                    block.Nonce,
+		"miner":                    block.Miner,
+		"size":                     block.Size,
+		"stateRoot":                block.StateRoot,
+		"sha3Uncles":               block.Sha3Uncles,
+		"transactionsRoot":         block.TransactionsRoot,
+		"receiptsRoot":             block.ReceiptsRoot,
+		"logsBloom":                block.LogsBloom,
+		"extraData":                block.ExtraData,
+		"mixHash":                  block.MixHash,
+		"uncles":                   block.Uncles,
+	}
+}
+
+func buildTxDocs(txs []*types.Transaction) []map[string]any {
+	var docs []map[string]any
+	for _, tx := range txs {
+		if tx == nil {
+			continue
+		}
+		docs = append(docs, buildTxMap(tx))
+	}
+	return docs
+}
+
+func buildTxMap(tx *types.Transaction) map[string]any {
+	txBlockNum, _ := strconv.ParseInt(tx.BlockNumber, 10, 64)
+	return map[string]any{
+		"hash":                        tx.Hash,
+		constants.BlockNumberKeyValue: txBlockNum,
+		constants.BlockHashKeyValue:   tx.BlockHash,
+		"transactionIndex":            tx.TransactionIndex,
+		"from":                        tx.From,
+		"to":                          tx.To,
+		"value":                       tx.Value,
+		"gas":                         tx.Gas,
+		"gasPrice":                    tx.GasPrice,
+		"maxFeePerGas":                tx.MaxFeePerGas,
+		"maxPriorityFeePerGas":        tx.MaxPriorityFeePerGas,
+		"input":                       tx.Input,
+		"nonce":                       tx.Nonce,
+		"type":                        tx.Type,
+		"chainId":                     tx.ChainID,
+		"v":                           tx.V,
+		"r":                           tx.R,
+		"s":                           tx.S,
+		"cumulativeGasUsed":           tx.CumulativeGasUsed,
+		"effectiveGasPrice":           tx.EffectiveGasPrice,
+		"status":                      tx.Status,
+	}
+}
+
+func buildReceiptMap(receipts []*types.TransactionReceipt) map[string]*types.TransactionReceipt {
+	m := make(map[string]*types.TransactionReceipt)
+	for _, receipt := range receipts {
+		if receipt != nil {
+			m[receipt.TransactionHash] = receipt
+		}
+	}
+	return m
+}
+
+func buildLogDocs(txs []*types.Transaction, receiptMap map[string]*types.TransactionReceipt) []map[string]any {
+	var docs []map[string]any
+	for _, tx := range txs {
+		if tx == nil {
+			continue
+		}
+		receipt, ok := receiptMap[tx.Hash]
+		if !ok || receipt == nil {
+			continue
+		}
+		for i := range receipt.Logs {
+			docs = append(docs, buildLogMap(&receipt.Logs[i]))
+		}
+	}
+	return docs
+}
+
+func buildLogMap(logEntry *types.Log) map[string]any {
+	logBlockNum, _ := utils.HexToInt(logEntry.BlockNumber)
+	return map[string]any{
+		"address":                     logEntry.Address,
+		"topics":                      logEntry.Topics,
+		"data":                        logEntry.Data,
+		constants.BlockNumberKeyValue: logBlockNum,
+		"transactionHash":             logEntry.TransactionHash,
+		"transactionIndex":            logEntry.TransactionIndex,
+		constants.BlockHashKeyValue:   logEntry.BlockHash,
+		"logIndex":                    logEntry.LogIndex,
+		"removed":                     fmt.Sprintf("%v", logEntry.Removed),
+	}
+}
+
+func buildALEDocs(txs []*types.Transaction, blockInt int64) ([]map[string]any, []string) {
+	var docs []map[string]any
+	var parentRefs []string
+	for _, tx := range txs {
+		if tx == nil {
+			continue
+		}
+		for i := range tx.AccessList {
+			docs = append(docs, buildALEMap(&tx.AccessList[i], blockInt))
+			parentRefs = append(parentRefs, tx.Hash)
+		}
+	}
+	return docs, parentRefs
+}
+
+func buildALEMap(ale *types.AccessListEntry, blockNumber int64) map[string]any {
+	return map[string]any{
+		"address":                     ale.Address,
+		constants.BlockNumberKeyValue: blockNumber,
+		"storageKeys":                 ale.StorageKeys,
+	}
+}

--- a/pkg/testutils/mock_converter.go
+++ b/pkg/testutils/mock_converter.go
@@ -23,7 +23,7 @@ type MockConverter struct {
 	mu sync.Mutex
 
 	// Optional overrides. When nil the method returns its zero value.
-	ConvertFn                     func(ctx context.Context, rawBlock any, vp chains.CollectionVersionProvider) ([]chains.DocumentGroup, string, error)
+	ConvertFn                     func(ctx context.Context, rawBlock any) (chains.ConversionResult, error)
 	GetSchemaFn                   func() (string, error)
 	GetCollectionsFn              func() []string
 	CollectionsFn                 func() chains.Collections
@@ -45,14 +45,14 @@ type MockConverter struct {
 var _ chains.Converter = (*MockConverter)(nil)
 
 // Convert records the rawBlock and delegates to ConvertFn.
-func (m *MockConverter) Convert(ctx context.Context, rawBlock any, vp chains.CollectionVersionProvider) ([]chains.DocumentGroup, string, error) {
+func (m *MockConverter) Convert(ctx context.Context, rawBlock any) (chains.ConversionResult, error) {
 	m.mu.Lock()
 	m.ConvertCalls = append(m.ConvertCalls, rawBlock)
 	m.mu.Unlock()
 	if m.ConvertFn != nil {
-		return m.ConvertFn(ctx, rawBlock, vp)
+		return m.ConvertFn(ctx, rawBlock)
 	}
-	return nil, "", ErrMockConvertFnNotSet
+	return chains.ConversionResult{}, ErrMockConvertFnNotSet
 }
 
 // GetSchema records the call and delegates to GetSchemaFn.


### PR DESCRIPTION
# Pull Request

## Description
This  PR implements provides  a chain-agnostic implementation of `BlockHandler`

## Changes
- Added `LinkStamper` interface, `ConversionResult `struct, `BatchSize` + `BlockNumField` fields in `DocumentGroup` to `pkg/chains`
- `BlockHandler `is fully chain-agnostic:  generic `Store(result)` loop, `writeGroup`, `SignExisting(result)`; holds no collections, no role names, no EVM constants
- `Fetcher` / `Converter` / `BlockHandler` split into three clean single-purpose interfaces.
- `Converter.Convert` returns `ConversionResult{Groups, SignatureCollection, LinkStamper}`: all chain-specific knowledge (field names, batch sizes, link logic) travels through this bundle
- `LinkStamper` implementation owns `_blockID`/`_transactionID` stamping via `StampLinks`; `BlockHandler` just calls it after each group write
- `DocumentGroup` carries `BatchSize` + `BlockNumField` metadata per group
- Progress queries live in `Converter` with explicit `*node.Node`

## Related Issue
#132 

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Verify core functionality works as expected (e.g., main page loads, API responds)

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
### ADR Diversion
The original ADR design assumed `Convert` could pre-compute `DocIDs` in-memory via `client.NewDocFromMap` before storage, enabling link fields (`_blockID`,` _transactionID`) to be stamped during conversion. This is not possible with the DefraDB version pinned in this repo (v1.0.1 post-v1.0.0), where `DocIDs `are derived from genesis composite block `CIDs` computed during `AddDocument` on a live node, not from `NewDocFromMap` alone.

**Consequences:**
- Link resolution stays in `Store`, not `Convert`: a two-phase write: parent doc first, then stamp children with the resulting `DocID`
- The `CollectionVersionProvider` interface and vp parameter from were removed  as they were circular and unused
- `LinkStamper` was introduced as the explicit chain extension point, replacing  EVM-specific `storeTxGroup`/`storeLogGroup`/`storeALEGroup` functions

If DefraDB re-introduces pre-storage `DocID` computation in the future, the `LinkStamper` pattern can be simplified or eliminated, `Convert` could stamp links directly and Store could become a pure writer.

### Phase 1 Removal Progress
Full removal of Phase 1 interfaces deferred to future PRs
