### PR TITLE
fix: persist the prune queue and bound work per prune cycle

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,6 +61,7 @@ logger:
 pruner:
   enabled: true             # Set to true to enable automatic pruning
   max_blocks: 1000          # Number of blocks to retain
+  max_blocks_per_cycle: 50  # Max blocks one prune cycle may delete
   prune_threshold: 1        # Trigger pruning when exceeding max_blocks by this amount
   interval_seconds: 30      # How often to check and prune
   prune_history: true       # Walk DAG chains to delete historical block versions (2-3x slower)

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -331,6 +331,15 @@ func (i *ChainIndexer) initServices(ctx context.Context, cfg *config.Config, blo
 	if cfg.Pruner.Enabled && i.defraNode != nil {
 		i.pruner = pruner.NewPruner(&cfg.Pruner, i.defraNode)
 		pruneQueue := pruner.NewIndexerQueue()
+		// Binds the queue to its file before anything tracks into it. Save is a no-op until this
+		// runs, so without it the queue is never written and never survives a restart.
+		queueFilePath := filepath.Join(cfg.DefraDB.Store.Path, "prune_queue.gob")
+		restored, err := pruneQueue.LoadFromFile(queueFilePath)
+		if err != nil {
+			logger.Sugar.Warnf("Failed to load prune queue from disk: %v", err)
+		} else if restored > 0 {
+			logger.Sugar.Infof("Restored %d entries from prune queue file", restored)
+		}
 		i.pruner.SetQueue(pruneQueue)
 		blockHandler.SetDocIDTracker(&indexerQueueTracker{
 			queue:       pruneQueue,

--- a/pkg/pruner/config.go
+++ b/pkg/pruner/config.go
@@ -12,6 +12,10 @@ type Config struct {
 	PruneThreshold  int64 `yaml:"prune_threshold"` // Deprecated: kept for backward compatibility, unused by pruner
 	IntervalSeconds int   `yaml:"interval_seconds"`
 	PruneHistory    bool  `yaml:"prune_history"`
+	// MaxBlocksPerCycle caps how many blocks one cycle may delete. A cycle's wall time scales with
+	// what it deletes, so without a cap a large backlog produces a cycle long enough that the queue
+	// cannot be checkpointed for hours. Zero leaves a cycle unbounded.
+	MaxBlocksPerCycle int64 `yaml:"max_blocks_per_cycle"`
 }
 
 // CollectionConfig defines which collections to prune and how.
@@ -54,5 +58,8 @@ func (c *Config) SetDefaults() {
 	}
 	if c.IntervalSeconds <= 0 {
 		c.IntervalSeconds = 60
+	}
+	if c.MaxBlocksPerCycle <= 0 {
+		c.MaxBlocksPerCycle = 50
 	}
 }

--- a/pkg/pruner/pruner.go
+++ b/pkg/pruner/pruner.go
@@ -196,19 +196,36 @@ func (p *Pruner) runPrune(ctx context.Context) error {
 // runIndexerQueuePrune drains the IndexerQueue and purges by docIDs.
 // No P2P pause needed — the indexer has no concurrent P2P replication.
 func (p *Pruner) runIndexerQueuePrune(ctx context.Context, q *IndexerQueue) error {
+	// The queue is the only record that a document is prunable, so it is written after every cycle
+	// rather than only on shutdown. A kill between checkpoints strands whatever the queue holds,
+	// including entries still inside the retention target that no cycle has drained yet.
+	defer func() {
+		if err := q.Save(); err != nil {
+			logger.Sugar.Warnf("Failed to checkpoint prune queue: %v", err)
+		}
+	}()
+
 	blockCount := int64(q.Len())
 
 	if blockCount <= p.cfg.MaxBlocks {
 		return p.filterBasedPrune(ctx)
 	}
 
-	result := q.Drain(int(p.cfg.MaxBlocks), p.collections)
+	// Keep more than the retention target when the backlog exceeds what one cycle should delete.
+	// The excess is drained over subsequent cycles, which bounds cycle wall time without changing
+	// how many blocks are ultimately retained.
+	keep := p.cfg.MaxBlocks
+	if p.cfg.MaxBlocksPerCycle > 0 && blockCount-keep > p.cfg.MaxBlocksPerCycle {
+		keep = blockCount - p.cfg.MaxBlocksPerCycle
+	}
+
+	result := q.Drain(int(keep), p.collections)
 	if result == nil {
 		return nil
 	}
 
-	logger.Sugar.Infof("Pruning %d blocks (queue had %d blocks, keeping %d, prune_history=%v)",
-		result.BlockCount, blockCount, p.cfg.MaxBlocks, p.cfg.PruneHistory)
+	logger.Sugar.Infof("Pruning %d blocks (queue had %d blocks, keeping %d, target %d, prune_history=%v)",
+		result.BlockCount, blockCount, keep, p.cfg.MaxBlocks, p.cfg.PruneHistory)
 
 	return p.purgeFromDrainResult(ctx, result)
 }

--- a/pkg/pruner/pruner_test.go
+++ b/pkg/pruner/pruner_test.go
@@ -477,6 +477,91 @@ func TestRunPrune_WithIndexerQueue(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// queueBlocks fills a queue with n blocks, each carrying one block doc and two transaction docs.
+func queueBlocks(t *testing.T, q *IndexerQueue, n int64) {
+	t.Helper()
+	for i := int64(1); i <= n; i++ {
+		err := q.TrackBlockDocIDs(i,
+			docIDPrefix+"-550e8400-e29b-41d4-a716-446655440000",
+			map[string][]string{constants.CollectionTransaction: {
+				docIDPrefix + "-660e8400-e29b-41d4-a716-446655440001",
+				docIDPrefix + "-770e8400-e29b-41d4-a716-446655440002",
+			}},
+			"",
+		)
+		require.NoError(t, err)
+	}
+}
+
+// A cycle deletes at most max_blocks_per_cycle blocks, so its wall time stays bounded as the
+// backlog grows instead of scaling with it.
+func TestRunIndexerQueuePrune_BoundsWorkPerCycle(t *testing.T) {
+	n := startTestNode(t)
+	cfg := &Config{Enabled: true, MaxBlocks: 1, MaxBlocksPerCycle: 2}
+	p := NewPruner(cfg, n, testCollections())
+	q := NewIndexerQueue()
+	p.SetQueue(q)
+
+	queueBlocks(t, q, 10)
+	require.Equal(t, 10, q.Len())
+
+	require.NoError(t, p.runIndexerQueuePrune(context.Background(), q))
+
+	// Nine blocks are over the retention target, but a cycle may delete two.
+	assert.Equal(t, 8, q.Len())
+}
+
+// A cycle that stays inside the retention target drains nothing, but the entries it holds are still
+// the only record that those documents are prunable, so it checkpoints too.
+func TestRunIndexerQueuePrune_CheckpointsBelowRetentionTarget(t *testing.T) {
+	n := startTestNode(t)
+	path := t.TempDir() + "/prune_queue.gob"
+	cfg := &Config{Enabled: true, MaxBlocks: 100, MaxBlocksPerCycle: 2}
+	p := NewPruner(cfg, n, testCollections())
+	q := NewIndexerQueue()
+	_, err := q.LoadFromFile(path)
+	require.NoError(t, err)
+	p.SetQueue(q)
+
+	queueBlocks(t, q, 3)
+	require.NoFileExists(t, path)
+
+	require.NoError(t, p.runIndexerQueuePrune(context.Background(), q))
+
+	// Below the target nothing is drained, so all three must still be there after a reload.
+	assert.Equal(t, 3, q.Len())
+	require.FileExists(t, path)
+	reloaded := NewIndexerQueue()
+	count, err := reloaded.LoadFromFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+}
+
+// The queue is the only record that a document is prunable, so it is written after every cycle
+// rather than only on shutdown.
+func TestRunIndexerQueuePrune_CheckpointsQueueEachCycle(t *testing.T) {
+	n := startTestNode(t)
+	path := t.TempDir() + "/prune_queue.gob"
+	cfg := &Config{Enabled: true, MaxBlocks: 1, MaxBlocksPerCycle: 2}
+	p := NewPruner(cfg, n, testCollections())
+	q := NewIndexerQueue()
+	// LoadFromFile binds the queue to the path Save writes to.
+	_, err := q.LoadFromFile(path)
+	require.NoError(t, err)
+	p.SetQueue(q)
+
+	queueBlocks(t, q, 10)
+	require.NoFileExists(t, path)
+
+	require.NoError(t, p.runIndexerQueuePrune(context.Background(), q))
+
+	require.FileExists(t, path)
+	reloaded := NewIndexerQueue()
+	count, err := reloaded.LoadFromFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, q.Len(), count)
+}
+
 func TestRunIndexerQueuePrune_BelowThreshold(t *testing.T) {
 	n := startTestNode(t)
 	cols := testCollections()


### PR DESCRIPTION
The prune queue was never bound to its file, so nothing ever wrote it and it was lost on every restart. It is now bound at startup and checkpointed after each cycle.

Each cycle also deletes at most max_blocks_per_cycle blocks (default 50), so cycle time stays bounded as the backlog grows.