### PR TITLE
fix: index block-number fields so pruner and block-exists queries can complete

### DIFF
--- a/pkg/pruner/index_test.go
+++ b/pkg/pruner/index_test.go
@@ -1,0 +1,61 @@
+package pruner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/testutils"
+)
+
+// The pruner finds the oldest documents with `order: {<field>: ASC}, limit`, and the block-exists
+// check filters by `<field>: {_eq}`. DefraDB serves both from a single-field index on that field,
+// and index-backed ordering requires the field to lead the index.
+//
+// Declaring an index is not the same as having a usable one: an index whose build errored or has
+// not finished is still listed on the collection but is excluded from query planning, so assert on
+// its lifecycle status rather than its presence.
+func TestSchemaIndexesBlockNumberField(t *testing.T) {
+	t.Parallel()
+	td := testutils.SetupTestDefraDB(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		collection string
+		field      string
+	}{
+		{constants.CollectionBlock, constants.NumberFieldValue},
+		{constants.CollectionTransaction, constants.BlockNumberKeyValue},
+		{constants.CollectionLog, constants.BlockNumberKeyValue},
+		{constants.CollectionAccessListEntry, constants.BlockNumberKeyValue},
+		{constants.CollectionBlockSignature, constants.BlockNumberKeyValue},
+	}
+
+	for _, c := range cases {
+		t.Run(c.collection, func(t *testing.T) {
+			col, err := td.Node.DB.GetCollectionByName(ctx, c.collection)
+			require.NoError(t, err)
+
+			indexes, err := col.ListIndexes(ctx)
+			require.NoError(t, err)
+
+			var leading *client.ListIndexesResult
+			for i := range indexes {
+				fields := indexes[i].Description.Fields
+				if len(fields) > 0 && fields[0].Name == c.field {
+					leading = &indexes[i]
+					break
+				}
+			}
+
+			require.NotNil(t, leading, "no index leads with %s", c.field)
+			require.NotEqual(t, client.ErroredActionStatus, leading.Execution.Status,
+				"index %s errored: %s", leading.Description.Name, leading.Execution.Reason)
+			require.NotEqual(t, client.InProgressActionStatus, leading.Execution.Status,
+				"index %s has not finished building", leading.Description.Name)
+		})
+	}
+}

