### PR TITLE
fix: rebuilding secondary indexes after ImportKV

### DIFF
--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shinzonetwork/shinzo-generator-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-generator-client/pkg/snapshot"
 	"github.com/sourcenetwork/defradb/node"
@@ -465,6 +466,20 @@ func (hs *HealthServer) snapshotImportHandler(w http.ResponseWriter, r *http.Req
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"error":  err.Error(),
+			"result": result, //nolint:goconst
+		})
+		return
+	}
+
+	// Rebuild secondary indexes after bulk KV import.
+	// ImportRawKVs writes raw KV pairs directly to the rootstore, bypassing
+	// the document layer. Index entries are not included in the export, so
+	// we must rebuild them from the imported document data.
+	if rebuildErr := snapshot.RebuildAllIndexes(r.Context(), hs.defraNode, constants.DefaultCollections()); rebuildErr != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":  rebuildErr.Error(),
 			"result": result,
 		})
 		return

--- a/pkg/snapshot/kv_restore.go
+++ b/pkg/snapshot/kv_restore.go
@@ -72,3 +72,14 @@ func ImportKV(ctx context.Context, defraNode *node.Node, filePath string) (*Impo
 		EndBlock:   header.EndBlock,
 	}, nil
 }
+
+// RebuildAllIndexes rebuilds indexes for all collections after bulk KV import.
+// Call this once after importing all snapshots, not after each individual import.
+func RebuildAllIndexes(ctx context.Context, defraNode *node.Node, collections []string) error {
+	for _, colName := range collections {
+		if err := defraNode.DB.RebuildCollectionIndexes(ctx, colName); err != nil {
+			return fmt.Errorf("failed to rebuild indexes for %s: %w", colName, err)
+		}
+	}
+	return nil
+}

--- a/pkg/snapshot/kv_snapshot.go
+++ b/pkg/snapshot/kv_snapshot.go
@@ -164,7 +164,7 @@ func (s *Snapshotter) exportCollectionKVs(ctx context.Context, gw *gzip.Writer, 
 		// Buffer each call so we can strip that sentinel before writing to the shared
 		// gzip stream; our caller (writeKVSnapshotContents) writes the single final sentinel.
 		var buf bytes.Buffer
-		n, err := s.defraNode.DB.ExportDocKVs(ctx, col.name, docIDs, &buf, true)
+		n, err := s.defraNode.DB.ExportDocKVs(ctx, col.name, docIDs, &buf, false)
 		if err != nil {
 			return 0, fmt.Errorf("export KVs for %s: %w", col.name, err)
 		}

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -1790,6 +1790,10 @@ func TestCreateKVSnapshot_AndImportKV_Roundtrip(t *testing.T) {
 	assert.Equal(t, int64(1000), importResult.StartBlock)
 	assert.Equal(t, int64(1004), importResult.EndBlock)
 
+	// Rebuild indexes after bulk KV import
+	err = RebuildAllIndexes(ctx, td2.Node, constants.DefaultCollections())
+	require.NoError(t, err)
+
 	// Verify blocks exist in the second node
 	lowest, err = s2.getBlockNumber(ctx, "ASC")
 	require.NoError(t, err)
@@ -2171,6 +2175,10 @@ func TestCheckAndSnapshot_ImportKV_EndToEnd(t *testing.T) {
 	require.NotNil(t, importResult)
 	assert.Equal(t, int64(100), importResult.StartBlock)
 	assert.Equal(t, int64(104), importResult.EndBlock)
+
+	// Rebuild indexes after bulk KV import
+	err = RebuildAllIndexes(ctx, td2.Node, constants.DefaultCollections())
+	require.NoError(t, err)
 
 	// Verify the second node has the blocks
 	s2 := New(&Config{Dir: t.TempDir(), BlocksPerFile: 5}, td2.Node)
@@ -3246,6 +3254,10 @@ func TestCreateKVSnapshot_ImportKV_LargerDataSet(t *testing.T) {
 	require.NotNil(t, importResult)
 	assert.Equal(t, int64(100), importResult.StartBlock)
 	assert.Equal(t, int64(109), importResult.EndBlock)
+
+	// Rebuild indexes after bulk KV import
+	err = RebuildAllIndexes(ctx, td2.Node, constants.DefaultCollections())
+	require.NoError(t, err)
 
 	// Verify
 	s2 := New(&Config{Dir: t.TempDir(), BlocksPerFile: 1000}, td2.Node)


### PR DESCRIPTION
# Pull Request

## Description

This PR  enables export complete KV state (heads + blocks, not just data store) and rebuild secondary indexes after import so snapshot-restored nodes have queryable documents to successfully restore secondary indexes.

## Changes
-  Added `RebuildAllIndexes(ctx, defraNode, collections []string)` which iterates the given collection names and calls `defraNode.DB.RebuildCollectionIndexes` on each. Designed as a separate call (not inside `ImportKV`) so it can be run once after all snapshots are imported.
- Changed `ExportDocKVs` call from `datastoreOnly=true` to `false`. This now exports head store entries and block store entries  alongside the data store KV pairs, enabling full document discovery after import.
-  Using `RebuildAllIndexes(ctx, td2.Node, constants.DefaultIndexedCollections())` after `ImportKV` in the 3 snapshot tests   `health.go` to successfully rebuild secondary indexes.

## Related Issue
#336 

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Verify core functionality works as expected (e.g., main page loads, API responds)

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
<!-- Any additional context for reviewers -->