--- a/pkg/pruner/pruner.go
+++ b/pkg/pruner/pruner.go
@@ -547,33 +547,72 @@ func (p *Pruner) getBlockRange(ctx context.Context) (lowest, highest int64, err 
 }
 
 func (p *Pruner) getLowestBlockNumber(ctx context.Context) (int64, error) {
-	query := `query {
-		` + p.collections.BlockCollection + ` (order: {` + p.collections.BlockNumberField + `: ASC}, limit: 7) {
-			` + p.collections.BlockNumberField + `
-		}
-	}`
-
-	result := p.defraNode.DB.ExecRequest(ctx, query)
-	if len(result.GQL.Errors) > 0 {
-		return 0, fmt.Errorf("lowest block query failed: %w", result.GQL.Errors[0])
-	}
-
-	return p.extractBlockNumber(result.GQL.Data)
+	return p.blockNumberBound(ctx, "ASC", "lowest")
 }
 
 func (p *Pruner) getHighestBlockNumber(ctx context.Context) (int64, error) {
+	return p.blockNumberBound(ctx, "DESC", "highest")
+}
+
+// blockNumberBound returns the first block number under the given sort order. Rows whose
+// number is null are excluded: under ASC they sort ahead of real numbers and can fill the
+// limit on their own. Block numbers are non-negative, so _geq: 0 admits every real block
+// including genesis.
+func (p *Pruner) blockNumberBound(ctx context.Context, order, label string) (int64, error) {
+	field := p.collections.BlockNumberField
 	query := `query {
-		` + p.collections.BlockCollection + ` (order: {` + p.collections.BlockNumberField + `: DESC}, limit: 7) {
-			` + p.collections.BlockNumberField + `
+		` + p.collections.BlockCollection + ` (filter: {` + field + `: {_geq: 0}}, order: {` + field + `: ` + order + `}, limit: 7) {
+			` + field + `
 		}
 	}`
 
 	result := p.defraNode.DB.ExecRequest(ctx, query)
 	if len(result.GQL.Errors) > 0 {
-		return 0, fmt.Errorf("highest block query failed: %w", result.GQL.Errors[0])
+		return 0, fmt.Errorf("%s block query failed: %w", label, result.GQL.Errors[0])
 	}
 
-	return p.extractBlockNumber(result.GQL.Data)
+	number, err := p.extractBlockNumber(result.GQL.Data)
+	if !errors.Is(err, ErrNoBlocks) {
+		return number, err
+	}
+
+	// The filter hides rows without a number, so an empty result does not by itself mean the
+	// collection is empty. Callers act on those two cases differently.
+	present, presentErr := p.hasAnyBlocks(ctx)
+	if presentErr != nil {
+		return 0, presentErr
+	}
+	if present {
+		return 0, ErrNoValidBlocks
+	}
+	return 0, ErrNoBlocks
+}
+
+// hasAnyBlocks reports whether the block collection holds any document, including rows with
+// no block number.
+func (p *Pruner) hasAnyBlocks(ctx context.Context) (bool, error) {
+	query := `query {
+		` + p.collections.BlockCollection + ` (limit: 1) {
+			_docID
+		}
+	}`
+
+	result := p.defraNode.DB.ExecRequest(ctx, query)
+	if len(result.GQL.Errors) > 0 {
+		return false, fmt.Errorf("block presence query failed: %w", result.GQL.Errors[0])
+	}
+
+	data, ok := result.GQL.Data.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	switch rows := data[p.collections.BlockCollection].(type) {
+	case []any:
+		return len(rows) > 0, nil
+	case []map[string]any:
+		return len(rows) > 0, nil
+	}
+	return false, nil
 }
 
 func (p *Pruner) extractBlockNumber(gqlData any) (int64, error) {

--- a/pkg/pruner/pruner_test.go
+++ b/pkg/pruner/pruner_test.go
@@ -667,7 +667,7 @@ func TestGetLowestAndHighestBlockNumber_SkipsRowsWithNoNumber(t *testing.T) {
 
 	// More rows without a number than the query's limit, so an ordering that does not
 	// exclude them returns nulls only.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		res := n.DB.ExecRequest(ctx, fmt.Sprintf(`mutation { add_TestBlock(input: [{hash: "no-number-%d"}]) { _docID } }`, i))
 		require.Empty(t, res.GQL.Errors, "insert failed: %v", res.GQL.Errors)
 	}
@@ -691,7 +691,7 @@ func TestGetLowestAndHighestBlockNumber_NoRowsWithNumber(t *testing.T) {
 	p := NewPruner(&Config{Enabled: true, MaxBlocks: 100}, n, testCollections())
 	ctx := context.Background()
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		res := n.DB.ExecRequest(ctx, fmt.Sprintf(`mutation { add_TestBlock(input: [{hash: "no-number-%d"}]) { _docID } }`, i))
 		require.Empty(t, res.GQL.Errors, "insert failed: %v", res.GQL.Errors)
 	}
@@ -902,7 +902,7 @@ func TestFilterBasedPrune_WithRowsWithNoNumber(t *testing.T) {
 	p := NewPruner(&Config{Enabled: true, MaxBlocks: 2, PruneHistory: false}, n, testCollections())
 	ctx := context.Background()
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		res := n.DB.ExecRequest(ctx, fmt.Sprintf(`mutation { add_TestBlock(input: [{hash: "no-number-%d"}]) { _docID } }`, i))
 		require.Empty(t, res.GQL.Errors, "insert failed: %v", res.GQL.Errors)
 	}

--- a/pkg/pruner/pruner_test.go
+++ b/pkg/pruner/pruner_test.go
@@ -660,6 +660,49 @@ func TestGetLowestAndHighestBlockNumber(t *testing.T) {
 	assert.Equal(t, int64(30), highest)
 }
 
+func TestGetLowestAndHighestBlockNumber_SkipsRowsWithNoNumber(t *testing.T) {
+	n := startTestNode(t)
+	p := NewPruner(&Config{Enabled: true, MaxBlocks: 100}, n, testCollections())
+	ctx := context.Background()
+
+	// More rows without a number than the query's limit, so an ordering that does not
+	// exclude them returns nulls only.
+	for i := 0; i < 10; i++ {
+		res := n.DB.ExecRequest(ctx, fmt.Sprintf(`mutation { add_TestBlock(input: [{hash: "no-number-%d"}]) { _docID } }`, i))
+		require.Empty(t, res.GQL.Errors, "insert failed: %v", res.GQL.Errors)
+	}
+	for _, num := range []int64{10, 20, 30} {
+		insertTestBlock(t, n, num, 0)
+	}
+
+	lowest, err := p.getLowestBlockNumber(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), lowest)
+
+	highest, err := p.getHighestBlockNumber(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(30), highest)
+}
+
+// A collection holding only rows without a number must stay distinguishable from an empty
+// one: the callers warn on the first and not on the second.
+func TestGetLowestAndHighestBlockNumber_NoRowsWithNumber(t *testing.T) {
+	n := startTestNode(t)
+	p := NewPruner(&Config{Enabled: true, MaxBlocks: 100}, n, testCollections())
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		res := n.DB.ExecRequest(ctx, fmt.Sprintf(`mutation { add_TestBlock(input: [{hash: "no-number-%d"}]) { _docID } }`, i))
+		require.Empty(t, res.GQL.Errors, "insert failed: %v", res.GQL.Errors)
+	}
+
+	_, err := p.getLowestBlockNumber(ctx)
+	assert.ErrorIs(t, err, ErrNoValidBlocks)
+
+	_, err = p.getHighestBlockNumber(ctx)
+	assert.ErrorIs(t, err, ErrNoValidBlocks)
+}
+
 func TestGetBlockRange(t *testing.T) {
 	n := startTestNode(t)
 	cols := testCollections()
@@ -851,6 +894,24 @@ func TestFilterBasedPrune(t *testing.T) {
 	// Metrics should be updated
 	assert.True(t, p.totalBlocksPruned > 0)
 	assert.True(t, p.totalDocsPruned > 0)
+}
+
+// Rows without a number must not stop the pruner reaching the block range and pruning.
+func TestFilterBasedPrune_WithRowsWithNoNumber(t *testing.T) {
+	n := startTestNode(t)
+	p := NewPruner(&Config{Enabled: true, MaxBlocks: 2, PruneHistory: false}, n, testCollections())
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		res := n.DB.ExecRequest(ctx, fmt.Sprintf(`mutation { add_TestBlock(input: [{hash: "no-number-%d"}]) { _docID } }`, i))
+		require.Empty(t, res.GQL.Errors, "insert failed: %v", res.GQL.Errors)
+	}
+	for _, num := range []int64{1, 2, 3, 4} {
+		insertTestBlock(t, n, num, 0)
+	}
+
+	require.NoError(t, p.filterBasedPrune(ctx))
+	assert.True(t, p.totalBlocksPruned > 0)
 }
 
 func TestFilterBasedPrune_WithinLimit(t *testing.T) {

--- a/pkg/schema/collections/accessListEntry.graphql
+++ b/pkg/schema/collections/accessListEntry.graphql
@@ -1,6 +1,6 @@
 type Ethereum__Mainnet__AccessListEntry {
     address: String
-    blockNumber: Int
+    blockNumber: Int @index
     storageKeys: [String]
     transaction: Ethereum__Mainnet__Transaction @relation(name: "transaction_accessList")
 }

--- a/pkg/schema/collections/block.graphql
+++ b/pkg/schema/collections/block.graphql
@@ -1,6 +1,6 @@
 type Ethereum__Mainnet__Block {
     hash: String
-    number: Int
+    number: Int @index
     timestamp: String
     parentHash: String
     difficulty: String

--- a/pkg/schema/collections/blockSignature.graphql
+++ b/pkg/schema/collections/blockSignature.graphql
@@ -1,7 +1,7 @@
 # BlockSignature covers all documents in a block (txs, logs, ALEs, and the block itself)
 # Created in the same transaction as the block data, arrives via P2P together
 type Ethereum__Mainnet__BlockSignature {
-    blockNumber: Int
+    blockNumber: Int @index
     blockHash: String
     merkleRoot: String
     cidCount: Int

--- a/pkg/schema/collections/log.graphql
+++ b/pkg/schema/collections/log.graphql
@@ -4,7 +4,7 @@ type Ethereum__Mainnet__Log {
     data: String
     transactionHash: String
     blockHash: String
-    blockNumber: Int
+    blockNumber: Int @index
     transactionIndex: Int
     logIndex: Int
     removed: String

--- a/pkg/schema/collections/transaction.graphql
+++ b/pkg/schema/collections/transaction.graphql
@@ -1,7 +1,7 @@
 type Ethereum__Mainnet__Transaction {
     hash: String
     blockHash: String
-    blockNumber: Int
+    blockNumber: Int @index
     from: String
     to: String
     value: String


### PR DESCRIPTION
`Block.number` and `blockNumber` on Transaction, Log, AccessListEntry and BlockSignature had no index, so every filter or order on them is a full collection scan. That covers the per-block existence check in `CreateBlockBatch`, which runs once per block, and the pruner's `queryOldestDocIDs`, which orders by block number.

The second commit excludes rows with no block number from the pruner's block-range queries. Under an ASC ordering those rows sort ahead of real block numbers and can fill the query's limit on their own, so the pruner reads no valid number and skips the run. The index does not change that ordering, so both changes are needed.

`AddSchema` is additive and `schema_apply.go` skips collections that already exist, so the index only takes effect on a new store; existing nodes need `scripts/purge_and_apply.sh` or a resync.
